### PR TITLE
Save FAQ entry from paulp/scala-faq on abstract value troubles

### DIFF
--- a/tutorials/FAQ/initialization-order.md
+++ b/tutorials/FAQ/initialization-order.md
@@ -7,7 +7,10 @@ disqus: true
 partof: FAQ
 num: 9
 ---
-Consider the following.
+
+## Example
+To understand the problem, let's pick the following concrete example.
+
 ```scala
 abstract class A {
   val x1: String
@@ -25,12 +28,18 @@ class C extends B {
   
   println("C: " + x1 + ", " + x2)
 }
-// scala> new C 
-// A: null, null
-// B: hello, null
-// C: hello, dad
+```
+Let's observe the initialization order through the Scala REPL:
+```
+scala> new C 
+A: null, null
+B: hello, null
+C: hello, dad
 ```
 
+Only when we get to the constructor of `C` are both `x1` and `x2` initialized. Therefore, constructors of `A` and `B` risk running into `NullPointerException`s.
+
+## Explanation
 A 'strict' or 'eager' val is one which is not marked lazy.
 
 In the absence of "early definitions" (see below), initialization of strict vals is done in the following order.


### PR DESCRIPTION
Take the source of [this wiki page](https://github.com/paulp/scala-faq/wiki/Initialization-Order) together with the template of [this other FAQ entry](https://raw.github.com/scala/scala.github.com/master/tutorials/FAQ/finding-implicits.md).

Paul Phillips wants to transfer that repo, and Simon Schäfer suggested moving this here:
https://groups.google.com/d/msg/scala-internals/wW7FOPwAYiU/RUet7R18URsJ
