### PR TITLE
Add "previous" And "next" To Tour Pages

### DIFF
--- a/_layouts/tour.html
+++ b/_layouts/tour.html
@@ -9,7 +9,18 @@ includeCollectionTOC: true
 		<div class="content-primary documentation">
 			<div class="inner-box">
 				{{content}}
-			</div>
+
+                <div class="two-columns">
+                    {% if page.previous-page %}
+                    <a href="{{page.previous-page}}">&larr; <strong>previous</strong></a>
+                    {% else %}
+                    <div></div>
+                    {% endif %}
+                    {% if page.next-page %}
+                    <a href="{{page.next-page}}"><strong>next</strong> &rarr;</a>
+                    {% endif %}
+                </div>
+            </div>
 		</div>
 
 		<!-- TOC -->


### PR DESCRIPTION
Hi! I just started reading the tour page, and one thing that I really wanted was a way to jump to the next page, without scrolling up and clicking something in the contents block to the right hand side. 

As far as I can tell, each page in the "tour" section implements front matter that specifies the previous and next pages, so this will just work for each of them.

<img width="660" alt="screen shot 2017-12-23 at 09 28 50" src="https://user-images.githubusercontent.com/175278/34318596-0c233dbc-e7c4-11e7-8ab3-0969fa21cdf6.png">
