### PR TITLE
fixes the breakage introduced in jekyll 1.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,5 +15,6 @@ scala-version: 2.10.0
 
 pygments: true
 permalink: /:categories/:title.html
+baseurl:
 
 # markdown: rdiscount


### PR DESCRIPTION
Looks like it silently assumes that site.baseurl is "/", which leads to
double-slashing paths to resources and breaking everything.
