### PR TITLE
Fix broken link to command line getting started

### DIFF
--- a/getting-started-intellij-track/building-a-scala-project-with-intellij-and-sbt.md
+++ b/getting-started-intellij-track/building-a-scala-project-with-intellij-and-sbt.md
@@ -15,7 +15,7 @@ or more than one code file.
 ## Creating the project
 In this section, we'll show you how to create the project in IntelliJ. However, if you're
 comfortable with the command line, we recommend you try [Getting
-Started with Scala and sbt on the Command Line]({{site.baseurl}}/documentation/getting-started-sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.html) and then come back
+Started with Scala and sbt on the Command Line]({{site.baseurl}}/getting-started-sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.html) and then come back
  here to the section "Writing Scala code".
 
 1. If you didn't create the project from the command line, open up IntelliJ and select "Create New Project"


### PR DESCRIPTION
Fix the link to `getting-started-sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.html` in Section `Creating the project`