### PR TITLE
Fix code style by removing `:fail` from lower-type-bounds.md

### DIFF
--- a/_tour/lower-type-bounds.md
+++ b/_tour/lower-type-bounds.md
@@ -18,7 +18,7 @@ While [upper type bounds](upper-type-bounds.html) limit a type to a subtype of a
 
 Here is an example where this is useful:
 
-```tut:fail
+```tut
 trait Node[+B] {
   def prepend(elem: B): Unit
 }

--- a/_tour/self-types.md
+++ b/_tour/self-types.md
@@ -24,12 +24,12 @@ trait User {
 }
 
 trait Tweeter {
-	this: User =>  // reassign this
-	def tweet(tweetText: String) = println(s"$username: $tweetText")
+  this: User =>  // reassign this
+  def tweet(tweetText: String) = println(s"$username: $tweetText")
 }
 
 class VerifiedTweeter(val username_ : String) extends Tweeter with User {  // We mixin User because Tweeter required it
-	def username = s"real $username_"
+  def username = s"real $username_"
 }
 
 val realBeyoncé = new VerifiedTweeter("Beyoncé")


### PR DESCRIPTION
Existing documentation layout:
<img width="335" alt="screen shot 2017-08-11 at 13 58 58" src="https://user-images.githubusercontent.com/4052072/29212162-524cc9e2-7e9d-11e7-9f75-ad2eda1490e2.png">
<img width="594" alt="screen shot 2017-08-11 at 14 53 19" src="https://user-images.githubusercontent.com/4052072/29213753-e5e6a9dc-7ea4-11e7-9d32-47ba95927586.png">
Expected one:
<img width="316" alt="screen shot 2017-08-11 at 13 59 50" src="https://user-images.githubusercontent.com/4052072/29212168-5e53bfa2-7e9d-11e7-9310-a55f21d4527c.png">
<img width="591" alt="screen shot 2017-08-11 at 14 54 52" src="https://user-images.githubusercontent.com/4052072/29213792-0da3a7b8-7ea5-11e7-9857-fc4e0b7d3c48.png">

