### PR TITLE
Replace "no side-effects" with ref transparency for arity-0 methods

### DIFF
--- a/style/method-invocation.md
+++ b/style/method-invocation.md
@@ -41,10 +41,11 @@ arguments):
     reply
 
 However, this syntax should *only* be used when the method in question
-has no side-effects (purely-functional). In other words, it would be
-acceptable to omit parentheses when calling `queue.size`, but not when
-calling `println()`. This convention mirrors the method declaration
-convention given above.
+is referentially transparent, i.e. if its call could be replaced with
+its value. In other words, it would be acceptable to omit parentheses
+when calling `queue.size`, but not when calling `println()` or
+`System.currentTimeMillis()`. This convention mirrors the method
+declaration convention given above.
 
 Religiously observing this convention will *dramatically* improve code
 readability and will make it much easier to understand at a glance the

--- a/style/naming-conventions.md
+++ b/style/naming-conventions.md
@@ -194,9 +194,11 @@ Thus, it is actually quite important that proper guidelines be observed
 regarding when it is appropriate to declare a method without parentheses
 and when it is not.
 
-Methods which act as accessors of any sort (either encapsulating a field
-or a logical property) should be declared *without* parentheses except
-if they have side effects. While Ruby and Lift use a `!` to indicate
+Arity-0 methods, e.g such that act as accessors of any sort (either
+encapsulating a field or a logical property), should be declared
+*without* parentheses if and only if they are referentially tranparent,
+i.e. if calls to such methods could be replaced with their value (stored
+after once called). While Ruby and Lift use a `!` to indicate
 this, the usage of parens is preferred (please note that fluid APIs and 
 internal domain-specific languages have a tendency to break the 
 guidelines given below for the sake of syntax. Such exceptions should 


### PR DESCRIPTION
Before merging let's look what others think => scala-lang mailing list
