### PR TITLE
Adds first pass at JDK compatibility table

### DIFF
--- a/_data/overviews.yml
+++ b/_data/overviews.yml
@@ -89,6 +89,10 @@
         The Scala REPL is a tool (<code>scala</code>) for evaluating expressions in Scala.
         <br><br>
         The <code>scala</code> command will execute a source script by wrapping it in a template and then compiling and executing the resulting program
+    - title: JDK Compatibility
+      icon: coffee
+      url: "jdk-compatibility/overview.html"
+      description: "Tables and more explaining Scala's use of the Java Virtual Machine and Java Development Kit."
 
 - category: Parallel and Concurrent Programming
   description: "Complete guides covering some of Scala's libraries for parallel and concurrent programming."

--- a/_data/overviews.yml
+++ b/_data/overviews.yml
@@ -89,10 +89,10 @@
         The Scala REPL is a tool (<code>scala</code>) for evaluating expressions in Scala.
         <br><br>
         The <code>scala</code> command will execute a source script by wrapping it in a template and then compiling and executing the resulting program
-    - title: JDK Compatibility
+    - title: JDK Version Compatibility
       icon: coffee
       url: "jdk-compatibility/overview.html"
-      description: "Tables and more explaining Scala's use of the Java Virtual Machine and Java Development Kit."
+      description: "Which Scala versions work on what JDK versions"
 
 - category: Parallel and Concurrent Programming
   description: "Complete guides covering some of Scala's libraries for parallel and concurrent programming."

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -20,7 +20,7 @@ This table shows the first Scala release in each series that functions on each J
 | 9           | 2.12.4, 2.11.12, 2.10.7                              |
 | 8           | 2.12.0, 2.11.0, 2.10.0                               |
 | 7           | 2.11.0, 2.10.0                                       |
-| 6           | 2.10.0                                               |
+| 6           | 2.11.0, 2.10.0                                       |
 
 ### JDK 9 compatibility notes
 

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -22,4 +22,10 @@ This table shows the first Scala release in each series that functions on each J
 | 7           | 2.11.0, 2.10.0                                       |
 | 6           | 2.10.0                                               |
 
-Note that JDK 9 support requires minimum sbt version 1.1.0, or 0.13.17 in the 0.13.x series.
+### JDK 9 compatibility notes
+
+As of Scala 2.12.4 and 2.11.12, **JDK 9 support is incomplete**. Notably, `scalac` will not enforce the restrictions of the Java Platform Module System, which means that code that typechecks may incur linkage errors at runtime.
+
+JDK 9 support requires minimum sbt version 1.1.0, or 0.13.17 in the 0.13.x series.
+
+For more information on JDK 9 compatibility, watch the ["Support JDK 9"](https://github.com/scala/scala-dev/issues/139 "scala/scala-dev #139") issue on GitHub.

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -1,0 +1,25 @@
+---
+layout: multipage-overview
+title: Overview
+
+discourse: true
+
+partof: jdk-compatibility
+overview-name: JDK Compatibility
+
+num: 1
+permalink: /overviews/jdk-compatibility/:title.html
+---
+
+Scala runs primarily on the Java Virtual Machine (JVM). As Scala and the JVM improve independently over time, Scala drops compatibility with older versions of the Java Developer Kit (JDK) in order to focus development efforts on supporting new JVM features that benefit Scala.
+
+This table shows the first Scala release in each series that functions on each JDK.
+
+| JDK version | First Scala release supporting JDK version per series |
+|:-----------:|:-----------------------------------------------------|
+| 9           | 2.12.4, 2.11.12                                      |
+| 8           | 2.12.0, 2.11.0, 2.10.7                               |
+| 7           | 2.11.0, 2.10.0                                       |
+| 6           | 2.10.0                                               |
+
+Note that JDK 9 support requires minimum sbt version 1.1.0, or 0.13.17 in the 0.13.x series.

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -17,8 +17,8 @@ This table shows the first Scala release in each series that functions on each J
 
 | JDK version | First Scala release supporting JDK version per series |
 |:-----------:|:-----------------------------------------------------|
-| 9           | 2.12.4, 2.11.12                                      |
-| 8           | 2.12.0, 2.11.0, 2.10.7                               |
+| 9           | 2.12.4, 2.11.12, 2.10.7                              |
+| 8           | 2.12.0, 2.11.0, 2.10.0                               |
 | 7           | 2.11.0, 2.10.0                                       |
 | 6           | 2.10.0                                               |
 


### PR DESCRIPTION
Information has not been fully verified beyond comments in #1000.

I'll happily fix the data given more input from those with a longer memory!

I think I'd prefer to represent this with a chart of some kind, perhaps a Gantt-like chart or something, but I can't think quickly of a good way to _script_ generation of this kind of chart so that it's easily updatable in the future.

Fixes #1000 