### PR TITLE
Ugly line break in some of the labels.

### DIFF
--- a/_includes/frontpage-content.txt
+++ b/_includes/frontpage-content.txt
@@ -36,13 +36,13 @@
 		<h3><a href="{{ site.baseurl }}/sips">Scala Improvement Process</a> <span class="label success">Available</span></h3>
 		<p>Read language improvement proposals, participate in discussions surrounding submitted proposals, or submit your own improvement proposal.</p>
 
-		<h3><a href="{{ site.baseurl }}/overviews">Guides and Overviews</a> <span class="label success">Some Available</span></h3>
+		<h3><a href="{{ site.baseurl }}/overviews">Guides and Overviews</a> <span class="label success">Some&nbsp;Available</span></h3>
 		<p>Some guides, such as Martin Odersky's Collections Overview are already available. Others are currently being converted to markdown markup for inclusion here.</p>
 		
-		<h3><a href="{{ site.baseurl }}/tutorials">Tutorials</a> <span class="label success">Some Available</span></h3>
+		<h3><a href="{{ site.baseurl }}/tutorials">Tutorials</a> <span class="label success">Some&nbsp;Available</span></h3>
 		<p>Some tutorials, such as the <em>Scala for Java Programmers</em> guide is already available. Others are currently being converted to markdown markup for inclusion here.</p>
 		
-		<h3><a href="{{ site.baseurl }}/glossary">Glossary</a> <span class="label warning">Pending Permission</span></h3>
+		<h3><a href="{{ site.baseurl }}/glossary">Glossary</a> <span class="label warning">Pending&nbsp;Permission</span></h3>
 		<p>Pending permission from Artima Inc., we'd like to include the glossary from <em>Programming in Scala</em> here, for quick and easy reference.</p>				
 		
 		<h3><a href="{{ site.baseurl }}/cheatsheets">Cheatsheets</a> <span class="label success">Available</span></h3>
@@ -51,7 +51,7 @@
 		<h3><a href="{{ site.baseurl }}/style">Scala Style Guide</a> <span class="label success">Available</span></h3>
 		<p>Daniel Spiewak and David Copland's <em>Scala Style Guide</em> is now available. Thanks to them for putting together such an excellent style guide, and thanks to Simon Ochsenreither for converting it to markdown!</p>		
 
-		<h3>Language Specification <span class="label notice">Just an Idea</span></h3>
+		<h3>Language Specification <span class="label notice">Just&nbsp;an&nbsp;Idea</span></h3>
 		<p>It would be nice to have an HTML version of the language specification, right? This is just an idea for now...</p>				
 		
 		<p>&nbsp;</p><p>&nbsp;</p>

--- a/overviews/index.md
+++ b/overviews/index.md
@@ -32,4 +32,4 @@ title: Guides and Overviews
 * [{{ post.title }}]({{ site.baseurl }}{{ post.url }}) <span class="label {{ post.label-color }}">{{ post.label-text }}</span>
 {% endif %}
 {% endfor %} 
-* Swing <span class="label important">In Progress</span>
+* Swing <span class="label important">In&nbsp;Progress</span>

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -10,8 +10,8 @@ title: Tutorials
       <h3>Tutorials geared for people coming...</h3>
 	  <ul>
 		<li><a href="{{ site.baseurl }}/tutorials/scala-for-java-programmers.html">...from Java</a> <span class="label success">Available</span></li>
-		<li><a href="#">...from Ruby</a> <span class="label important">In Progress</span></li>
-		<li><a href="#">...from Python</a> <span class="label important">In Progress</span></li>		
+		<li><a href="#">...from Ruby</a> <span class="label important">In&nbsp;Progress</span></li>
+		<li><a href="#">...from Python</a> <span class="label important">In&nbsp;Progress</span></li>		
  	  </ul>
 	</div>
 	


### PR DESCRIPTION
Hi,
whenever one of the labels is too close to its container, an ugly line wrap occurs ( https://lh4.googleusercontent.com/-f55lxu6A6hY/TrFskRgt7sI/AAAAAAAAABE/7MO5bm5UgWg/s804/Tutorials%2B%2B%2BScala%2BDocumentation.png ).

This commit changes all spaces in label elements to non-break-spaces.

In general, though, one should prefer a CSS solution `.label { white-space: nowrap; }` instead of such a hack.
