### PR TITLE
naming convention for constants.

### DIFF
--- a/style/naming-conventions.md
+++ b/style/naming-conventions.md
@@ -257,13 +257,13 @@ letter lower-case:
     def myMethod = ...
     var myVariable
 
-If the member is final, immutable and it belongs to a package or an object, it may be considered a constant (similar to java's `static final` members) in which case the capitalization is like this:
+If the member is final, immutable and it belongs to a package or an object, it may be considered a constant (similar to Java's `static final` members) in which case the capitalization is like this:
 
     object Container {
         val Constant = 42
     }
 
-Another example: `Pi` on `scala.math` package 
+Another example: `Pi` in `scala.math` package
 
 ## Type Parameters (generics)
 


### PR DESCRIPTION
source: p108 of Programming Scala, Odersky et al.
