### PR TITLE
Update files.md

### DIFF
--- a/_style/files.md
+++ b/_style/files.md
@@ -39,7 +39,7 @@ file. One common example is that of a sealed trait and several
 sub-classes (often emulating the ADT language feature available in
 functional languages):
 
-    sealed trait Option[+A]
+    sealed abstract class Option[+A]
 
     case class Some[A](a: A) extends Option[A]
 


### PR DESCRIPTION
Follow the Scala API, ```Option[+A]``` should be an abstract class, NOT a trait.

Conceptually, this is important. When you define a type, it should be a class or an abstract class. When you annotate a type, it can be a class, an abstract class, or a trait.