### PR TITLE
Try to clarify implicit parameters tour

### DIFF
--- a/_tour/implicit-parameters.md
+++ b/_tour/implicit-parameters.md
@@ -18,7 +18,9 @@ A method can have an _implicit_ parameter list, marked by the _implicit_ keyword
 The places Scala will look for these parameters fall into two categories:
 
 * Scala will first look for implicit definitions and implicit parameters that can be accessed directly (without a prefix) at the point the method with the implicit parameter block is called.
-* Then, it falls back to all members that are marked implicit in the companion object of the implicit parameter.
+* Then it looks for members marked implicit in all the companion objects associated with the implicit candidate type.
+
+A more detailed guide to where scala looks for implicits can be found in [the FAQ](//docs.scala-lang.org/tutorials/FAQ/finding-implicits.html)
 
 In the following example we define a method `sum` which computes the sum of a list of elements using the monoid's `add` and `unit` operations. Please note that implicit values can not be top-level.
 

--- a/_tour/implicit-parameters.md
+++ b/_tour/implicit-parameters.md
@@ -13,52 +13,58 @@ previous-page: self-types
 redirect_from: "/tutorials/tour/implicit-parameters.html"
 ---
 
-A method with _implicit parameters_ can be applied to arguments just like a normal method. In this case the implicit label has no effect. However, if such a method misses arguments for its implicit parameters, such arguments will be automatically provided.
+A method can have an _implicit_ parameter list, marked by the _implicit_ keyword at the start of the parameter list. If the parameters in that parameter list are not passed as usual, scala will look if it can get an implicit value of the correct type, and if it can, pass it automatically.
 
-The actual arguments that are eligible to be passed to an implicit parameter fall into two categories:
+The places scala will look for these parameters fall into two categories:
 
-* First, eligible are all identifiers x that can be accessed at the point of the method call without a prefix and that denote an implicit definition or an implicit parameter.
-* Second, eligible are also all members of companion modules of the implicit parameter's type that are labeled implicit.
+* First, eligible are all identifiers that can be accessed at the point of the method call without a prefix and that denote an implicit definition or an implicit parameter.
+* Second, eligible are also all members of companion objects of the implicit parameter's type that are labeled implicit.
 
-In the following example we define a method `sum` which computes the sum of a list of elements using the monoid's `add` and `unit` operations. Please note that implicit values can not be top-level, they have to be members of a template.
+In the following example we define a method `sum` which computes the sum of a list of elements using the monoid's `add` and `unit` operations. Please note that implicit values can not be top-level.
 
 ```tut
-abstract class SemiGroup[A] {
+abstract class Monoid[A] {
   def add(x: A, y: A): A
-}
-abstract class Monoid[A] extends SemiGroup[A] {
   def unit: A
 }
-object ImplicitTest extends App {
+
+object ImplicitTest {
   implicit object StringMonoid extends Monoid[String] {
     def add(x: String, y: String): String = x concat y
     def unit: String = ""
   }
+  
   implicit object IntMonoid extends Monoid[Int] {
     def add(x: Int, y: Int): Int = x + y
     def unit: Int = 0
   }
+  
   def sum[A](xs: List[A])(implicit m: Monoid[A]): A =
     if (xs.isEmpty) m.unit
     else m.add(xs.head, sum(xs.tail))
-
-  println(sum(List(1, 2, 3)))       // uses IntMonoid implicitly
-  println(sum(List("a", "b", "c"))) // uses StringMonoid implicitly
+    
+  def main(args: Array[String]): Unit = {
+    println(sum(List(1, 2, 3)))       // uses IntMonoid implicitly
+    println(sum(List("a", "b", "c"))) // uses StringMonoid implicitly
+  }
 }
 ```
 
-This example uses a structure from abstract algebra to show how implicit parameters work. A semigroup, modeled by `SemiGroup` here, is an algebraic structure on a set of `A` with an (associative) operation, called `add` here, that combines a pair of `A`s and returns another `A`.
+`Monoid` defines an operation called `add` here, that combines a pair of `A`s and returns another `A`, together with an operation called `unit` that is able to create some (specific) `A`.
 
-A monoid, modeled by `Monoid` here, is a semigroup with a distinguished element of `A`, called `unit`, that when combined with any other element of `A` returns that other element again.
+To show how implicit parameters work, we first define monoids `StringMonoid` and `IntMonoid` for strings and integers, respectively. The `implicit` keyword indicates that the corresponding object can be used implicitly.
 
-To show how implicit parameters work, we first define monoids `StringMonoid` and `IntMonoid` for strings and integers, respectively. The `implicit` keyword indicates that the corresponding object can be used implicitly, within this scope, as a parameter of a function marked implicit.
+The method `sum` takes a `List[A]` and returns an `A`, which takes the initial `A` from `unit`, and combines each next `A` in the list to that with the `add` method. Making the parameter `m` implicit here means we only have to provide the `xs` parameter when we call the method if scala can find a an implict `Monoid[A]` to use for the implicit `m` parameter.
 
-Method `sum` takes a `List[A]` and returns an `A`, which represents the result of applying the monoid operation successively across the whole list. Making the parameter `m` implicit here means we only have to provide the `xs` parameter at the call site, since if we have a `List[A]` we know what type `A` actually is and therefore what type `Monoid[A]` is needed. We can then implicitly find whichever `val` or `object` in the current scope also has that type and use that without needing to specify it explicitly.
+In our `main` method we call `sum` twice, and only provide the `xs` parameter. Scala will now look for an implicit in the scope mentioned above. The first call to `sum` passes a `List[Int]` for `xs`, which means that `A` is `Int`. The implicit parameter list with `m` is left out, so scala will look for an implicit of type `Monoid[Int]`. The first lookup rule reads
 
-Finally, we call `sum` twice, with only one parameter each time. Since the second parameter of `sum`, `m`, is implicit, its value is looked up in the current scope, based on the type of monoid required in each case, meaning both expressions can be fully evaluated.
+> First, eligible are all identifiers that can be accessed at the point of the method call without a prefix and that denote an implicit definition or an implicit parameter.
 
-Here is the output of the Scala program:
+`IntMonoid` is an identifier, it can be accessed directly in `main`, and it is an implicit definition. It is also of the correct type, so it's passed to the sum method automatically.
 
+The second call to `sum` passes a `List[String]`, which means that `A` is `String`. Implicit lookup will go the same way as with `Int`, but will this time find `StringMonoid`, and passes that automatically as `m`.
+
+The program will output
 ```
 6
 abc

--- a/_tour/implicit-parameters.md
+++ b/_tour/implicit-parameters.md
@@ -17,8 +17,8 @@ A method can have an _implicit_ parameter list, marked by the _implicit_ keyword
 
 The places Scala will look for these parameters fall into two categories:
 
-* First, eligible are all identifiers that can be accessed at the point of the method call without a prefix and that denote an implicit definition or an implicit parameter.
-* Second, eligible are also all members of companion objects of the implicit parameter's type that are labeled implicit.
+* Scala will first look for implicit definitions and implicit parameters that can be accessed directly (without a prefix) at the point the method with the implicit parameter block is called.
+* Then, it falls back to all members that are marked implicit in the companion object of the implicit parameter.
 
 In the following example we define a method `sum` which computes the sum of a list of elements using the monoid's `add` and `unit` operations. Please note that implicit values can not be top-level.
 
@@ -29,12 +29,12 @@ abstract class Monoid[A] {
 }
 
 object ImplicitTest {
-  implicit object StringMonoid extends Monoid[String] {
+  implicit val stringMonoid: Monoid[String] = new Monoid[String] {
     def add(x: String, y: String): String = x concat y
     def unit: String = ""
   }
   
-  implicit object IntMonoid extends Monoid[Int] {
+  implicit val intMonoid: Monoid[Int] = new Monoid[Int] {
     def add(x: Int, y: Int): Int = x + y
     def unit: Int = 0
   }
@@ -58,11 +58,11 @@ The method `sum` takes a `List[A]` and returns an `A`, which takes the initial `
 
 In our `main` method we call `sum` twice, and only provide the `xs` parameter. Scala will now look for an implicit in the scope mentioned above. The first call to `sum` passes a `List[Int]` for `xs`, which means that `A` is `Int`. The implicit parameter list with `m` is left out, so Scala will look for an implicit of type `Monoid[Int]`. The first lookup rule reads
 
-> First, eligible are all identifiers that can be accessed at the point of the method call without a prefix and that denote an implicit definition or an implicit parameter.
+> Scala will first look for implicit definitions and implicit parameters that can be accessed directly (without a prefix) at the point the method with the implicit parameter block is called.
 
-`IntMonoid` is an identifier, it can be accessed directly in `main`, and it is an implicit definition. It is also of the correct type, so it's passed to the sum method automatically.
+`intMonoid` is an implicit definition that can be accessed directly directly in `main`. It is also of the correct type, so it's passed to the sum method automatically.
 
-The second call to `sum` passes a `List[String]`, which means that `A` is `String`. Implicit lookup will go the same way as with `Int`, but will this time find `StringMonoid`, and passes that automatically as `m`.
+The second call to `sum` passes a `List[String]`, which means that `A` is `String`. Implicit lookup will go the same way as with `Int`, but will this time find `stringMonoid`, and passes that automatically as `m`.
 
 The program will output
 ```

--- a/_tour/implicit-parameters.md
+++ b/_tour/implicit-parameters.md
@@ -13,9 +13,9 @@ previous-page: self-types
 redirect_from: "/tutorials/tour/implicit-parameters.html"
 ---
 
-A method can have an _implicit_ parameter list, marked by the _implicit_ keyword at the start of the parameter list. If the parameters in that parameter list are not passed as usual, scala will look if it can get an implicit value of the correct type, and if it can, pass it automatically.
+A method can have an _implicit_ parameter list, marked by the _implicit_ keyword at the start of the parameter list. If the parameters in that parameter list are not passed as usual, Scala will look if it can get an implicit value of the correct type, and if it can, pass it automatically.
 
-The places scala will look for these parameters fall into two categories:
+The places Scala will look for these parameters fall into two categories:
 
 * First, eligible are all identifiers that can be accessed at the point of the method call without a prefix and that denote an implicit definition or an implicit parameter.
 * Second, eligible are also all members of companion objects of the implicit parameter's type that are labeled implicit.
@@ -54,9 +54,9 @@ object ImplicitTest {
 
 To show how implicit parameters work, we first define monoids `StringMonoid` and `IntMonoid` for strings and integers, respectively. The `implicit` keyword indicates that the corresponding object can be used implicitly.
 
-The method `sum` takes a `List[A]` and returns an `A`, which takes the initial `A` from `unit`, and combines each next `A` in the list to that with the `add` method. Making the parameter `m` implicit here means we only have to provide the `xs` parameter when we call the method if scala can find a an implict `Monoid[A]` to use for the implicit `m` parameter.
+The method `sum` takes a `List[A]` and returns an `A`, which takes the initial `A` from `unit`, and combines each next `A` in the list to that with the `add` method. Making the parameter `m` implicit here means we only have to provide the `xs` parameter when we call the method if Scala can find a an implict `Monoid[A]` to use for the implicit `m` parameter.
 
-In our `main` method we call `sum` twice, and only provide the `xs` parameter. Scala will now look for an implicit in the scope mentioned above. The first call to `sum` passes a `List[Int]` for `xs`, which means that `A` is `Int`. The implicit parameter list with `m` is left out, so scala will look for an implicit of type `Monoid[Int]`. The first lookup rule reads
+In our `main` method we call `sum` twice, and only provide the `xs` parameter. Scala will now look for an implicit in the scope mentioned above. The first call to `sum` passes a `List[Int]` for `xs`, which means that `A` is `Int`. The implicit parameter list with `m` is left out, so Scala will look for an implicit of type `Monoid[Int]`. The first lookup rule reads
 
 > First, eligible are all identifiers that can be accessed at the point of the method call without a prefix and that denote an implicit definition or an implicit parameter.
 


### PR DESCRIPTION
* Don't explain what a monoid and a semigroup are. This is not the place for that.
* Don't make `Monoid[A]` extend `Semigroup[A]`. This only complicates the example for no gain.
* Explain the lookup procedure.
* Use "Companion object" instead of "companion module"
* Don't mention templates. It's an uncommonly used 
* Don't extend `App`. It doesn't simplify the example.

Further improvements could be to show an example of the second rule of implicit lookup, and/or a chained implicit lookup.