### PR TITLE
fix the warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ keywords:
 
 scala-version: 2.10.0
 
-pygments: true
+highlighter: pygments
 permalink: /:categories/:title.html
 
 # markdown: rdiscount


### PR DESCRIPTION
Hello,

During the two previous test for the pull request #361, the "jekyll compiler" reported the following deprecation: 

Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.

This commit fixing it.

Sincerly,
