### PR TITLE
Ported missing Additions and Updates section in Maps

### DIFF
--- a/overviews/collections/maps.md
+++ b/overviews/collections/maps.md
@@ -29,6 +29,11 @@ The fundamental operations on maps are similar to those on sets. They are summar
 |  `ms contains k`  	    |Tests whether `ms` contains a mapping for key `k`.|
 |  `ms isDefinedAt k`  	    |Same as `contains`.                             |    
 | **Additions and Updates:**|						     |
+|  `ms + (k -> v)`          |The map containing all mappings of `ms` as well as the mapping `k -> v` from key `k` to value `v`.|
+|  `ms + (k -> v, l -> w)`  |The map containing all mappings of `ms` as well as the given key/value pairs.|
+|  `ms ++ kvs`              |The map containing all mappings of `ms` as well as all key/value pairs of `kvs`.|
+|  `ms updated (k, v)`      |Same as `ms + (k -> v)`.|
+| **Removals:**             |						     |
 |  `ms - k`  	            |The map containing all mappings of `ms` except for any mapping of key `k`.|  
 |  `ms - (k, 1, m)`  	    |The map containing all mappings of `ms` except for any mapping with the given keys.|    
 |  `ms -- ks`  	            |The map containing all mappings of `ms` except for any mapping with a key in `ks`.|    


### PR DESCRIPTION
The [Operation in Class Map](http://docs.scala-lang.org/overviews/collections/maps.html#operations_in_class_map) table is missing "Additions and Updates" found in the [original](http://www.scala-lang.org/docu/files/collections-api/collections_10.html).

The section is there, but it's actually mislabeled  Removals section. The section is ported to markdown from the original.
