### PR TITLE
Update readme: bundle install instructions, kramdown not maruku, links to Mou

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: vendor/bundle
+BUNDLE_DISABLE_SHARED_GEMS: '1'

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site
 .project
 .settings
 *~
+vendor/bundle

--- a/README.md
+++ b/README.md
@@ -13,13 +13,11 @@ in order to be accepted.
 
 ## Dependencies ##
 
-This site uses a Jekyll, a ruby framework. You'll need ruby and bundler installed; see [Jekyll installation instructions](http://jekyllrb.com/docs/installation/) for the details.
+This site uses a Jekyll, a Ruby framework. You'll need Ruby and Bundler installed; see [Jekyll installation instructions](http://jekyllrb.com/docs/installation/) for the details.
 
 ## Building & Viewing ##
 
-cd into the directory where you cloned this repository, then install the required gems:
-
-    bundle install
+cd into the directory where you cloned this repository, then install the required gems with `bundle install`. This will automatically put the gems into `./vendor/bundle`.
 
 Start the server in the context of the bundle:
 

--- a/_config.yml
+++ b/_config.yml
@@ -18,5 +18,4 @@ scala-version: 2.10.0
 highlighter: pygments
 permalink: /:categories/:title.html
 baseurl:
-
-# markdown: rdiscount
+exclude: ["vendor"]


### PR DESCRIPTION
Updated instructions for bundler. Clarified how to install ruby. Clarified how to run jekyll in the bundle, and how watching the filesystem works. Link to kramdown, since the site uses that, not maruku. Fix links to Mou. 
