### PR TITLE
Fix Tour of Scala link

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -53,7 +53,7 @@ Scala project. -->
 ## Next Steps
 Once you've finished these tutorials, check out
 
-* [The Tour of Scala](tutorials/tour/tour-of-scala.html) for bite-sized introductions to Scala's features.
+* [The Tour of Scala](tour/tour-of-scala.html) for bite-sized introductions to Scala's features.
 * [Learning Resources](learn.html), which includes online interactive tutorials and courses.
 * [Our list of some popular Scala books](books.html).
 


### PR DESCRIPTION
The URL http://docs.scala-lang.org/tutorials/tour/tour-of-scala.html redirects to a version in another language (not English), which is undesirable since the link appears on an English-language page.