### PR TITLE
Fix dangling links to "The Scala 2.8 Collections API"

### DIFF
--- a/overviews/core/_posts/2010-12-15-architecture-of-scala-collections.md
+++ b/overviews/core/_posts/2010-12-15-architecture-of-scala-collections.md
@@ -9,13 +9,13 @@ label-text: Available
 
 These pages describe the architecture of the Scala collections
 framework in detail. Compared to
-[the Scala 2.8 Collections API](http://scala.github.com/overviews/collections.html) you
+[the Scala 2.8 Collections API]({{ site.baseurl }}/overviews/collections/introduction.html) you
 will find out more about the internal workings of the framework. You
 will also learn how this architecture helps you define your own
 collections in a few lines of code, while reusing the overwhelming
 part of collection functionality from the framework.
 
-[The Scala 2.8 Collections API](http://scala.github.com/overviews/collections.html)
+[The Scala 2.8 Collections API]({{ site.baseurl }}/overviews/collections/introduction.html)
 contains a large number of collection
 operations, which exist uniformly on many different collection
 implementations. Implementing every collection operation anew for


### PR DESCRIPTION
Ok. I've fixed dangling links actually and add a baseurl prefix.
