### PR TITLE
Fix return type of forecastInFahrenheit

### DIFF
--- a/_tour/higher-order-functions.md
+++ b/_tour/higher-order-functions.md
@@ -53,7 +53,7 @@ case class WeeklyWeatherForecast(temperatures: Seq[Double]) {
 
   private def convertCtoF(temp: Double) = temp * 1.8 + 32
 
-  def forecastInFahrenheit: Double = temperatures.map(convertCtoF) // <-- passing the method convertCtoF
+  def forecastInFahrenheit: Seq[Double] = temperatures.map(convertCtoF) // <-- passing the method convertCtoF
 }
 ```
 Here the method `convertCtoF` is passed to forecastInFahrenheit  This is possible because the compiler coerces `convertCtoF` to the function `x => convertCtoF(x)` (note: `x` will


### PR DESCRIPTION
forecastInFahrenheit returns a `Seq[Double]`, not a `Double`