### PR TITLE
Fixed a bad link on "The Scala Actors API" page 

### DIFF
--- a/overviews/core/_posts/2010-11-30-actors.md
+++ b/overviews/core/_posts/2010-11-30-actors.md
@@ -11,7 +11,7 @@ languages: [es]
 
 This guide describes the API of the `scala.actors` package of Scala 2.8/2.9. The organization follows groups of types that logically belong together. The trait hierarchy is taken into account to structure the individual sections. The focus is on the run-time behavior of the various methods that these traits define, thereby complementing the existing Scaladoc-based API documentation.
 
-NOTE: In Scala 2.10 the Actors library is deprecated and will be removed in future Scala releases. Users should use [Akka](akka.io) actors from the package `akka.actor`. For migration from Scala actors to Akka refer to the [Actors Migration Guide](docs.scala-lang.org/overviews/core/actors-migration-guide.html).
+NOTE: In Scala 2.10 the Actors library is deprecated and will be removed in future Scala releases. Users should use [Akka](http://akka.io) actors from the package `akka.actor`. For migration from Scala actors to Akka refer to the [Actors Migration Guide](docs.scala-lang.org/overviews/core/actors-migration-guide.html).
 
 ## The actor traits Reactor, ReplyReactor, and Actor
 


### PR DESCRIPTION
Hi, I fixed a bad link to the external http://akka.io site in the second paragraph on "The Scala Actors API" page at http://docs.scala-lang.org/overviews/core/actors.html. 

![image](https://f.cloud.github.com/assets/127138/62701/3cb5a370-5d54-11e2-9963-88fbb9f8ad5c.png)
