### PR TITLE
fix links to nightly docs and specification

### DIFF
--- a/_includes/footerbar.txt
+++ b/_includes/footerbar.txt
@@ -3,7 +3,7 @@
 		<ul>
 			<li><h5>API</h5></li>
 			<li><a href="http://www.scala-lang.org/api/current/">Current</a></li>
-			<li><a href="http://www.scala-lang.org/archives/downloads/distrib/files/nightly/docs/library/index.html">Nightly</a></li>
+			<li><a href="http://www.scala-lang.org/files/archive/nightly/2.11.x/api/2.11.x/">Nightly</a></li>
 		</ul>
 		<ul>
 			<li><h5>Learn</h5></li>

--- a/_includes/topbar.txt
+++ b/_includes/topbar.txt
@@ -10,7 +10,7 @@
                       <a href="#" class="menu">API</a>
                       <ul class="menu-dropdown">
                         <li><a href="http://www.scala-lang.org/api/current/">Current</a></li>
-                        <li><a href="http://www.scala-lang.org/api/nightly/">Nightly</a></li>
+                        <li><a href="http://www.scala-lang.org/files/archive/nightly/2.11.x/api/2.11.x/">Nightly</a></li>
                         <!--<li class="divider"></li>
                         <li><a href="#">Previous Versions</a></li>
                         -->

--- a/es/overviews/core/string-interpolation.md
+++ b/es/overviews/core/string-interpolation.md
@@ -86,7 +86,7 @@ En Scala, todas las cadenas "procesadas" son simples transformaciones de código
 
     id"string content"
 
