### PR TITLE
add return type other than Unit onto the prepend() function in trait …

### DIFF
--- a/_tour/lower-type-bounds.md
+++ b/_tour/lower-type-bounds.md
@@ -42,7 +42,7 @@ To fix this, we need to flip the variance of the type of the parameter `elem` in
 
 ```tut
 trait Node[+B] {
-  def prepend[U >: B](elem: U)
+  def prepend[U >: B](elem: U): Node[U]
 }
 
 case class ListNode[+B](h: B, t: Node[B]) extends Node[B] {


### PR DESCRIPTION
…Bird

I don't think this page intends to have a Unit return type for prepend. Without it, prepend() doesn't do anything useful: ```scala> birdList.prepend(new EuropeanSwallow)``` returns Unit. So add the return type so prepend() does what the reader expects it to. With the suggested change, I get ```scala> birdList.prepend(new EuropeanSwallow)
res16: Node[Bird] = ListNode(EuropeanSwallow(),ListNode(AfricanSwallow(),Nil()))```