### PR TITLE
Future documentation improvements

### DIFF
--- a/overviews/core/_posts/2012-09-20-futures.md
+++ b/overviews/core/_posts/2012-09-20-futures.md
@@ -11,30 +11,138 @@ languages: [ja]
 
 ## Introduction
 
-Futures provide a nice way to reason about performing many operations
-in parallel-- in an efficient and non-blocking way. The idea
-is simple, a `Future` is a sort of a placeholder object that you can
-create for a result that does not yet exist. Generally, the result of
-the `Future` is computed concurrently and can be later collected.
-Composing concurrent tasks in this way tends to result in faster, asynchronous, non-blocking parallel code.
+Very much like its [java counter part](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Future.html), a [Future](http://www.scala-lang.org/api/current/index.html#scala.concurrent.Future) represents the result of an asynchronous computation but build upon Scala features such as clojures and partial functions to provide a slicker API.
 
-By default, futures and promises are non-blocking, making use of
-callbacks instead of typical blocking operations.
-To simplify the use of callbacks both syntactically and conceptually,
-Scala provides combinators such as `flatMap`, `foreach`, and `filter` used to compose
-futures in a non-blocking way.
-Blocking is still possible - for cases where it is absolutely
-necessary, futures can be blocked on (although this is discouraged).
+Future and Promises come along a redesign of `scala.concurrent`, meant to act as a common foundation for multiple parallel frameworks and libraries.
 
-<!--
-The futures and promises API builds upon the notion of an
-`ExecutionContext`, an execution environment designed to manage
-resources such as thread pools between parallel frameworks and
-libraries (detailed in an accompanying SIP, forthcoming). Futures and
-promises are created through such `ExecutionContext`s. For example, this makes it possible, 
-in the case of an application which requires blocking futures, for an underlying execution 
-environment to resize itself if necessary to guarantee progress.
--->
+A typical future look like this:
+
+    val inverseFuture : Future[Matrix] = Future {
+      fatMatrix.inverse() // non-blocking long lasting computation
+    }(executionContext)
+
+
+Or with the more idiomatic
+
+    implicit val ec : ExecutionContext = ...
+    val inverseFuture : Future[Matrix] = Future {
+      fatMatrix.inverse()
+    } // ec is implicitly passed
+
+
+Both code snippets delegate the execution of `fatMatrix.inverse()` to `ec` and embody the result of the computation in `inverseFuture`. 
+At some point in the future, `inverseFuture` will contain a Matrix.
+
+We'll start by looking at `ExecutionContext` before diving into the rich `Future` API.
+
+
+## Execution Context   
+
+Future and Promises revolve around [ExecutionContexts](http://www.scala-lang.org/api/current/index.html#scala.concurrent.ExecutionContext), responsible for executing computations.
+
+An `ExecutionContext` is similar to an [Executor](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executor.html): it is free to execute  computations in a new thread, in a pooled thread or in the current thread (although this is discouraged - more on that below).
+
+The `scala.concurrent` package comes out of the box with an `ExecutionContext` implementation, a global static thread pool.
+It is also possible to adapt an `Executor` into an `ExecutionContext`, and you are of course free to implement your own. 
+
+
+### The Global Execution Context
+
+`ExecutionContext.global` is an `ExecutionContext` backed by a [ForkJoinPool](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ForkJoinPool.html). It should be sufficient for most situations but requires some care.  
+A `ForkJoinPool` has a fixed amount of threads (refered to as parallelism level) which can be exceeded in the presence of blocking computation (the pool must be notified though). 
+
+By default the `ExecutionContext.global` set the parallelism level of its underlying fork-join pool to the amount of available processors ([Runtime.availableProcessors](http://docs.oracle.com/javase/7/docs/api/java/lang/Runtime.html#availableProcessors%28%29)).
+This configuration can be overriden by setting one (or more) of the following VM attribute:
+
+  * scala.concurrent.context.minThreads - defaults to `Runtime.availableProcessors`
+  * scala.concurrent.context.numThreads - can be a number or a multiplier (N) in the form 'xN' ;  defaults to `Runtime.availableProcessors`
+  * scala.concurrent.context.maxThreads - defaults to `Runtime.availableProcessors`
+
+The parallelism level will be set to `numThreads` as long as it remains within `[minThreads; maxThreads]`.
+
+As stated above the `ForkJoinPool` can increase the amount of threads beyond its `parallelismLevel` in the presence of blocking computation. As explained in the `ForkJoinPool` API, this is only possible if the pool is explicitly notified:
+
+    import scala.concurrent.Future
+    import scala.concurrent.forkjoin._
+
+    implicit val ec = ExecutionContext.global
+
+    Future {
+      ForkJoinPool.managedBlock(
+        new ManagedBlocker {
+           var done = false
+
+           def block(): Boolean = {
+             try {
+               myLock.lock()
+               // ...
+             } finally {
+              done = true
+             }
+             true
+           }
+
+           def isReleasable: Boolean = done
+        }
+      )
+    }
+
+
+Fortunately the concurrent package provides a convenient way for doing so:
+
+    import scala.concurrent.Future
+	  import scala.concurrent.blocking
+
+    Future {
+      blocking {
+        myLock.lock()
+        // ...
+      }
+    }
+
+Note that `blocking` is a general construct that will be discussed more in depth [below](#in_a_future).
+
+Last but not least, you must remember that the `ForkJoinPool` isn't designed for long lasting blocking operations. Even when notified with `blocking` the pool might not spawn new workers as you would expect, and when new workers are created they can be as many as 32767. 
+To give you an idea, the following code will use 32000 threads:
+
+    implicit val ec = ExecutionContext.global
+
+    for( i <- 1 to 32000 ) {
+      Future {
+        blocking {
+          Thread.sleep(999999)		
+        }
+      }
+    }
+
+
+If you need to wrap long lasting blocking operations we recommend using a dedicated `ExecutionContext`, for instance by wrapping a Java `Executor`.
+   
+
+### Adapting Java Executor
+
+Using `ExecutionContext.fromExecutor` you can adapt a Java `Executor` into an `ExecutionContext`.  
+For instance:
+
+    ExecutionContext.fromExecutor(new ThreadPoolExecutor( /* your configuration */ ))
+
+
+### Synchronous Execution Context
+
+One might be tempted to have an `ExecutionContext` that runs computations within the current thread:
+
+    val currentThreadExecutionContext = ExecutionContext.fromExecutor(
+      new Executor {
+        def execute(runnable: Runnable) { runnable.run() }
+    })
+
+This should be avoided as it introduce non-determinism in the execution of your future.
+
+    Future { doSomething }(ExecutionContext.global).map { doSomethingElse }(currentThreadExecutionContext)
+
+`doSomethingElse` might either execute in `doSomething`'s thread or in the main thread, and therefore be either asynchronous or synchronous.
+As explained [here](http://blog.ometer.com/2011/07/24/callbacks-synchronous-and-asynchronous/) a callback shouldn't be both.
+
 
 ## Futures
 
@@ -76,16 +184,11 @@ a request to obtain a list of friends of a particular user:
     
     val session = socialNetwork.createSessionFor("user", credentials)
     val f: Future[List[Friend]] = future {
-      session.getFriends()
+      blocking {
+        session.getFriends()
+      }
     }
 
-Above, we first import the contents of the `scala.concurrent` package
-to make the type `Future` and the construct `future` visible.
-We will explain the second import shortly.
-
-We then initialize a session variable which we will use to send
-requests to the server, using a hypothetical `createSessionFor`
-method.
 To obtain the list of friends of a user, a request
 has to be sent over a network, which can take a long time.
 This is illustrated with the call to the method `getFriends` that returns `List[Friend]`.
@@ -108,19 +211,7 @@ This future `f` is then failed with this exception instead of being completed su
       session.getFriends
     }
 
-The line `import ExecutionContext.Implicits.global` above imports
-the default global execution context.
-Execution contexts execute tasks submitted to them, and
-you can think of execution contexts as thread pools.
-They are essential for the `future` method because
-they handle how and when the asynchronous computation is executed.
-You can define your own execution contexts and use them with `future`,
-but for now it is sufficient to know that
-you can import the default execution context as shown above.
 
-Our example was based on a hypothetical social network API where
-the computation consists of sending a network request and waiting
-for a response.
 It is fair to offer an example involving an asynchronous computation
 which you can try out of the box. Assume you have a text file and
 you want to find the position of the first occurrence of a particular keyword.
@@ -129,8 +220,10 @@ are being retrieved from the disk, so it makes sense to perform it
 concurrently with the rest of the computation.
 
     val firstOccurrence: Future[Int] = future {
-      val source = scala.io.Source.fromFile("myText.txt")
-      source.toSeq.indexOfSlice("myKeyword")
+      blocking {
+        val source = scala.io.Source.fromFile("myText.txt")
+        source.toSeq.indexOfSlice("myKeyword")
+      }
     }
 
 
@@ -617,6 +710,27 @@ This will allow external frameworks to provide more specialized utilities.
 
 ## Blocking
 
+### in a Future
+
+As seen with the global `ExecutionContext`, it is possible to notify an `ExecutionContext` of a blocking call with the `blocking` construct.
+The implementation is however at the complete discretion of the `ExecutionContext`. While some `ExecutionContext` such as `ExecutionContext.global`
+implement `blocking` by means of `ManagedBlocker`, some just do nothing:
+
+    implicit val ec = ExecutionContext.fromExecutor(
+                        Executors.newFixedThreadPool(4))
+    Future {
+      // here blocking serves only for documentation purpose
+      blocking { blockingStuff() }
+    }
+
+Is equivalent to
+ 
+    Future { blockingStuff() }
+
+The blocking code may also throw an exception. In this case, the exception is forwarded to the caller.
+
+### on a Future
+
 As mentioned earlier, blocking on a future is strongly discouraged
 for the sake of performance and for the prevention of deadlocks.
 Callbacks and combinators on futures are a preferred way to use their results.
@@ -656,16 +770,6 @@ The `Future` trait implements the `Awaitable` trait with methods
 method `ready()` and `result()`. These methods cannot be called directly
 by the clients-- they can only be called by the execution context.
 
-To allow clients to call 3rd party code which is potentially blocking
-and avoid implementing the `Awaitable` trait, the same
-`blocking` primitive can also be used in the following form:
-
-    blocking {
-      potentiallyBlockingCall()
-    }
-
-The blocking code may also throw an exception. In this case, the
-exception is forwarded to the caller.
 
 
 


### PR DESCRIPTION
- Added `ExecutionContext.global` details, especially regarding blocking
- Added a section on synchronous `ExecutionContext`
- Wrapped blocking calls in the Future section with `blocking`
- Made the distinction between blocking in a future and on a future clearer
