### PR TITLE
Formatting in the Tour / Jekyll under Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ cd into the `scala.github.com` directory, and build by:
 
 The generated site is available at `http://localhost:4000`
 
+If you get `incompatible encoding` errors when generating the site under Windows, then ensure that the
+console in which you are running jekyll can work with UTF-8 characters. As described in the blog
+[Solving UTF problem with Jekyll on Windows](http://joseoncode.com/2011/11/27/solving-utf-problem-with-jekyll-on-windows/)
+you have to execute `chcp 65001`. This command is best added to the `jekyll.bat`-script.
+
 ## Markdown ##
 
 The markdown used in this site uses [Maruku](http://maruku.rubyforge.org/maruku.html) extensions.

--- a/es/tutorials/tour/case-classes.md
+++ b/es/tutorials/tour/case-classes.md
@@ -27,7 +27,7 @@ Aquí un ejemplo:
 Los parámetros constructores de las clases Case son tratados como valores públicos y pueden ser accedidos directamente.
 
     val x = Var("x")
-    Console.println(x.name)
+    println(x.name)
 
 Para cada una de las clases Case el compilador de Scala genera el método `equals` el cual implementa la igualdad estructural y un método `toString`. Por ejemplo:
 

--- a/tutorials/tour/case-classes.md
+++ b/tutorials/tour/case-classes.md
@@ -10,14 +10,14 @@ num: 5
 
 Scala supports the notion of _case classes_. Case classes are regular classes which export their constructor parameters and which provide a recursive decomposition mechanism via [pattern matching](pattern-matching.html).
 
-Here is an example for a class hierarchy which consists of an abstract super class Term and three concrete case classes `Var`, `Fun`, and `App`.
+Here is an example for a class hierarchy which consists of an abstract super class `Term` and three concrete case classes `Var`, `Fun`, and `App`.
 
     abstract class Term
     case class Var(name: String) extends Term
     case class Fun(arg: String, body: Term) extends Term
     case class App(f: Term, v: Term) extends Term
 
-This class hierarchy can be used to represent terms of the [untyped lambda calculus](http://www.ezresult.com/article/Lambda_calculus). To facilitate the construction of case class instances, Scala does not require that the new primitive is used. One can simply use the class name as a function.
+This class hierarchy can be used to represent terms of the [untyped lambda calculus](http://www.ezresult.com/article/Lambda_calculus). To facilitate the construction of case class instances, Scala does not require that the `new` primitive is used. One can simply use the class name as a function.
 
 Here is an example:
 
@@ -26,9 +26,9 @@ Here is an example:
 The constructor parameters of case classes are treated as public values and can be accessed directly.
 
     val x = Var("x")
-    Console.println(x.name)
+    println(x.name)
 
-For every case class the Scala compiler generates equals method which implements structural equality and a `toString` method. For instance:
+For every case class the Scala compiler generates an `equals` method which implements structural equality and a `toString` method. For instance:
 
     val x1 = Var("x")
     val x2 = Var("x")

--- a/tutorials/tour/currying.md
+++ b/tutorials/tour/currying.md
@@ -26,7 +26,7 @@ Here is an example:
       println(filter(nums, modN(3)))
     }
 
-_Note: method `modN` is partially applied in the two `filter` calls; i.e. only its first argument is actually applied. The `termmodN(2)` yields a function of type `Int => Boolean` and is thus a possible candidate for the second argument of function `filter`._
+_Note: method `modN` is partially applied in the two `filter` calls; i.e. only its first argument is actually applied. The term `modN(2)` yields a function of type `Int => Boolean` and is thus a possible candidate for the second argument of function `filter`._
 
 Here's the output of the program above:
 


### PR DESCRIPTION
Some further corrections which I found while reading through the "Tour of Scala".
I corrected mostly formatting errors (missing quotes).

I also added a remark on the installation of Jekyll  under Windows.
