### PR TITLE
Removed Bosnian translation redirects

### DIFF
--- a/_ba/tour/abstract-types.md
+++ b/_ba/tour/abstract-types.md
@@ -12,7 +12,6 @@ next-page: compound-types
 previous-page: inner-classes
 prerequisite-knowledge: variance, upper-type-bound
 
-redirect_from: "/tutorials/tour/abstract-types.html"
 ---
 
 Trejtovi i apstraktne klase mogu imati apstraktne tipove kao članove.

--- a/_ba/tour/annotations.md
+++ b/_ba/tour/annotations.md
@@ -11,7 +11,6 @@ num: 32
 next-page: default-parameter-values
 previous-page: by-name-parameters
 
-redirect_from: "/tutorials/tour/annotations.html"
 ---
 
 Anotacije pridružuju meta-informacije definicijama.

--- a/_ba/tour/basics.md
+++ b/_ba/tour/basics.md
@@ -11,7 +11,6 @@ num: 2
 next-page: unified-types
 previous-page: tour-of-scala
 
-redirect_from: "/tutorials/tour/basics.html"
 ---
 
 Na ovoj stranici ćemo objasniti osnove Scale.

--- a/_ba/tour/by-name-parameters.md
+++ b/_ba/tour/by-name-parameters.md
@@ -11,7 +11,6 @@ num: 31
 next-page: annotations
 previous-page: operators
 
-redirect_from: "/tutorials/tour/by-name-parameters.html"
 ---
 
 _By-name parametri_ (u slobodnom prevodu "po-imenu parametri") se izračunavaju samo kada se koriste. 

--- a/_ba/tour/case-classes.md
+++ b/_ba/tour/case-classes.md
@@ -12,7 +12,6 @@ next-page: pattern-matching
 previous-page: currying
 prerequisite-knowledge: classes, basics, mutability
 
-redirect_from: "/tutorials/tour/case-classes.html"
 ---
 
 Case klase su kao obične klase s par ključnih razlika.

--- a/_ba/tour/classes.md
+++ b/_ba/tour/classes.md
@@ -13,7 +13,6 @@ previous-page: unified-types
 topics: classes
 prerequisite-knowledge: no-return-keyword, type-declaration-syntax, string-interpolation, procedures
 
-redirect_from: "/tutorials/tour/classes.html"
 ---
 
 Klase u Scali su šabloni za kreiranje objekata.

--- a/_ba/tour/compound-types.md
+++ b/_ba/tour/compound-types.md
@@ -11,7 +11,6 @@ num: 24
 next-page: self-types
 previous-page: abstract-types
 
-redirect_from: "/tutorials/tour/compound-types.html"
 ---
 
 Ponekad je potrebno izraziti da je tip objekta podtip nekoliko drugih tipova. 

--- a/_ba/tour/currying.md
+++ b/_ba/tour/currying.md
@@ -11,7 +11,6 @@ num: 10
 next-page: case-classes
 previous-page: nested-functions
 
-redirect_from: "/tutorials/tour/currying.html"
 ---
 
 Metode mogu definisati više listi parametara. 

--- a/_ba/tour/default-parameter-values.md
+++ b/_ba/tour/default-parameter-values.md
@@ -12,7 +12,6 @@ next-page: named-arguments
 previous-page: annotations
 prerequisite-knowledge: named-arguments, function syntax
 
-redirect_from: "/tutorials/tour/default-parameter-values.html"
 ---
 
 Scala omogućuje davanje podrazumijevanih vrijednosti parametrima koje dozvoljavaju korisniku metode da izostavi te parametre.

--- a/_ba/tour/extractor-objects.md
+++ b/_ba/tour/extractor-objects.md
@@ -11,7 +11,6 @@ num: 16
 next-page: for-comprehensions
 previous-page: regular-expression-patterns
 
-redirect_from: "/tutorials/tour/extractor-objects.html"
 ---
 
 Ekstraktor objekat je objekat koji ima `unapply` metodu.

--- a/_ba/tour/for-comprehensions.md
+++ b/_ba/tour/for-comprehensions.md
@@ -11,7 +11,6 @@ num: 17
 next-page: generic-classes
 previous-page: extractor-objects
 
-redirect_from: "/tutorials/tour/sequence-comprehensions.html"
 ---
 
 Scala ima skraćenu notaciju za pisanje *komprehensija sekvenci*.

--- a/_ba/tour/generic-classes.md
+++ b/_ba/tour/generic-classes.md
@@ -12,7 +12,6 @@ next-page: variances
 previous-page: for-comprehensions
 assumed-knowledge: classes unified-types
 
-redirect_from: "/tutorials/tour/generic-classes.html"
 ---
 
 Generičke klase su klase koje primaju tipove kao parametre.

