### PR TITLE
Remove paragraph on method 'either'

### DIFF
--- a/overviews/core/_posts/2012-09-20-futures.md
+++ b/overviews/core/_posts/2012-09-20-futures.md
@@ -539,26 +539,6 @@ the case it fails to obtain the dollar value:
 	
 	anyQuote onSuccess { println(_) }
 
-The `either` combinator creates a new future which either holds
-the result of this future or the argument future, whichever completes
-first, irregardless of success or failure. Here is an example in which
-the quote which is returned first gets printed:
-
-	val usdQuote = future {
-	  connection.getCurrentValue(USD)
-	} map {
-	  usd => "Value: " + usd + "$"
-	}
-	val chfQuote = future {
-	  connection.getCurrentValue(CHF)
-	} map {
-	  chf => "Value: " + chf + "CHF"
-	}
-	
-	val anyQuote = usdQuote either chfQuote
-	
-	anyQuote onSuccess { println(_) }
-
 The `andThen` combinator is used purely for side-effecting purposes.
 It returns a new future with exactly the same result as the current
 future, irregardless of whether the current future failed or not.


### PR DESCRIPTION
Method 'either' of the 'Future' trait will not be part of Scala 2.10.0, therefore
it should not be mentioned in the futures overview article.

The corresponding pull request:
https://github.com/scala/scala/pull/1656

Review by @axel22 and @heathermiller
