### PR TITLE
Fix title capitalization

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 markdown: kramdown
 
 title: "Scala Documentation"
-description: "Documentation for the Scala programming language- Tutorials, Overviews, Cheatsheets, and more."
+description: "Documentation for the Scala programming language - Tutorials, Overviews, Cheatsheets, and more."
 keywords:
 - Scala
 - Documentation

--- a/_includes/header.txt
+++ b/_includes/header.txt
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-
-    <title>{% if page.partof %}{{ page.partof | replace: '-',' ' | capitalize }} - {% endif %}{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+    <title>{% if page.partof %}{% assign words = page.partof | split: '-' %}{% for word in words %}{{ word | capitalize }} {% endfor %}- {% endif %}{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
     {% if page.description %}
     <meta name="description" content="{{ page.description }}" />
     {% endif %}


### PR DESCRIPTION
The `capitalize` filter in Liquid templates does not work on arrays.
It first converts arrays to string, and then capitalizes.

The `map` filter wouldn't work either, because it only maps properties.

Solution based on: http://stackoverflow.com/a/21829139/58808
