### PR TITLE
Add tour list include, keep consistent order, #37.

### DIFF
--- a/_includes/tutorial-toc.txt
+++ b/_includes/tutorial-toc.txt
@@ -1,12 +1,6 @@
       <div id="scroller-anchor">
         <div id="scroller">
           <p class="contents">Contents</p>
-          <ul>
-          {% for p in site.pages %}
-            {% if p.tutorial == page.tutorial and p.language == page.language %}
-              <li><a href="{{ p.url }}">{{p.title}}</a></li>
-            {% endif %}
-          {% endfor %}
-          </li>   
+          {% include tutorial-tour-list.txt %}
 	    </div>
       </div>

--- a/_includes/tutorial-tour-list.txt
+++ b/_includes/tutorial-tour-list.txt
@@ -1,0 +1,22 @@
+{% for pg in site.pages %}
+  {% if pg.tutorial == "scala-tour" and pg.outof %}
+    {% unless pg.language %}
+      {% assign totalPagesTour = pg.outof %}
+    {% endunless %}
+  {% endif %}
+{% endfor %}
+
+{% if totalPagesTour %}
+  <ul>
+  {% for i in (1..totalPagesTour) %}
+    {% for pg in site.pages %}
+      {% if pg.tutorial == "scala-tour" and pg.num and pg.num == i %}
+        {% unless pg.language %}
+          <li class="tour-of-scala"><a href="{{ pg.url }}">{{ pg.title }}</a></li>
+        {% endunless %}
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
+  </ul>
+{% else %} **ERROR**. Couldn't find the total number of pages in this set of tutorial articles. Have you declared the `outof` tag in your YAML front matter?
+{% endif %}

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -43,28 +43,7 @@ title: Tutorials
   <div class="page-header-index">
     <h1>A Tour of Scala <br /></h1><p class="under">Bite-size pieces of the essentials...</p>
   </div>
-  {% for pg in site.pages %}
-    {% if pg.tutorial == "scala-tour" and pg.outof %}
-      {% unless pg.language %}
-        {% assign totalPagesTour = pg.outof %}  
-      {% endunless %}
-    {% endif %}
-  {% endfor %}
-
-  {% if totalPagesTour %}
-    <ul>
-    {% for i in (1..totalPagesTour) %}
-      {% for pg in site.pages %}
-        {% if pg.tutorial == "scala-tour" and pg.num and pg.num == i %}
-          {% unless pg.language %}
-            <li class="tour-of-scala"><a href="{{ pg.url }}">{{ pg.title }}</a></li> 
-          {% endunless %}
-        {% endif %}
-      {% endfor %}
-    {% endfor %}
-    </ul>
-  {% else %} **ERROR**. Couldn't find the total number of pages in this set of tutorial articles. Have you declared the `outof` tag in your YAML front matter?
-  {% endif %}
+  {% include tutorial-tour-list.txt %}
 </div>
 
 


### PR DESCRIPTION
This fixes #37:

> The ordering is correct on the index page, but incorrect when you navigate into the document.

-Ron
