### PR TITLE
Update declarations.md

### DIFF
--- a/_style/declarations.md
+++ b/_style/declarations.md
@@ -123,7 +123,7 @@ applicable):
 
     @Transaction
     @throws(classOf[IOException])
-    override protected final def foo() {
+    override protected final def foo(): Unit = {
       ...
     }
 


### PR DESCRIPTION
In the **Modifiers** subsection there is a method definition ```foo()```, which does NOT follow a rule of this style guide.