--- a/_ba/tour/higher-order-functions.md
+++ b/_ba/tour/higher-order-functions.md
@@ -11,7 +11,6 @@ num: 8
 next-page: nested-functions
 previous-page: mixin-class-composition
 
-redirect_from: "/tutorials/tour/higher-order-functions.html"
 ---
 
 Scala dozvoljava definisanje funkcija višeg reda.

--- a/_ba/tour/implicit-conversions.md
+++ b/_ba/tour/implicit-conversions.md
@@ -11,7 +11,6 @@ num: 27
 next-page: polymorphic-methods
 previous-page: implicit-parameters
 
-redirect_from: "/tutorials/tour/implicit-conversions.html"
 ---
 
 Implicitna konverzija iz tipa `S` u tip `T` je definisana kao implicitna vrijednost koja ima tip `S => T` (funkcija), 

--- a/_ba/tour/implicit-parameters.md
+++ b/_ba/tour/implicit-parameters.md
@@ -11,7 +11,6 @@ num: 26
 next-page: implicit-conversions
 previous-page: self-types
 
-redirect_from: "/tutorials/tour/implicit-parameters.html"
 ---
 
 Metoda s _implicitnim parametrima_ može biti primijenjena na argumente kao i normalna metoda.

--- a/_ba/tour/inner-classes.md
+++ b/_ba/tour/inner-classes.md
@@ -11,7 +11,6 @@ num: 22
 next-page: abstract-types
 previous-page: lower-type-bounds
 
-redirect_from: "/tutorials/tour/inner-classes.html"
 ---
 
 U Scali je moguće da klase imaju druge klase kao članove.

--- a/_ba/tour/local-type-inference.md
+++ b/_ba/tour/local-type-inference.md
@@ -11,7 +11,6 @@ num: 29
 next-page: operators
 previous-page: polymorphic-methods
 
-redirect_from: "/tutorials/tour/local-type-inference.html"
 ---
 Scala ima ugrađen mehanizam zaključivanja tipova koji dozvoljava programeru da izostavi određene anotacije tipova.
 Često nije potrebno specificirati tip varijable u Scali,

--- a/_ba/tour/lower-type-bounds.md
+++ b/_ba/tour/lower-type-bounds.md
@@ -12,7 +12,6 @@ next-page: inner-classes
 previous-page: upper-type-bounds
 prerequisite-knowledge: upper-type-bounds, generics, variance
 
-redirect_from: "/tutorials/tour/lower-type-bounds.html"
 ---
 
 Dok [gornja granica tipa](upper-type-bounds.html) limitira tip na podtip nekog drugog tipa,

--- a/_ba/tour/mixin-class-composition.md
+++ b/_ba/tour/mixin-class-composition.md
@@ -12,7 +12,6 @@ next-page: higher-order-functions
 previous-page: traits
 prerequisite-knowledge: inheritance, traits, abstract-classes, unified-types
 
-redirect_from: "/tutorials/tour/mixin-class-composition.html"
 ---
 
 Mixini su trejtovi koji se koriste za kompoziciju klase.

--- a/_ba/tour/named-arguments.md
+++ b/_ba/tour/named-arguments.md
@@ -11,7 +11,6 @@ num: 34
 previous-page: default-parameter-values
 prerequisite-knowledge: function-syntax
 
-redirect_from: "/tutorials/tour/named-arguments.html"
 ---
 
 Kada se pozivaju metode, možete koristiti imena varijabli eksplicitno pri pozivu:

--- a/_ba/tour/nested-functions.md
+++ b/_ba/tour/nested-functions.md
@@ -11,7 +11,6 @@ num: 9
 next-page: currying
 previous-page: higher-order-functions
 
-redirect_from: "/tutorials/tour/nested-functions.html"
 ---
 
 U Scali je moguće ugnježdavati definicije metode.

--- a/_ba/tour/operators.md
+++ b/_ba/tour/operators.md
@@ -12,7 +12,6 @@ next-page: by-name-parameters
 previous-page: local-type-inference
 prerequisite-knowledge: case-classes
 
-redirect_from: "/tutorials/tour/operators.html"
 ---
 
 U Scali, operatori su metode. 

--- a/_ba/tour/pattern-matching.md
+++ b/_ba/tour/pattern-matching.md
@@ -13,7 +13,6 @@ next-page: singleton-objects
 previous-page: case-classes
 prerequisite-knowledge: case-classes, string-interpolation, subtyping
 
-redirect_from: "/tutorials/tour/pattern-matching.html"
 ---
 
 Podudaranje uzoraka je mehanizam za provjeranje da li vrijednost odgovara uzroku. Uspješno podudaranje može također i dekonstruisati vrijednost na njene dijelove. Ono je moćnija verzija `switch` izjave u Javi tako da se može koristiti umjesto serije if/else izjava.

