### PR TITLE
Fix code sample in reflection overview

### DIFF
--- a/_ja/overviews/reflection/annotations-names-scopes.md
+++ b/_ja/overviews/reflection/annotations-names-scopes.md
@@ -56,7 +56,7 @@ Scala または Java アノテーションに対しては `scalaArgs` は空で
 ## 名前
 
 **名前** (name) は文字列の簡単なラッパーだ。
-[`Name`](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.Names$NameApi)
+[`Name`](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Names$NameApi.html)
 には 2つのサブタイプ `TermName` と `TypeName` があり (オブジェクトやメンバーのような) 項の名前と
 (クラス、トレイト、型メンバのような) 型の名前を区別する。同じオブジェクト内に同名の項と型が共存することができる。別の言い方をすると、型と項は別の名前空間を持つ。
 
@@ -99,30 +99,30 @@ Scala のプログラムにおいて、「`_root_`」のような特定の名前
 
 「`package`」のようないくつかの名前は型名と項名の両方が存在する。
 標準名は `Universe` クラスの `nme` と `tpnme` というメンバとして公開されている。
-全ての標準名の仕様は [API doc](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.StandardNames) を参照。
+全ての標準名の仕様は [API doc](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/StandardNames.html) を参照。
 
 ## スコープ
 
 **スコープ** (scope) は一般にある構文スコープ内の名前をシンボルに関連付ける。
 スコープは入れ子にすることもできる。リフレクション API
-で公開されているスコープの基底型は [Symbol](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.Symbols$Symbol) の iterable という最小限のインターフェイスのみを公開する。
+で公開されているスコープの基底型は [Symbol](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Symbols$Symbol.html) の iterable という最小限のインターフェイスのみを公開する。
 
 追加機能は
