### PR TITLE
Grammar fix.

### DIFF
--- a/overviews/core/_posts/2012-09-20-futures.md
+++ b/overviews/core/_posts/2012-09-20-futures.md
@@ -857,7 +857,7 @@ for library writers
 ## Utilities
 
 To simplify handling of time in concurrent applications `scala.concurrent`
- introduces a `Duration` abstraction. `Duration` is not supposed be yet another
+ introduces a `Duration` abstraction. `Duration` is not supposed to be yet another
  general time abstraction. It is meant to be used with concurrency libraries and
  resides in `scala.concurrent` package.
 


### PR DESCRIPTION
Sentence missing the word "to".
