### PR TITLE
Fixed code to match comments

### DIFF
--- a/_tour/traits.md
+++ b/_tour/traits.md
@@ -50,8 +50,8 @@ class IntIterator(to: Int) extends Iterator[Int] {
 
 
 val iterator = new IntIterator(10)
-iterator.next()  // prints 0
-iterator.next()  // prints 1
+println(iterator.next())  // prints 0
+println(iterator.next())  // prints 1
 ```
 This `IntIterator` class takes a parameter `to` as an upper bound. It `extends Iterator[Int]` which means that the `next` method must return an Int.
 


### PR DESCRIPTION
Comments on lines 53 and 54 make me think that the program prints something as output, which obviously wasn't the case in the previous version. I've added the calls to "println" that are necessary to match the corresponding comments.