### PR TITLE
Statify and curate the overview of guides

### DIFF
--- a/overviews/index.md
+++ b/overviews/index.md
@@ -67,3 +67,7 @@ languages: [es, ja]
     * [Implicit Macros](/overviews/macros/implicits.html)
     * [Extractor Macros](/overviews/macros/extractors.html)
     * [Type Providers](/overviews/macros/typeproviders.html)
+    * [Macro Annotations](/overviews/macros/annotations.html)
+    * [Macro Paradise](/overviews/macros/paradise.html)
+    * [Roadmap](/overviews/macros/roadmap.html)
+    * [Changes in 2.11](/overviews/macros/changelog211.html)


### PR DESCRIPTION
Right now a Jekyll upgrade on GitHub has broken
the page. The first commit tries to alleviate this
by creating a cleaner, static markdown version of
the page.

The subsequent commits reorder and categorize the content.
