### PR TITLE
Set vote-status to 'complete', fixes scala/docs.scala-lang/issues/1001

### DIFF
--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -3,7 +3,7 @@ layout: sip
 discourse: true
 title: SIP-23 - Literal-based singleton types
 
-vote-status: completed 
+vote-status: complete
 permalink: /sips/:title.html
 ---
 

--- a/_sips/sips/2017-02-07-priority-based-infix-type-precedence.md
+++ b/_sips/sips/2017-02-07-priority-based-infix-type-precedence.md
@@ -3,7 +3,7 @@ layout: sip
 discourse: true
 title: SIP-33 - Priority-based infix type precedence
 
-vote-status: completed
+vote-status: complete
 permalink: /sips/:title.html
 ---
 


### PR DESCRIPTION
The list of all SIPs https://docs.scala-lang.org/sips/all.html is missing two SIPs, because it is looking for vote-status 'complete', while two SIPs had vote-status 'completed'.