### PR TITLE
Support for linking to glossary terms via URL hash

### DIFF
--- a/_includes/glossary-header.txt
+++ b/_includes/glossary-header.txt
@@ -114,18 +114,14 @@
     <script type="text/javascript">
       jQuery(document).ready(function($) {
  
-            $(".scroll").click(function(event){		
-              event.preventDefault();
-              $('html,body').animate({scrollTop:$('li '+this.hash).offset().top}, 500);
-              $('html,body').animate({scrollTop:$('li '+this.hash).offset().top-=50}, 500);
-              $('li '+this.hash+',li '+this.hash+'+ p').effect("highlight", {color: "#FFCC85"}, 3000);
-            });
-      });
-    </script>
+        // Scroll to glossary term specified by hash on page load
+        hash = window.location.hash;
+        if (hash != '') {
+          $('html,body').animate({scrollTop:$('li '+hash).offset().top}, 500);
+          $('html,body').animate({scrollTop:$('li '+hash).offset().top-=50}, 500);
+          $('li '+hash+',li '+hash+'+ p').effect("highlight", {color: "#FFCC85"}, 3000);
+        }
 
-    <script type="text/javascript">
-      jQuery(document).ready(function($) {
- 
         // Set scroll animation for glossary term links within page
         $("#glossary a[href^='#']").click(function(event) {
           event.preventDefault();


### PR DESCRIPTION
Re: Issue #[172](https://github.com/scala/scala.github.com/issues/172)

As suggested by @swartzrock, you could now link directly to the entry for "function literal" like this:
http://docs.scala-lang.org/glossary/#function-literal

It also fixes a (potential future) issue where external links in the glossary would not have worked, since all `<a>` elements had their default prevented, so I've limited this behaviour to `<a href="#...">` elements.
