### PR TITLE
fix out-of-order: def foldLeft[B](z: B)(op: (A,B) => B): B

### DIFF
--- a/_style/declarations.md
+++ b/_style/declarations.md
@@ -207,7 +207,7 @@ There are three main reasons you should do this:
     type inferencer can allow a simpler syntax when invoking the
     remaining parameter lists. Consider fold:
 
-        def foldLeft[B](z: B)(op: (A,B) => B): B
+        def foldLeft[B](z: B)(op: (B, A) => B): B
         List("").foldLeft(0)(_ + _.length)
 
         // If, instead:


### PR DESCRIPTION
fix out-of-order:  ```def foldLeft[B](z: B)(op: (A,B) => B): B```  to ```def foldLeft[B](z: B)(op: (B, A) => B): B```
The details is in https://github.com/scala/docs.scala-lang/issues/975