### PR TITLE
adds style/overview.md back in

### DIFF
--- a/style/overview.md
+++ b/style/overview.md
@@ -1,0 +1,27 @@
+---
+layout: overview-large
+title: Overview
+
+partof: style-guide
+num: 1
+outof: 10
+---
+
+Generally speaking, Scala seeks to mimic Java conventions to ease
+interoperability. When in doubt regarding the idiomatic way to express a
+particular concept, adopt conventions and idioms from the following
+languages (in this order):
+
+-   Java
+-   [Standard ML](http://en.wikipedia.org/wiki/Standard_ML)
+-   Haskell
+-   C\#
+-   OCaml
+-   Ruby
+-   Python
+
+For example, you should use Java's naming conventions for classes and
+methods, but SML's conventions for type annotation, Haskell's
+conventions for type parameter naming (except upper-case rather than
+lower) and Ruby's conventions for non-boolean accessor methods. Scala
+really is a hybrid language!


### PR DESCRIPTION
## motivation

This page is linked to by http://docs.scala-lang.org/style/ and http://davetron5000.github.com/scala-style/ so even if this is supposed to be destroyed, it should at least be replaced with a permanent redirect instead of a file not found.
## different behavior

Just a reversion back to the style/overview.md of 59afeb1106bce5a7ad0a7359bce11ca30459b65e.  I think the breaking commit was 8abc6d1f5321d8aed2a045d827268323f47e3562.
