### PR TITLE
Improved typography on the front page.

### DIFF
--- a/_includes/frontpage-content.txt
+++ b/_includes/frontpage-content.txt
@@ -30,14 +30,14 @@
 
       <div class="span8">
 
-        <h2>We're growing...</h2>
-        <p>We're working on porting much of Scala's useful documentation to this documentation repository. So hang on, content is soon forthcoming.<p>
+        <h2>We’re growing…</h2>
+        <p>We’re working on porting much of Scala’s useful documentation to this documentation repository. So hang on, content is soon forthcoming.<p>
 
 		<h3><a href="{{ site.baseurl }}/sips">Scala Improvement Process</a> <span class="label success">Available</span></h3>
 		<p>Read language improvement proposals, participate in discussions surrounding submitted proposals, or submit your own improvement proposal.</p>
 
 		<h3><a href="{{ site.baseurl }}/overviews">Guides and Overviews</a> <span class="label success">Some Available</span></h3>
-		<p>Some guides, such as Martin Odersky's Collections Overview are already available. Others are currently being converted to markdown markup for inclusion here.</p>
+		<p>Some guides, such as Martin Odersky’s Collections Overview are already available. Others are currently being converted to markdown markup for inclusion here.</p>
 		
 		<h3><a href="{{ site.baseurl }}/tutorials">Tutorials</a> <span class="label success">Some Available</span></h3>
 		<p>Some tutorials, such as the <em>Scala for Java Programmers</em> guide is already available. Others are currently being converted to markdown markup for inclusion here.</p>
@@ -46,22 +46,22 @@
 		<p>With permission from Artima Inc., we reproduce the glossary from <em>Programming in Scala</em> here, for easy reference.</p>				
 		
 		<h3><a href="{{ site.baseurl }}/cheatsheets">Cheatsheets</a> <span class="label success">Available</span></h3>
-		<p>We've currently got one cheatsheet, thanks to Brendan O'Connor, and are looking for more to include!</p>
+		<p>We've currently got one cheatsheet, thanks to Brendan O’Connor, and are looking for more to include!</p>
 		
 		<h3><a href="{{ site.baseurl }}/style">Scala Style Guide</a> <span class="label success">Available</span></h3>
-		<p>Daniel Spiewak and David Copeland's <em>Scala Style Guide</em> is now available. Thanks to them for putting together such an excellent style guide, and thanks to Simon Ochsenreither for converting it to markdown!</p>		
+		<p>Daniel Spiewak and David Copeland’s <em>Scala Style Guide</em> is now available. Thanks to them for putting together such an excellent style guide, and thanks to Simon Ochsenreither for converting it to markdown!</p>		
 
 		<h3>Language Specification <span class="label notice">Just an Idea</span></h3>
-		<p>It would be nice to have an HTML version of the language specification, right? This is just an idea for now...</p>				
+		<p>It would be nice to have an HTML version of the language specification, right? This is just an idea for now…</p>				
 		
 		<p>&nbsp;</p><p>&nbsp;</p>
 		
       </div>
       <div class="span8">
 		<h1>Contributions Welcomed!</h1>
-		This site was designed so it would be easy for core committers and the community alike to build documentation. We'd love help of any kind-- from detailed articles or overviews of Scala's language features, to help converting documents to markdown. 
+                This site was designed so it would be easy for core committers and the community alike to build documentation. We’d love help of any kind&nbsp;– from detailed articles or overviews of Scala’s language features, to help converting documents to markdown. 
 		<p>&nbsp;</p>
-		<p><b>If you'd like to help us, please see the <a href="{{ site.baseurl }}/contribute.html">Contribute</a> section of the site, and feel free to contact <a href="http://people.epfl.ch/heather.miller">Heather</a>.</b></p>
+		<p><b>If you’d like to help us, please see the <a href="{{ site.baseurl }}/contribute.html">Contribute</a> section of the site, and feel free to contact <a href="http://people.epfl.ch/heather.miller">Heather</a>.</b></p>
 		
 		<div id="recentcomments" class="dsq-widget"><h2 class="dsq-widget-title">Recent Comments</h2><script type="text/javascript" src="http://scalasip.disqus.com/recent_comments_widget.js?num_items=5&hide_avatars=0&avatar_size=32&excerpt_length=200"></script></div>
 		

--- a/_includes/thanks-to.txt
+++ b/_includes/thanks-to.txt
@@ -2,13 +2,13 @@
   <h1>Thank you</h1><p class="under">It helps many</p>
 </div>
 
-This site and the documentation it contains is the result of a tremendous amount of work by a large number of people over time, from the first Scala team members, to today's newcomers. In an effort to only scratch the surface, we list some of those whose help was invaluable in the realization of this iteration of the Scala Documentation repository. 
+This site and the documentation it contains is the result of a tremendous amount of work by a large number of people over time, from the first Scala team members, to today’s newcomers. In an effort to only scratch the surface, we list some of those whose help was invaluable in the realization of this iteration of the Scala Documentation repository. 
 
 <ul class="thanks">
   <li><a href="http://suereth.blogspot.com">Josh Suereth</a></li>
   <li><a href="http://www.naildrivin5.com">Dave Copeland</a></li>
   <li><a href="http://www.codecommit.com">Daniel Spiewak</a></li>
   <li>Simon Ochsenreither</li>
-  <li><a href="http://brenocon.com/">Brendan O'Connor</a></li>
+  <li><a href="http://brenocon.com/">Brendan O’Connor</a></li>
   <li><a href="http://yuvimasory.com">Yuvi Masory</a></li>
 <ul>


### PR DESCRIPTION
I mainly did some replacements from `'` to `’`. Looks a bit nicer and it’s what markdown does automatically on the auto-generated pages.
