### PR TITLE
Fix formatting of Binary Operations

### DIFF
--- a/overviews/collections/sets.md
+++ b/overviews/collections/sets.md
@@ -48,8 +48,8 @@ For example
 |  **Binary Operations:**   |						     |
 |  `xs & ys`  	            |The set intersection of `xs` and `ys`.          |
 |  `xs intersect ys`        |Same as `xs & ys`.                              |
-|  `xs | ys`  	            |The set union of `xs` and `ys`.                 |
-|  `xs union ys`  	    |Same as `xs | ys`.                              |
+|  <code>xs &#124; ys</code>  	            |The set union of `xs` and `ys`.                 |
+|  `xs union ys`  	    |Same as <code>xs &#124; ys</code>.                              |
 |  `xs &~ ys`  	            |The set difference of `xs` and `ys`.            |
 |  `xs diff ys`  	    |Same as `xs &~ ys`.                             |
 


### PR DESCRIPTION
The formatting of the Binary Operations portion of the Operations in Class Set was messed up (due to the pipe character being interpreted as part of the table specification). Unfortunately, there seems to be no way to escape a pipe character within backticks, so I've had to resort to using <code> tags.