--- a/_ba/tour/polymorphic-methods.md
+++ b/_ba/tour/polymorphic-methods.md
@@ -13,7 +13,6 @@ next-page: local-type-inference
 previous-page: implicit-conversions
 prerequisite-knowledge: unified-types
 
-redirect_from: "/tutorials/tour/polymorphic-methods.html"
 ---
 
 Metode u Scali mogu biti parametrizovane i s vrijednostima i s tipovima.

--- a/_ba/tour/regular-expression-patterns.md
+++ b/_ba/tour/regular-expression-patterns.md
@@ -12,7 +12,6 @@ num: 15
 next-page: extractor-objects
 previous-page: singleton-objects
 
-redirect_from: "/tutorials/tour/regular-expression-patterns.html"
 ---
 
 Regularni izrazi su stringovi koji se mogu koristiti za traženje uzoraka u podacima.

--- a/_ba/tour/self-types.md
+++ b/_ba/tour/self-types.md
@@ -12,7 +12,6 @@ next-page: implicit-parameters
 previous-page: compound-types
 prerequisite-knowledge: nested-classes, mixin-class-composition
 
-redirect_from: "/tutorials/tour/self-types.html"
 ---
 Self-tipovi su način da deklarišemo da trejt mora biti umiksan u drugi trejt, iako ga ne nasljeđuje direktno.
 Ovo omogućuje da članovi zavisnog trejta budu dostupni bez importovanja.

--- a/_ba/tour/singleton-objects.md
+++ b/_ba/tour/singleton-objects.md
@@ -12,7 +12,6 @@ num: 13
 next-page: regular-expression-patterns
 previous-page: pattern-matching
 
-redirect_from: "/tutorials/tour/singleton-objects.html"
 ---
 
 Metode i vrijednosti koje ne pripadaju individualnim instancama [klase](classes.html) pripadaju *singlton objektima*,

--- a/_ba/tour/tour-of-scala.md
+++ b/_ba/tour/tour-of-scala.md
@@ -11,7 +11,6 @@ num: 1
 
 next-page: basics
 
-redirect_from: "/tutorials/tour/tour-of-scala.html"
 ---
 
 Scala je moderan programski jezik koji spaja više paradigmi,

--- a/_ba/tour/traits.md
+++ b/_ba/tour/traits.md
@@ -12,7 +12,6 @@ next-page: mixin-class-composition
 previous-page: classes
 assumed-knowledge: expressions, classes, generics, objects, companion-objects
 
-redirect_from: "/tutorials/tour/traits.html"
 ---
 
 Trejtovi se koriste za dijeljenje interfejsa i polja među klasama.

--- a/_ba/tour/unified-types.md
+++ b/_ba/tour/unified-types.md
@@ -12,7 +12,6 @@ next-page: classes
 previous-page: basics
 prerequisite-knowledge: classes, basics
 
-redirect_from: "/tutorials/tour/unified-types.html"
 ---
 
 Sve vrijednosti u Scali su objekti, uključujući brojeve i funkcije.

--- a/_ba/tour/upper-type-bounds.md
+++ b/_ba/tour/upper-type-bounds.md
@@ -11,7 +11,6 @@ num: 20
 next-page: lower-type-bounds
 previous-page: variances
 
-redirect_from: "/tutorials/tour/upper-type-bounds.html"
 ---
 
 U Scali, [tipski parametri](generic-classes.html) i [apstraktni tipovi](abstract-types.html) mogu biti ograničeni granicom tipa.

--- a/_ba/tour/variances.md
+++ b/_ba/tour/variances.md
@@ -11,7 +11,6 @@ num: 19
 next-page: upper-type-bounds
 previous-page: generic-classes
 
-redirect_from: "/tutorials/tour/variances.html"
 ---
 
 Varijansa je korelacija podtipskih veza kompleksnih tipova i podtipskih veza njihovih tipova komponenti. 


### PR DESCRIPTION
I clicked a 'normal' looking link (http://docs.scala-lang.org/tutorials/tour/singleton-objects.html) to the docs in an English [blog post](http://www.jesperdj.com/2016/01/08/scala-access-modifiers-and-qualifiers-in-detail/) about access qualifiers, and ended up with the Bosnian translation. I forwarded the link to some scala gitter members and they all reported the same thing happening. I'm pretty sure this is unintended, left over from copy-pasting the articles under `_tour/` to translate as none of the other languages have it.

I just removed the lines from each of the Bosnian articles to bring them in line with the other languages, though it may be worth considering redirecting to the different translations based on the user's browser language?