-la transforma en la llamada a un método (`id`) sobre una instancia de [StringContext](http://www.scala-lang.org/archives/downloads/distrib/files/nightly/docs/library/index.html#scala.StringContext). Este método también puede estar disponible en un ámbito implícito. Para definiir nuestra propia cadena de interpolación simplemente necesitamos crear una clase implícita que añada un nuevo método a la clase `StringContext`. A continuación se muestra un ejemplo:
+la transforma en la llamada a un método (`id`) sobre una instancia de [StringContext](http://www.scala-lang.org/api/current/index.html#scala.StringContext). Este método también puede estar disponible en un ámbito implícito. Para definiir nuestra propia cadena de interpolación simplemente necesitamos crear una clase implícita que añada un nuevo método a la clase `StringContext`. A continuación se muestra un ejemplo:
 
     // Note: We extends AnyVal to prevent runtime instantiation.  See 
     // value class guide for more info.

--- a/ja/overviews/core/string-interpolation.md
+++ b/ja/overviews/core/string-interpolation.md
@@ -85,7 +85,7 @@ Scala では、全ての加工文字列リテラルは簡単なコード変換�
 
     id"string content"
 
-これは [`StringContext`](http://www.scala-lang.org/archives/downloads/distrib/files/nightly/docs/library/index.html#scala.StringContext) のインスタンスへのメソッドの呼び出し (`id`) へと変換される。このメソッドは implicit スコープ内で提供することもできる。独自の文字列の補間を定義するには、`StringContext` に新しいメソッドを追加する implicit クラスを作るだけでいい。以下に具体例で説明する:
+これは [`StringContext`](http://www.scala-lang.org/api/current/index.html#scala.StringContext) のインスタンスへのメソッドの呼び出し (`id`) へと変換される。このメソッドは implicit スコープ内で提供することもできる。独自の文字列の補間を定義するには、`StringContext` に新しいメソッドを追加する implicit クラスを作るだけでいい。以下に具体例で説明する:
 
     // 注意: 実行時のインスタンス化を避けるために AnyVal を継承する。
     // これに関しては値クラスのガイドを参照。

--- a/ja/overviews/reflection/annotations-names-scopes.md
+++ b/ja/overviews/reflection/annotations-names-scopes.md
@@ -172,7 +172,7 @@ Scala のプログラムにおいて、「`_root_`」のような特定の名前
 Scala の仕様において**定数式** (constant expression) と呼ばれる式は
 Scala コンパイラによってコンパイル時に評価することができる。
 以下に挙げる式の種類はコンパイル時定数だ。
-([Scala 言語仕様](http://www.scala-lang.org/docu/files/ScalaReference.pdf) の 6.24 参照):
+([Scala 言語仕様 の 6.24](http://scala-lang.org/files/archive/spec/2.11/06-expressions.html#constant-expressions) 参照):
 
 1. プリミティブ値クラスのリテラル ([Byte](http://www.scala-lang.org/api/current/index.html#scala.Byte)、 [Short](http://www.scala-lang.org/api/current/index.html#scala.Short)、 [Int](http://www.scala-lang.org/api/current/index.html#scala.Int)、 [Long](http://www.scala-lang.org/api/current/index.html#scala.Long)、 [Float](http://www.scala-lang.org/api/current/index.html#scala.Float)、 [Double](http://www.scala-lang.org/api/current/index.html#scala.Double)、 [Char](http://www.scala-lang.org/api/current/index.html#scala.Char)、 [Boolean](http://www.scala-lang.org/api/current/index.html#scala.Boolean) および [Unit](http://www.scala-lang.org/api/current/index.html#scala.Unit))。これは直接対応する型で表される。
 2. 文字列リテラル。これは文字列のインスタンスとして表される。

--- a/overviews/core/_posts/2012-09-21-string-interpolation.md
+++ b/overviews/core/_posts/2012-09-21-string-interpolation.md
@@ -94,7 +94,7 @@ In Scala, all processed string literals are simple code transformations.   Anyti
 
     id"string content"
 
-it transforms it into a method call (`id`) on an instance of [StringContext](http://www.scala-lang.org/archives/downloads/distrib/files/nightly/docs/library/index.html#scala.StringContext).
+it transforms it into a method call (`id`) on an instance of [StringContext](http://www.scala-lang.org/api/current/index.html#scala.StringContext).
 This method can also be available on implicit scope.   To define our own string interpolation, we simply need to create an implicit class that adds a new method
 to `StringContext`.  Here's an example:
 

--- a/overviews/reflection/annotations-names-scopes.md
+++ b/overviews/reflection/annotations-names-scopes.md
@@ -187,8 +187,7 @@ API, flag sets could be replaced with something else.
 
 Certain expressions that the Scala specification calls *constant expressions*
 can be evaluated by the Scala compiler at compile time. The following kinds of
-expressions are compile-time constants (see section 6.24 of the
-[Scala language specification](http://www.scala-lang.org/docu/files/ScalaReference.pdf)):
+expressions are compile-time constants (see [section 6.24 of the Scala language specification](http://scala-lang.org/files/archive/spec/2.11/06-expressions.html#constant-expressions)):
 
 1. Literals of primitive value classes ([Byte](http://www.scala-lang.org/api/current/index.html#scala.Byte), [Short](http://www.scala-lang.org/api/current/index.html#scala.Short), [Int](http://www.scala-lang.org/api/current/index.html#scala.Int), [Long](http://www.scala-lang.org/api/current/index.html#scala.Long), [Float](http://www.scala-lang.org/api/current/index.html#scala.Float), [Double](http://www.scala-lang.org/api/current/index.html#scala.Double), [Char](http://www.scala-lang.org/api/current/index.html#scala.Char), [Boolean](http://www.scala-lang.org/api/current/index.html#scala.Boolean) and [Unit](http://www.scala-lang.org/api/current/index.html#scala.Unit)) - represented directly as the corresponding type.
 

--- a/tutorials/FAQ/finding-implicits.md
+++ b/tutorials/FAQ/finding-implicits.md
@@ -328,8 +328,8 @@ Related questions of interest:
 This question and answer were originally submitted on [Stack Overflow][3].
 
   [1]: http://suereth.blogspot.com/2011/02/slides-for-todays-nescala-talk.html
-  [2]: http://lampsvn.epfl.ch/trac/scala/ticket/4427
+  [2]: https://issues.scala-lang.org/browse/SI-4427
   [3]: http://stackoverflow.com/q/5598085/53013
   [4]: http://stackoverflow.com/questions/5512397/passing-scala-math-integral-as-implicit-parameter
-  [5]: www.scala-lang.org/docu/files/ScalaReference.pdf
+  [5]: http://scala-lang.org/files/archive/spec/2.11/
 

--- a/tutorials/FAQ/finding-symbols.md
+++ b/tutorials/FAQ/finding-symbols.md
@@ -183,8 +183,8 @@ And, of course, there's various combinations that can appear in code:
 
 This answer was originally submitted in response to [this question on Stack Overflow][6].
 
-  [1]: http://www.scala-lang.org/sites/default/files/linuxsoft_archives/docu/files/ScalaReference.pdf
-  [2]: http://www.scala-lang.org/archives/downloads/distrib/files/nightly/docs/library/index.html#index.index-_
+  [1]: http://scala-lang.org/files/archive/spec/2.11/
+  [2]: http://www.scala-lang.org/api/current/index.html#index.index-_
   [3]: http://www.scala-lang.org/api/current/index.html#scala.Predef$
   [4]: http://www.scala-lang.org/api/current/scala/Predef$$ArrowAssoc.html
   [5]: http://www.scala-lang.org/api/current/index.html#scala.collection.immutable.List


### PR DESCRIPTION
- nightly docs are here: http://scala-lang.org/files/archive/nightly/2.11.x/api/2.11.x/
  
  the old link points to some pre-2.11.0 nightly.
- specification is now here: http://scala-lang.org/files/archive/spec/2.11/
