### PR TITLE
Update mixin-class-composition.md

### DIFF
--- a/_tour/mixin-class-composition.md
+++ b/_tour/mixin-class-composition.md
@@ -73,7 +73,7 @@ We would like to combine the functionality of `StringIterator` and `RichIterator
 
 ```tut
 object StringIteratorTest extends App {
-  class Iter extends StringIterator(args(0)) with RichIterator
+  class RichStringIter extends StringIterator(args(0)) with RichIterator
   val iter = new Iter
   iter foreach println
 }


### PR DESCRIPTION
`Iter` should be replaced with `RichStringIter` or other way around. Class name in code is not consistent with class name in explanation. Also, I suggest using some literal string instead of `args(0)` because it is not obvious for beginners what `args(0)` is.