### PR TITLE
fixes a typo in an implicit macro guide

### DIFF
--- a/overviews/macros/implicits.md
+++ b/overviews/macros/implicits.md
@@ -119,7 +119,7 @@ which represents isomorphisms between types. `Iso` can be used to map cases clas
     tp == (23, "foo", true)
 
 If we try to write an implicit materializer for `Iso`, we will run into a wall.
-When typechecking applications of methods like `foo`, scalac has to infer the type argument `L`,
+When typechecking applications of methods like `conv`, scalac has to infer the type argument `L`,
 which it has no clue about (and that's no wonder, since this is domain-specific knowledge). As a result, when we define an implicit
 macro, which synthesizes `Iso[C, L]`, scalac will helpfully infer `L` as `Nothing` before expanding the macro and then everything will crumble.
 


### PR DESCRIPTION
/cc @eed3si9n
