### PR TITLE
#875 - Clarify how to get to next page on Tour of Scala page

### DIFF
--- a/_tour/tour-of-scala.md
+++ b/_tour/tour-of-scala.md
@@ -45,4 +45,4 @@ A joint use of both features facilitates the definition of new statements withou
 
 Scala is designed to interoperate well with the popular Java Runtime Environment (JRE). In particular, the interaction with the mainstream object-oriented Java programming language is as smooth as possible. Newer Java features like [annotations](annotations.html) and Java generics have direct analogues in Scala. Those Scala features without Java analogues, such as [default](default-parameter-values.html) and [named parameters](named-arguments.html), compile as close to Java as they can reasonably come. Scala has the same compilation model (separate compilation, dynamic class loading) like Java and allows access to thousands of existing high-quality libraries.
 
-Please continue to the next page to read more.
+Please continue to the [next page](basics.html) in the Contents menu to read more.


### PR DESCRIPTION
Implemented the clarification requested in the ticket.  Does not address the sequence pattern link comment.