### PR TITLE
SI-7859 Value class member need not be public in 2.11+

### DIFF
--- a/overviews/core/_posts/2012-11-03-value-classes.md
+++ b/overviews/core/_posts/2012-11-03-value-classes.md
@@ -138,7 +138,7 @@ Full details on the implementation of value classes and their limitations may be
 
 A value class ...
 
-1. ... must have only a primary constructor with exactly one public, val parameter whose type is not a value class.
+1. ... must have only a primary constructor with exactly one public, val parameter whose type is not a value class. (From Scala 2.11.0, the parameter may be non-public.)
 2. ... may not have specialized type parameters.
 3. ... may not have nested or local classes, traits, or objects
 4. ... may not define a equals or hashCode method.


### PR DESCRIPTION
See: https://issues.scala-lang.org/browse/SI-7859

Not to be merged until https://github.com/scala/scala/pull/2965 is reviewed and merged.
