### PR TITLE
packages-and-imports.md - remove next button

### DIFF
--- a/_tour/packages-and-imports.md
+++ b/_tour/packages-and-imports.md
@@ -8,7 +8,6 @@ partof: scala-tour
 
 num: 35
 previous-page: named-arguments
-next-page: type-inference
 ---
 
 # Packages and Imports


### PR DESCRIPTION
packages-and-imports.md is the last page in the tour, so I'm removing the next link/button.