### PR TITLE
Formatting error in the futures document

### DIFF
--- a/overviews/core/_posts/2012-09-20-futures.md
+++ b/overviews/core/_posts/2012-09-20-futures.md
@@ -524,7 +524,7 @@ the exception from this future, as in the following example which
 tries to print US dollar value, but prints the Swiss franc value in
 the case it fails to obtain the dollar value:
 
-  val usdQuote = future {
+	val usdQuote = future {
 	  connection.getCurrentValue(USD)
 	} map {
 	  usd => "Value: " + usd + "$"
@@ -544,7 +544,7 @@ the result of this future or the argument future, whichever completes
 first, irregardless of success or failure. Here is an example in which
 the quote which is returned first gets printed:
 
-  val usdQuote = future {
+	val usdQuote = future {
 	  connection.getCurrentValue(USD)
 	} map {
 	  usd => "Value: " + usd + "$"
@@ -571,7 +571,7 @@ and then renders all the posts to the screen:
 
 	val allposts = mutable.Set[String]()
 	
-  future {
+	future {
 	  session.getRecentPosts
 	} andThen {
 	  posts => allposts ++= posts


### PR DESCRIPTION
I found a small error in the indentation. The code examples for future compositions (`fallbackTo`, `either` and  `andThen`) didn't show correctly.
I hope I've put everything back right.
