### PR TITLE
Fix rebuild example to be compliant with previous section

### DIFF
--- a/getting-started-intellij-track/building-a-scala-project-with-intellij-and-sbt.md
+++ b/getting-started-intellij-track/building-a-scala-project-with-intellij-and-sbt.md
@@ -74,8 +74,7 @@ to see if sbt can run your project on the command line.
 when you save changes to a file in the project.
 1. Click **OK**.
 1. On the **Run** menu. Click **Run 'Run the program'**.
-1. In the code, change `currentYear - 1` to `currentYear - 2`
-and look at the updated output in the console.
+1. In the code, change the `ages` sequence replacing `29` with `99`, save and look at the updated output in the console.
 
 ## Adding a dependency
 Changing gears a bit, let's look at how to use published libraries to add


### PR DESCRIPTION
Change the rebuild functionality example to be compliant to the code created before in the tutorial. 