### PR TITLE
try to clarify with a compiling example.

### DIFF
--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -23,7 +23,13 @@ Implicit conversions are applied in two situations:
 In the first case, a conversion `c` is searched for which is applicable to `e` and whose result type conforms to `T`.
 In the second case, a conversion `c` is searched for which is applicable to `e` and whose result contains a member named `m`.
 
-If an implicit method `List[A] => Ordered[List[A]]` like the one below
+If an implicit method `List[A] => Ordered[List[A]]` is in scope, as well as an implicit method `Int => Ordered[Int]`, the following operation on the two lists of type `List[Int]` is legal:
+
+```
+List(1, 2, 3) <= List(4, 5)
+```
+
+An implicit method `Int => Ordered[Int]` is provided automatically through `scala.Predef.intWrapper`. An example of an implicit method `List[A] => Ordered[List[A]]` is provided below.
 
 ```
 implicit def list2ordered[A](x: List[A])
@@ -32,13 +38,6 @@ implicit def list2ordered[A](x: List[A])
     //replace with a more useful implementation
     def compare(that: List[A]): Int = 1
   }
-```
-
-is in scope, as well as an implicit method `Int => Ordered[Int]`, one of which is provided automatically
-through `scala.Predef.intWrapper`, the following operation on the two lists of type `List[Int]` is legal:
-
-```
-List(1, 2, 3) <= List(4, 5)
 ```
 
 The implicitly imported object `scala.Predef` declares several predefined types (e.g. `Pair`) and methods (e.g. `assert`) but also several implicit conversions.

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -34,7 +34,8 @@ implicit def list2ordered[A](x: List[A])
   }
 ```
 
-is in scope, the following operation on the two lists of type `List[Int]` is legal:
+is in scope, as well as an implicit method `Int => Ordered[Int]`, one of which is provided automatically
+through `scala.Predef.intWrapper`, the following operation on the two lists of type `List[Int]` is legal:
 
 ```
 List(1, 2, 3) <= List(4, 5)

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -32,6 +32,8 @@ List(1, 2, 3) <= List(4, 5)
 An implicit method `Int => Ordered[Int]` is provided automatically through `scala.Predef.intWrapper`. An example of an implicit method `List[A] => Ordered[List[A]]` is provided below.
 
 ```tut
+import scala.language.implicitConversions
+
 implicit def list2ordered[A](x: List[A])
     (implicit elem2ordered: A => Ordered[A]): Ordered[List[A]] =
   new Ordered[List[A]] { 

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -31,7 +31,7 @@ List(1, 2, 3) <= List(4, 5)
 
 An implicit method `Int => Ordered[Int]` is provided automatically through `scala.Predef.intWrapper`. An example of an implicit method `List[A] => Ordered[List[A]]` is provided below.
 
-```
+```tut
 implicit def list2ordered[A](x: List[A])
     (implicit elem2ordered: A => Ordered[A]): Ordered[List[A]] =
   new Ordered[List[A]] { 

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -23,21 +23,21 @@ Implicit conversions are applied in two situations:
 In the first case, a conversion `c` is searched for which is applicable to `e` and whose result type conforms to `T`.
 In the second case, a conversion `c` is searched for which is applicable to `e` and whose result contains a member named `m`.
 
-The following operation on the two lists xs and ys of type `List[Int]` is legal:
-
-```
-xs <= ys
-```
-
-assuming the implicit methods `list2ordered` and `int2ordered` defined below are in scope:
+If an implicit method `List[A] => Ordered[List[A]]` like the one below
 
 ```
 implicit def list2ordered[A](x: List[A])
     (implicit elem2ordered: A => Ordered[A]): Ordered[List[A]] =
-  new Ordered[List[A]] { /* .. */ }
+  new Ordered[List[A]] { 
+    //replace with a more useful implementation
+    def compare(that: List[A]): Int = 1
+  }
+```
 
-implicit def int2ordered(x: Int): Ordered[Int] =
-  new Ordered[Int] { /* .. */ }
+is in scope, the following operation on the two lists of type `List[Int]` is legal:
+
+```
+List(1, 2, 3) <= List(4, 5)
 ```
 
 The implicitly imported object `scala.Predef` declares several predefined types (e.g. `Pair`) and methods (e.g. `assert`) but also several implicit conversions.


### PR DESCRIPTION
https://gitter.im/scala/scala?at=5a773dcde217167e2c3f4ea0 shows people not understanding this page. Tried to clarify. 

The error message with the unimplemented `Ordered` doesn't give a hint that the problem is with the implementation of Ordered, rather than with `xs <= ys`.

Further, the `Int => Ordered[Int]` implementation leads to ambiguous implicits because of the implementation in `Predef`