### PR TITLE
Update scala-for-java-programmers.md

### DIFF
--- a/_overviews/tutorials/scala-for-java-programmers.md
+++ b/_overviews/tutorials/scala-for-java-programmers.md
@@ -342,7 +342,7 @@ inherited from `Object`.
       def re = real
       def im = imaginary
       override def toString() =
-        "" + re + (if (im < 0) "-" else "+") + im + "i"
+        "" + re + (if (im < 0) "-" else "+") + scala.math.abs(im) + "i"
     }
 
 

--- a/_overviews/tutorials/scala-for-java-programmers.md
+++ b/_overviews/tutorials/scala-for-java-programmers.md
@@ -342,7 +342,7 @@ inherited from `Object`.
       def re = real
       def im = imaginary
       override def toString() =
-        "" + re + (if (im < 0) "-" else "+") + scala.math.abs(im) + "i"
+        "" + re + (if (im < 0) "" else "+") + im + "i"
     }
 
 


### PR DESCRIPTION
Not sure if that change is scala-compliant, but if im<0, we should use the absolute value of im to avoid printing a leading minus sign.