### PR TITLE
Minor typos fix

### DIFF
--- a/_tour/nested-functions.md
+++ b/_tour/nested-functions.md
@@ -13,7 +13,7 @@ previous-page: higher-order-functions
 redirect_from: "/tutorials/tour/nested-functions.html"
 ---
 
-In Scala it is possible to nest function definitions. The following object provides a `factorial` function for computing the factorial of a given number:
+In Scala it is possible to nest method definitions. The following object provides a `factorial` method for computing the factorial of a given number:
 
 ```tut
  def factorial(x: Int): Int = {

--- a/_tour/traits.md
+++ b/_tour/traits.md
@@ -36,12 +36,6 @@ Extending the `trait Iterator[A]` requires a type `A` and implementations of the
 ## Using traits
 Use the `extends` keyword to extend a trait. Then implement any abstract members of the trait using the `override` keyword:
 ```tut
-trait Iterator[A] {
-  def hasNext: Boolean
-  def next(): A
-}
-
-
 class IntIterator(to: Int) extends Iterator[Int] {
   private var current = 0
   override def hasNext: Boolean = current < to

--- a/_tour/upper-type-bounds.md
+++ b/_tour/upper-type-bounds.md
@@ -14,7 +14,7 @@ redirect_from: "/tutorials/tour/upper-type-bounds.html"
 ---
 
 In Scala, [type parameters](generic-classes.html) and [abstract types](abstract-types.html) may be constrained by a type bound. Such type bounds limit the concrete values of the type variables and possibly reveal more information about the members of such types. An _upper type bound_ `T <: A` declares that type variable `T` refers to a subtype of type `A`.
-Here is an example that demonstrates upper type bound for a type parameter of class `Cage`:
+Here is an example that demonstrates upper type bound for a type parameter of class `PetContainer`:
 
 ```tut
 abstract class Animal {


### PR DESCRIPTION
Like mentioned in #895, fix for these:
- changed 'Cage' to 'PetContainer'
- changed 'function' to 'method'
- removed duplicate 'Iterator' definition