### PR TITLE
Add SIP-23: Literal-based singleton types

### DIFF
--- a/sips/pending/_posts/2014-06-27-42.type.md
+++ b/sips/pending/_posts/2014-06-27-42.type.md
@@ -6,6 +6,13 @@ title: SIP-23 - Literal-based singleton types
 
 **By: George Leontiev, Eugene Burmako, Jason Zaugg, Adriaan Moors, Paul Phillips**
 
+<span class="label warning">Note: This SIP is considered a "good idea", but is a work-in-process.</span>
+<span class="label warning">There is no guarantee that it will not be dropped if at some point it is decided that its foundation is not good enough.</span>
+
+<span class="label success">Champion: Adriaan Moors</span>
+
+<span class="label success">Last update: July 9, 2014</span>
+
 ## Motivation
 
 Singleton types bridge the gap between the value level and the type level and hence allow the exploration in Scala of techniques which would typically only be available in languages with support for full-spectrum dependent types.


### PR DESCRIPTION
Hello folks,

Looks like we've discussed all the details on the mailing lists ([scala-language](https://groups.google.com/forum/#!topic/scala-language/9VEnFZImyJI) and [scala-sips](https://groups.google.com/forum/#!topic/scala-sips/YRHd8WW0V40)), and there seem to be a general agreement on what this feature has to look like. So I decided to be bold, and go ahead with porting the [draft document](https://docs.google.com/document/d/1V5Xc3Up_hTuhFNtsZMYJwvCG0IHviq0UMWTjWANwvZ4/edit#) to markdown, incorporating all the suggestions from mailing lists as well as comments from the document itself.

Just read through the [SIP Submission Process document](http://docs.scala-lang.org/sips/sip-submission.html), and it looks like I've messed up some intermediate steps (for example I've posted to scala-language instead of scala-debates). Hope this is okay. Also not sure if I can have number 42 for this SIP. Hope this is okay too :)

Please let me know what you think.

/cc @xeno-by @retronym @adriaanm @paulp @odersky @milessabin @gkossakowski @heathermiller