-[scala.reflect.api.Types#TypeApi](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.Types$TypeApi)
-内で定義されている `member` と `declarations`
+[scala.reflect.api.Types#TypeApi](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Types$TypeApi.html)
+内で定義されている `member` と `decls`
 が返す**メンバスコープ** (member scope) にて公開される。
-[scala.reflect.api.Scopes#MemberScope](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.Scopes$MemberScope)
+[scala.reflect.api.Scopes#MemberScope](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Scopes$MemberScope.html)
 は `sorted` メソッドをサポートしており、これはメンバを**宣言順に**ソートする。
 
 以下に `List` クラスでオーバーライドされている全てのシンボルのリストを宣言順に返す具体例をみてみよう:
 
-    scala> val overridden = listTpe.declarations.sorted.filter(_.isOverride)
+    scala> val overridden = listTpe.decls.sorted.filter(_.isOverride)
     overridden: List[scala.reflect.runtime.universe.Symbol] = List(method companion, method ++, method +:, method toList, method take, method drop, method slice, method takeRight, method splitAt, method takeWhile, method dropWhile, method span, method reverse, method stringPrefix, method toStream, method foreach)
 
 ## Expr
 
 構文木の基底型である `scala.reflect.api.Trees#Tree` の他に、型付けされた構文木は
-[`scala.reflect.api.Exprs#Expr`](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.Exprs$Expr) 型によっても表すことができる。
+[`scala.reflect.api.Exprs#Expr`](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Exprs$Expr.html) 型によっても表すことができる。
 `Expr` は構文木と、その構文木の型に対するアクセスを提供するための型タグをラッピングする。
 `Expr` は主にマクロのために便宜的に型付けられた構文木を作るために使われる。多くの場合、これは
 `reify` と `splice` メソッドが関わってくる。
@@ -178,8 +178,8 @@ Scala コンパイラによってコンパイル時に評価することがで�
 
 1. プリミティブ値クラスのリテラル ([Byte](http://www.scala-lang.org/api/current/index.html#scala.Byte)、 [Short](http://www.scala-lang.org/api/current/index.html#scala.Short)、 [Int](http://www.scala-lang.org/api/current/index.html#scala.Int)、 [Long](http://www.scala-lang.org/api/current/index.html#scala.Long)、 [Float](http://www.scala-lang.org/api/current/index.html#scala.Float)、 [Double](http://www.scala-lang.org/api/current/index.html#scala.Double)、 [Char](http://www.scala-lang.org/api/current/index.html#scala.Char)、 [Boolean](http://www.scala-lang.org/api/current/index.html#scala.Boolean) および [Unit](http://www.scala-lang.org/api/current/index.html#scala.Unit))。これは直接対応する型で表される。
 2. 文字列リテラル。これは文字列のインスタンスとして表される。
-3. 一般に [scala.Predef#classOf](http://www.scala-lang.org/api/current/index.html#scala.Predef$@classOf[T]:Class[T]) で構築されるクラスへの参照。[型](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.Types$Type)として表される。
-4. Java の列挙要素。[シンボル](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.Symbols$Symbol)として表される。
+3. 一般に [scala.Predef#classOf](http://www.scala-lang.org/api/current/index.html#scala.Predef$@classOf[T]:Class[T]) で構築されるクラスへの参照。[型](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Types$Type.html)として表される。
+4. Java の列挙要素。[シンボル](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Symbols$Symbol.html)として表される。
 
 定数式の用例としては
 
@@ -253,7 +253,7 @@ Java の列挙要素への参照はシンボル (`scala.reflect.api.Symbols#Symb
       val enumRef = jarg("enumRef").value.asInstanceOf[Symbol]
       println(enumRef)                   // value BAR
 
-      val siblings = enumRef.owner.typeSignature.declarations
+      val siblings = enumRef.owner.typeSignature.decls
       val enumValues = siblings.filter(sym => sym.isVal && sym.isPublic)
       println(enumValues)                // Scope {
                                          //   final val FOO: JavaSimpleEnumeration;
@@ -267,8 +267,8 @@ Java の列挙要素への参照はシンボル (`scala.reflect.api.Symbols#Symb
 
 ## プリティプリンタ
 
-[`Trees`](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.Trees) と
-[`Types`](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.Types)
+[`Trees`](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Trees.html) と
+[`Types`](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Types.html)
 を整形して表示するユーティリティを説明しよう。
 
 ### 構文木の表示
@@ -383,7 +383,7 @@ Java の列挙要素への参照はシンボル (`scala.reflect.api.Symbols#Symb
 
 ## 位置情報
 
-**位置情報** ([`Position`](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.Position))
+**位置情報** ([`Position`](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Position.html))
 はシンボルや構文木のノードの出処を追跡するのに使われる。警告やエラーの表示でよく使われ、プログラムのどこが間違ったのかを正確に表示することができる。位置情報はソースファイルの列と行を表す。
 (ソースファイルの初めからのオフセットは「ポイント」と呼ばれるが、これは便利ではないことがある)
 位置情報はそれが指す行の内容も保持する。全ての構文木やシンボルが位置情報を持つわけではなく、ない場合は

--- a/_ja/overviews/reflection/environment-universes-mirrors.md
+++ b/_ja/overviews/reflection/environment-universes-mirrors.md
@@ -90,7 +90,7 @@ invoker ミラーを作成することができる。
 `MethodMirror` はインスタンス・メソッド (Scala にはインスタンス・メソッドのみがある。オブジェクトのメソッドは `ModuleMirror.instance` から取得されるオブジェクト・インスタンスのインスタンス・メソッドだ。) の呼び出しに使われる。作り方: `val mm = im.reflectMethod(<method symbol>)`。
 具体例:
 
-    scala> val methodX = ru.typeOf[C].declaration(ru.TermName("x")).asMethod
+    scala> val methodX = ru.typeOf[C].decl(ru.TermName("x")).asMethod
     methodX: scala.reflect.runtime.universe.MethodSymbol = method x
 
     scala> val mm = im.reflectMethod(methodX)
@@ -111,7 +111,7 @@ invoker ミラーを作成することができる。
     scala> val im = m.reflect(new C)
     im: scala.reflect.runtime.universe.InstanceMirror = instance mirror for C@5f0c8ac1
 
-    scala> val fieldX = ru.typeOf[C].declaration(ru.TermName("x")).asTerm.accessed.asTerm
+    scala> val fieldX = ru.typeOf[C].decl(ru.TermName("x")).asTerm.accessed.asTerm
     fieldX: scala.reflect.runtime.universe.TermSymbol = value x
 
     scala> val fmX = im.reflectField(fieldX)
@@ -122,7 +122,7 @@ invoker ミラーを作成することができる。
 
     scala> fmX.set(3)
 
-    scala> val fieldY = ru.typeOf[C].declaration(ru.TermName("y")).asTerm.accessed.asTerm
+    scala> val fieldY = ru.typeOf[C].decl(ru.TermName("y")).asTerm.accessed.asTerm
     fieldY: scala.reflect.runtime.universe.TermSymbol = variable y
 
     scala> val fmY = im.reflectField(fieldY)
@@ -151,7 +151,7 @@ invoker ミラーを作成することができる。
     scala> val cm = m.reflectClass(classC)
     cm: scala.reflect.runtime.universe.ClassMirror = class mirror for C (bound to null)
 
-    scala> val ctorC = ru.typeOf[C].declaration(ru.nme.CONSTRUCTOR).asMethod
+    scala> val ctorC = ru.typeOf[C].decl(ru.nme.CONSTRUCTOR).asMethod
     ctorC: scala.reflect.runtime.universe.MethodSymbol = constructor C
 
     scala> val ctorm = cm.reflectConstructor(ctorC)

--- a/_ja/overviews/reflection/overview.md
+++ b/_ja/overviews/reflection/overview.md
@@ -91,7 +91,7 @@ Scala コンパイラが持つ型情報を全ては入手できない可能性�
 
 目的の `Type` のインスタンスが得られれば、これをインスペクトすることもできる。以下に具体例で説明しよう:
 
-    scala> val decls = theType.declarations.take(10)
+    scala> val decls = theType.decls.take(10)
     decls: Iterable[ru.Symbol] = List(constructor List, method companion, method isEmpty, method head, method tail, method ::, method :::, method reverse_:::, method mapConserve, method ++)
 
 #### ランタイム型のインスタンス化
@@ -118,7 +118,7 @@ Scala コンパイラが持つ型情報を全ては入手できない可能性�
 次に、`reflectClass` メソッドを使って `Person` クラスの `ClassMirror` を取得する。
 `ClassMirror` は `Person` クラスのコンストラクタへのアクセスを提供する。
 
-    scala> val ctor = ru.typeOf[Person].declaration(ru.nme.CONSTRUCTOR).asMethod
+    scala> val ctor = ru.typeOf[Person].decl(ru.nme.CONSTRUCTOR).asMethod
     ctor: scala.reflect.runtime.universe.MethodSymbol = constructor Person
 
 `Person` のコンストラクタのシンボルは実行時ユニバース `ru` を用いて `Person` 型の宣言から照会することによってのみ得られる。
@@ -152,7 +152,7 @@ Scala コンパイラが持つ型情報を全ては入手できない可能性�
 `shipped` メンバにアクセスするには、前の例と同じく、`p` のクラス (`Purchase`) を含むクラスローダが読み込んだ全てのクラスを入手可能とするミラー `m`
 を取得することから始める。
 
-    scala> val shippingTermSymb = ru.typeOf[Purchase].declaration(ru.TermName("shipped")).asTerm
+    scala> val shippingTermSymb = ru.typeOf[Purchase].decl(ru.TermName("shipped")).asTerm
     shippingTermSymb: scala.reflect.runtime.universe.TermSymbol = method shipped
 
 次に、`shipped` フィールドの宣言を照会して `TermSymbol` (`Symbol` 型の 1つ) を得る。

--- a/_ja/overviews/reflection/symbols-trees-types.md
+++ b/_ja/overviews/reflection/symbols-trees-types.md
@@ -170,7 +170,7 @@ title: シンボル、構文木、型
     scala> val intTpe = universe.definitions.IntTpe
     intTpe: scala.reflect.runtime.universe.Type = Int
 
-標準型のリストは [`scala.reflect.api.StandardDefinitions`](http://www.scala-lang.org/api/current/index.html#scala.reflect.api.StandardDefinitions$StandardTypes) 内の `StandardTypes`
+標準型のリストは [`scala.reflect.api.StandardDefinitions`](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/StandardDefinitions$StandardTypes.html) 内の `StandardTypes`
 トレイトにて定義されている。
 
 ### 型の一般的な演算
@@ -299,8 +299,8 @@ Scala の数値型は以下の順序付けに従っている (Scala 言語仕様
 `Type` の**宣言** (declaration) にはその `Type` が表すクラス/オブジェクト/トレイト内で宣言された (継承されなかった) メンバのみが含まれる。
 
 ある特定のメンバや宣言の `Symbol` を取得するにはその型に関連する定義のリストを提供する
-`members` か `declarations` メソッドを使うだけでいい。単一のシンボルのみを返す
-`meber` と `declaration` というメソッドもある。以下に 4つのメソッド全てのシグネチャを示す:
+`members` か `decls` メソッドを使うだけでいい。単一のシンボルのみを返す
+`member` と `decl` というメソッドもある。以下に 4つのメソッド全てのシグネチャを示す:
 
     /** The member with given name, either directly declared or inherited, an
       * OverloadedSymbol if several exist, NoSymbol if none exist. */
@@ -308,7 +308,7 @@ Scala の数値型は以下の順序付けに従っている (Scala 言語仕様
 
     /** The defined or declared members with name name in this type; an
       * OverloadedSymbol if several exist, NoSymbol if none exist. */
-    def declaration(name: Universe.Name): Universe.Symbol
+    def decl(name: Universe.Name): Universe.Symbol
 
     /** A Scope containing all members of this type
       * (directly declared or inherited). */
@@ -318,7 +318,7 @@ Scala の数値型は以下の順序付けに従っている (Scala 言語仕様
                                       // filter, foreach to query!
 
     /** A Scope containing the members declared directly on this type. */
-    def declarations: Universe.MemberScope // MemberScope is a type of
+    def decls: Universe.MemberScope // MemberScope is a type of
                                            // Traversable, use higher-order
                                            // functions such as map,
                                            // filter, foreach to query!

--- a/_overviews/reflection/annotations-names-scopes.md
+++ b/_overviews/reflection/annotations-names-scopes.md
@@ -61,7 +61,7 @@ represent different kinds of Java annotation arguments:
 ## Names
 
 Names are simple wrappers for strings.
-[Name](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Names$NameApi)
+[Name](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Names$NameApi.html)
 has two subtypes `TermName` and `TypeName` which distinguish names of terms (like
 objects or members) and types (like classes, traits, and type members). A term
 and a type of the same name can co-exist in the same object. In other words,
@@ -111,32 +111,32 @@ There are both
 Some names, such as "package", exist both as a type name and a term name.
 Standard names are made available through the `nme` and `tpnme` members of
 class `Universe`. For a complete specification of all standard names, see the
-[API documentation](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.StandardNames).
+[API documentation](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/StandardNames.html).
 
 ## Scopes
 
 A scope object generally maps names to symbols available in a corresponding
 lexical scope. Scopes can be nested. The base type exposed in the reflection
 API, however, only exposes a minimal interface, representing a scope as an
-iterable of [Symbol](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Symbols$Symbol)s.
+iterable of [Symbol](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Symbols$Symbol.html)s.
 
 Additional functionality is exposed in *member scopes* that are returned by
-`members` and `declarations` defined in
-[scala.reflect.api.Types#TypeApi](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Types$TypeApi).
-[scala.reflect.api.Scopes#MemberScope](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Scopes$MemberScope)
+`members` and `decls` defined in
+[scala.reflect.api.Types#TypeApi](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Types$TypeApi.html).
+[scala.reflect.api.Scopes#MemberScope](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Scopes$MemberScope.html)
 supports the `sorted` method, which sorts members *in declaration order*.
 
 The following example returns a list of the symbols of all overridden members
 of the `List` class, in declaration order:
 
-    scala> val overridden = listTpe.declarations.sorted.filter(_.isOverride)
+    scala> val overridden = listTpe.decls.sorted.filter(_.isOverride)
     overridden: List[scala.reflect.runtime.universe.Symbol] = List(method companion, method ++, method +:, method toList, method take, method drop, method slice, method takeRight, method splitAt, method takeWhile, method dropWhile, method span, method reverse, method stringPrefix, method toStream, method foreach)
 
 ## Exprs
 
 In addition to type `scala.reflect.api.Trees#Tree`, the base type of abstract
 syntax trees, typed trees can also be represented as instances of type
-[`scala.reflect.api.Exprs#Expr`](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Exprs$Expr).
+[`scala.reflect.api.Exprs#Expr`](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Exprs$Expr.html).
 An `Expr` wraps
 an abstract syntax tree and an internal type tag to provide access to the type
 of the tree. `Expr`s are mainly used to simply and conveniently create typed
@@ -196,9 +196,9 @@ expressions are compile-time constants (see [section 6.24 of the Scala language 
 
 2. String literals - represented as instances of the string.
 
-3. References to classes, typically constructed with [scala.Predef#classOf](http://www.scala-lang.org/api/current/index.html#scala.Predef$@classOf[T]:Class[T]) - represented as [types](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Types$Type).
+3. References to classes, typically constructed with [scala.Predef#classOf](http://www.scala-lang.org/api/current/index.html#scala.Predef$@classOf[T]:Class[T]) - represented as [types](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Types$Type.html).
 
-4. References to Java enumeration values - represented as [symbols](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Symbols$Symbol).
+4. References to Java enumeration values - represented as [symbols](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Symbols$Symbol.html).
 
 Constant expressions are used to represent
 
@@ -278,7 +278,7 @@ Example:
       val enumRef = jarg("enumRef").value.asInstanceOf[Symbol]
       println(enumRef)                   // value BAR
 
-      val siblings = enumRef.owner.typeSignature.declarations
+      val siblings = enumRef.owner.typeSignature.decls
       val enumValues = siblings.filter(sym => sym.isVal && sym.isPublic)
       println(enumValues)                // Scope {
                                          //   final val FOO: JavaSimpleEnumeration;
@@ -293,8 +293,8 @@ Example:
 ## Printers
 
 Utilities for nicely printing
-[`Trees`](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Trees) and
-[`Types`](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Types).
+[`Trees`](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Trees.html) and
+[`Types`](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Types.html).
 
 ### Printing Trees
 
@@ -414,7 +414,7 @@ additionally shows the unique identifiers of symbols, as well as their kind
 ## Positions
 
 Positions (instances of the
-[Position](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Position) trait)
+[Position](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Position.html) trait)
 are used to track the origin of symbols and tree nodes. They are commonly used when
 displaying warnings and errors, to indicate the incorrect point in the
 program. Positions indicate a column and line in a source file (the offset

--- a/_overviews/reflection/environment-universes-mirrors.md
+++ b/_overviews/reflection/environment-universes-mirrors.md
@@ -94,7 +94,7 @@ An `InstanceMirror` is used for creating invoker mirrors for methods and fields 
 
 A `MethodMirror` is used for invoking instance methods (Scala only has instance methods-- methods of objects are instance methods of object instances, obtainable via `ModuleMirror.instance`). Entry point: `val mm = im.reflectMethod(<method symbol>)`. Example:
 
-    scala> val methodX = ru.typeOf[C].declaration(ru.TermName("x")).asMethod
+    scala> val methodX = ru.typeOf[C].decl(ru.TermName("x")).asMethod
     methodX: scala.reflect.runtime.universe.MethodSymbol = method x
 
     scala> val mm = im.reflectMethod(methodX)
@@ -114,7 +114,7 @@ A `FieldMirror` is used for getting/setting instance fields (like methods, Scala
     scala> val im = m.reflect(new C)
     im: scala.reflect.runtime.universe.InstanceMirror = instance mirror for C@5f0c8ac1
 
-    scala> val fieldX = ru.typeOf[C].declaration(ru.TermName("x")).asTerm.accessed.asTerm
+    scala> val fieldX = ru.typeOf[C].decl(ru.TermName("x")).asTerm.accessed.asTerm
     fieldX: scala.reflect.runtime.universe.TermSymbol = value x
 
     scala> val fmX = im.reflectField(fieldX)
@@ -125,7 +125,7 @@ A `FieldMirror` is used for getting/setting instance fields (like methods, Scala
 
     scala> fmX.set(3)
 
-    scala> val fieldY = ru.typeOf[C].declaration(ru.TermName("y")).asTerm.accessed.asTerm
+    scala> val fieldY = ru.typeOf[C].decl(ru.TermName("y")).asTerm.accessed.asTerm
     fieldY: scala.reflect.runtime.universe.TermSymbol = variable y
 
     scala> val fmY = im.reflectField(fieldY)
@@ -153,7 +153,7 @@ A `ClassMirror` is used for creating invoker mirrors for constructors. Entry poi
     scala> val cm = m.reflectClass(classC)
     cm: scala.reflect.runtime.universe.ClassMirror = class mirror for C (bound to null)
 
-    scala> val ctorC = ru.typeOf[C].declaration(ru.nme.CONSTRUCTOR).asMethod
+    scala> val ctorC = ru.typeOf[C].decl(ru.nme.CONSTRUCTOR).asMethod
     ctorC: scala.reflect.runtime.universe.MethodSymbol = constructor C
 
     scala> val ctorm = cm.reflectConstructor(ctorC)

--- a/_overviews/reflection/overview.md
+++ b/_overviews/reflection/overview.md
@@ -132,7 +132,7 @@ The second step involves obtaining a `ClassMirror` for class `Person` using
 the `reflectClass` method. The `ClassMirror` provides access to the
 constructor of class `Person`.
 
-    scala> val ctor = ru.typeOf[Person].decls(ru.nme.CONSTRUCTOR).asMethod
+    scala> val ctor = ru.typeOf[Person].decl(ru.nme.CONSTRUCTOR).asMethod
     ctor: scala.reflect.runtime.universe.MethodSymbol = constructor Person
 
 The symbol for `Person`s constructor can be obtained using only the runtime
@@ -171,7 +171,7 @@ which makes all classes and types available that are loaded by the classloader
 that also loaded the class of `p` (`Purchase`), which we need in order to
 access member `shipped`.
 
-    scala> val shippingTermSymb = ru.typeOf[Purchase].decls(ru.TermName("shipped")).asTerm
+    scala> val shippingTermSymb = ru.typeOf[Purchase].decl(ru.TermName("shipped")).asTerm
     shippingTermSymb: scala.reflect.runtime.universe.TermSymbol = method shipped
 
 We now look up the declaration of the `shipped` field, which gives us a
@@ -325,7 +325,7 @@ reflection, such as `Types`, `Trees`, and `Annotations`. For more details, see
 the section of this guide on
 [Universes]({{ site.baseurl}}/overviews/reflection/environment-universes-mirrors.html),
 or the
-[Universes API docs](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Universe)
+[Universes API docs](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Universe.html)
 in package `scala.reflect.api`.
 
 To use most aspects of Scala reflection, including most code examples provided
@@ -345,5 +345,5 @@ different flavors of mirrors must be used.
 For more details, see the section of this guide on
 [Mirrors]({{ site.baseurl}}/overviews/reflection/environment-universes-mirrors.html),
 or the
-[Mirrors API docs](http://www.scala-lang.org/api/current/scala-reflect/index.html#scala.reflect.api.Mirrors)
+[Mirrors API docs](http://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Mirrors.html)
 in package `scala.reflect.api`.

--- a/_overviews/reflection/symbols-trees-types.md
+++ b/_overviews/reflection/symbols-trees-types.md
@@ -325,7 +325,7 @@ types, nested classes/objects/traits, etc. A `Type`'s _declarations_ are only
 those members that were declared (not inherited) in the class/trait/object
 definition which the given `Type` represents.
 
-To obtain a `Symbol` for some specific member or declaration, one need only to use methods `members` or `declarations` which provide the list of definitions associated with that type. There also exists singular counterparts for each, methods `member` and `declaration` as well. The signatures of all four are shown below:
+To obtain a `Symbol` for some specific member or declaration, one need only to use methods `members` or `decls` which provide the list of definitions associated with that type. There also exists singular counterparts for each, methods `member` and `decl` as well. The signatures of all four are shown below:
 
     /** The member with given name, either directly declared or inherited, an
       * OverloadedSymbol if several exist, NoSymbol if none exist. */
@@ -333,7 +333,7 @@ To obtain a `Symbol` for some specific member or declaration, one need only to u
 
     /** The defined or declared members with name name in this type; an
       * OverloadedSymbol if several exist, NoSymbol if none exist. */
-    def declaration(name: Universe.Name): Universe.Symbol
+    def decl(name: Universe.Name): Universe.Symbol
 
     /** A Scope containing all members of this type
       * (directly declared or inherited). */
@@ -343,7 +343,7 @@ To obtain a `Symbol` for some specific member or declaration, one need only to u
                                       // filter, foreach to query!
 
     /** A Scope containing the members declared directly on this type. */
-    def declarations: Universe.MemberScope // MemberScope is a type of
+    def decls: Universe.MemberScope // MemberScope is a type of
                                            // Traversable, use higher-order
                                            // functions such as map,
                                            // filter, foreach to query!


### PR DESCRIPTION
Fix the following issues:

0. Deprecated methods `declarations`/`declaration` replaced with `decls`/`decl`;
0. `decls` used instead of `decl`
0. Links to current Scaladoc;
0. Typo in Japanese docs: `meber`