### PR TITLE
HTML spec: replace "moonshot" link with real one

### DIFF
--- a/_includes/frontpage-content.txt
+++ b/_includes/frontpage-content.txt
@@ -51,7 +51,7 @@
 		<h3><a href="{{ site.baseurl }}/style">Scala Style Guide</a> <span class="label success">Available</span></h3>
 		<p>Daniel Spiewak and David Copeland’s <em>Scala Style Guide</em> is now available. Thanks to them for putting together such an excellent style guide, and thanks to Simon Ochsenreither for converting it to markdown!</p>		
 
-		<h3>Language Specification <span class="label notice">Just an Idea</span></h3>
+		<h3><a href="http://www.scala-lang.org/files/archive/spec/2.11/">Language Specification</a> <span class="label success">Available</span></h3>
 		<p>It would be nice to have an HTML version of the language specification, right? This is just an idea for now…</p>				
 		
 		<p>&nbsp;</p><p>&nbsp;</p>


### PR DESCRIPTION
Review @heathermiller.
