### PR TITLE
Change "Iter" class name for "RichStringIter"

### DIFF
--- a/_tour/mixin-class-composition.md
+++ b/_tour/mixin-class-composition.md
@@ -73,9 +73,9 @@ We would like to combine the functionality of `StringIterator` and `RichIterator
 
 ```tut
 object StringIteratorTest extends App {
-  class Iter extends StringIterator(args(0)) with RichIterator
-  val iter = new Iter
-  iter foreach println
+  class RichStringIter extends StringIterator(args(0)) with RichIterator
+  val richStringIter = new RichStringIter
+  richStringIter foreach println
 }
 ```
 The new class `RichStringIter` has `StringIterator` as a superclass and `RichIterator` as a mixin.


### PR DESCRIPTION
The comments refer to the "RichStringIter" class name which I guess makes more sense for the code example given than "Iter".