### PR TITLE
french translation of cheatsheets page

### DIFF
--- a/cheatsheets/index.md
+++ b/cheatsheets/index.md
@@ -3,6 +3,7 @@ layout: cheatsheet
 title: Scalacheat
 by: Brendan O'Connor
 about: Thanks to <a href="http://brenocon.com/">Brendan O'Connor</a>, this cheatsheet aims to be a quick reference of Scala syntactic constructions. Licensed by Brendan O'Connor under a CC-BY-SA 3.0 license.
+languages: [fr]
 ---
 
 ###### Contributed by {{ page.by }}

--- a/fr/cheatsheets/index.md
+++ b/fr/cheatsheets/index.md
@@ -3,6 +3,7 @@ layout: cheatsheet
 title: Memento Scala
 by: Brendan O'Connor
 about: Grâce à  <a href="http://brenocon.com/">Brendan O'Connor</a>, ce memento vise à être un guide de référence rapide pour les constructions syntaxiques en Scala. Licencié par Brendan O'Connor sous licence CC-BY-SA 3.0.
+language: fr
 ---
 
 ###### Contribué par {{ page.by }}


### PR DESCRIPTION
Hello,

I haven’t translate the "infix sugar" because i doesn’t undertand what’s does it mean with the example.
(parens is the abbreviation of parenthesis or bracket ?)
(for : sole member of the Unit type  ; can be , in other word, could be understand as  « empty member of the Unit Type »  ?)

Oh, I forgot an important thing, The cheatsheets-sidbar.txt in _includes :
this terms can be translate in french :
Contents => Sommaire
Other Cheatsheets => Autre Antisèches
About => A Propos

The last loop prints the two about message, the english and the french one.

Thanks for all, 

Benoît
