### PR TITLE
removed redundant word to fix sentence

### DIFF
--- a/_tour/type-inference.md
+++ b/_tour/type-inference.md
@@ -65,7 +65,7 @@ Also, type inference can sometimes infer a too-specific type.  Suppose we write:
 var obj = null
 ```
 
-Then we can't then go on and make this reassignment:
+We can't then go on and make this reassignment:
 
 ```tut:fail
 obj = new AnyRef


### PR DESCRIPTION
Changed "Then we can't then ..." to "We can't then..."