### PR TITLE
Fix typo: 'Iter' -> 'RichStringIter' on the CLASS COMPOSITION WITH MIXINS page

### DIFF
--- a/_tour/mixin-class-composition.md
+++ b/_tour/mixin-class-composition.md
@@ -78,6 +78,6 @@ object StringIteratorTest extends App {
   richStringIter foreach println
 }
 ```
-The new class `Iter` has `StringIterator` as a superclass and `RichIterator` as a mixin.
+The new class `RichStringIter` has `StringIterator` as a superclass and `RichIterator` as a mixin.
 
 With single inheritance we would not be able to achieve this level of flexibility.


### PR DESCRIPTION
Corrected a typo on the [CLASS COMPOSITION WITH MIXINS](http://docs.scala-lang.org/tour/mixin-class-composition.html) page.