### PR TITLE
Some more opaque type SIP improvements

### DIFF
--- a/_sips/sips/2017-09-20-opaque-types.md
+++ b/_sips/sips/2017-09-20-opaque-types.md
@@ -763,11 +763,12 @@ pattern:
  3. Return the array, which is now treated as immutable.
 
 In this pattern, the vast majority of time is spent in the third step,
-where the arrays compactness and speed of iteration/access provide
+where the array's compactness and speed of iteration/access provide
 major wins over other data types.
 
 This pattern is currently only enforced by convention. However, opaque
-types create an opportunity to provide more safety without overhead:
+types create an opportunity to provide more safety without incurring
+any overhead:
 
 ```scala
 package object ia {

--- a/_sips/sips/2017-09-20-opaque-types.md
+++ b/_sips/sips/2017-09-20-opaque-types.md
@@ -886,7 +886,15 @@ possibly the runtime performance).
 By contrast, replacing `String` with `Digits` is guaranteed to have no
 impact (all occurances of `Digits` are guaranteed to be erased to
 `String`). Aside from the ergonomics of calling the `fromString` and
-`asString` methods, there's no runtime impact of any kind.
+`asString` methods, there's no runtime impact versus using the
+underlying type.
+
+One wrinkle to the above is that built-in primitive types will
+naturally box in some situations (but not others). For example
+`List[Double]` will be represented as a `List[java.lang.Double]`,
+`(Double, Double)` will be represented as a `scala.Tuple2$mcDD$sp`,
+and so on. In these cases, an opaque type will exhibit the same
+behavior.
 
 ### Default visibility
 

--- a/_sips/sips/2017-09-20-opaque-types.md
+++ b/_sips/sips/2017-09-20-opaque-types.md
@@ -32,7 +32,7 @@ Some use cases for opaque types are:
    are expanded in-place.
 
  * New numeric classes, such as unsigned integers. There would no
-   longer need to be a boxing overhead for such classes. So this is
+   longer need to be a boxing overhead for such classes. This is
    similar to value types in .NET and `newtype` in Haskell. Many APIs
    currently use signed integers (to avoid overhead) but document that
    the values will be treated as unsigned.

--- a/_sips/sips/2017-09-20-opaque-types.md
+++ b/_sips/sips/2017-09-20-opaque-types.md
@@ -27,9 +27,15 @@ time.
 
 Some use cases for opaque types are:
 
- * New numeric classes, such as unsigned ints. There would no longer
-   need to be a boxing overhead for such classes. So this is similar
-   to value types in .NET and `newtype` in Haskell.
+ * Implementing type members while retaining parametricity. Currently,
+   concrete `type` definitions are treated as type aliases, i.e. they
+   are expanded in-place.
+
+ * New numeric classes, such as unsigned integers. There would no
+   longer need to be a boxing overhead for such classes. So this is
+   similar to value types in .NET and `newtype` in Haskell. Many APIs
+   currently use singed integers (to avoid overhead) but document that
+   the values will be treated as unsigned.
 
  * Classes representing units of measure. Again, no boxing overhead
    would be incurred for these classes.
@@ -53,16 +59,27 @@ details of the proposal might change driven by implementation concerns.
 
 ### Motivation
 
-Value classes, a Scala feature proposed in [SIP-15], were introduced to the
-language to offer inlined classes whose operations have zero overhead at runtime.
+Authors often introduce type aliases to differentiate many values that
+share a very common type (e.g. `String`, `Int`, `Double`, `Boolean`,
+etc.). In some cases, these authors may believe that using type
+aliases such as `Id` and `Password` means that if they later mix these
+values up, the compiler will catch their error. However, since type
+aliases are replaced by their underlying type (e.g. `String`), these
+values are considered interchangeable (i.e. type aliases are not
+appropriate for differentiating various `String` values).
 
-This feature allows users to define classes with a few restrictions in exchange of
-performance (value classes are boxed/unboxed under some concrete scenarios,
-that are deemed to be commonplace).
+One appropriate solution to the above problem is to create case
+classes which wrap `String`. This works, but incurs a small runtime
+overhead (for every `String` in the previous system we also allocate a
+wrapper, or a "box"). In many cases this is fine but in some it is not.
 
-These scenarios, while certainly common, do not cover the majority of scenarios
-that library authors have to deal with. In reality, experimentation shows that they
-are insufficient, and hence performance-sensitive code suffers (see [Appendix A]).
+Value classes, a Scala feature proposed in [SIP-15], were introduced
+to the language to offer classes that could be inlined in some
+scenarios, thereby removing runtime overhead. These scenarios, while
+certainly common, do not cover the majority of scenarios that library
+authors have to deal with. In reality, experimentation shows that they
+are insufficient, and hence performance-sensitive code suffers (see
+[Appendix A]).
 
 In the following example, we show the current limitations of value classes and
 motivate the need of compile-time wrapper types.
@@ -735,6 +752,177 @@ compile-time safety to a program doesn't add any additional cost
 This example is somewhat similar to `Logarithm` above. Other
 properties we might want to verify at compile-time: `NonNegative`,
 `Positive`, `Finite`, `Unsigned` and so on.
+
+### Immutable (i.e. write-once) arrays
+
+Often performance sensitive code will use arrays via the following
+pattern:
+
+ 1. Allocate an array of a fixed, known size.
+ 2. Initialize the array via code which mutates it.
+ 3. Return the array, which is now treated as immutable.
+
+In this pattern, the vast majority of time is spent in the third step,
+where the arrays compactness and speed of iteration/access provide
+major wins over other data types.
+
+This pattern is currently only enforced by convention. However, opaque
+types create an opportunity to provide more safety without overhead:
+
+```scala
+package object ia {
+
+  import java.util.Arrays
+
+  opaque type IArray[A] = Array[A]
+
+  object IArray {
+    @inline final def initialize[A](body: => Array[A]): IArray[A] = body
+
+    @inline final def size(ia: IArray[A]): Int = ia.length
+    @inline final def get(ia: IArray[A], i: Int): A = ia(i)
+
+    // return a sorted copy of the array
+    def sorted(ia: IArray[A]): IArray[A] = {
+      val arr = Arrays.copyOf(ia, ia.length)
+      scala.util.Sorting.quickSort(arr)
+      arr
+    }
+
+    // use a standard java method to search a sorted IArray.
+    // (note that this doesn't mutate the array).
+    def binarySearch(ia: IArray[Long], elem: Long): Int =
+      Arrays.binarySearch(ia, elem)
+  }
+
+  // same as IArray.binarySearch but implemented by-hand.
+  //
+  // given a sorted IArray, returns index of `elem`,
+  // or a negative value if not found.
+  def binaryIndexOf(ia: IArray[Long], elem: Long): Int = {
+    var lower: Int = 0
+    var upper: Int = IArray.size(ia)
+    while (lower <= upper) {
+      val middle = (lower + upper) >>> 1
+      val n = IArray.get(ia, middle)
+
+      if (n == elem) return middle
+      else if (n < elem) first = middle + 1
+      else last = middle - 1
+    }
+    -lower - 1
+  }
+}
+```
+
+This example is a bit different from others: there's no attempt to
+enrich the `IArray` type with syntactic conveniences. Rather, the goal
+is to show that traditional, "low-level" code with `Array`, `Int`,
+etc. can be written with opaque types without sacrificing any
+performance.
+
+## Differences with value classes
+
+Most of the above examples can also be implemented using value
+classes. This section will highlight some differences between these
+hypothetical encodings.
+
+### Used as a type parameter
+
+In many cases an author would introduce opaque types or value classes
+to add extra type safety to a "stringly-typed" API, by replacing
+instances of the `String` type with a more specific type.
+
+For example:
+
+```scala
+package object pkg {
+
+  import Character.{isAlphabetic, isDigit}
+
+  class Alphabetic private[pkg] (val value: String) extends AnyVal
+
+  object Alphabetic {
+    def fromString(s: String): Option[Alphabetic] =
+      if (s.forall(isAlphabetic(_))) Some(new Alphabetic(s))
+      else None
+  }
+
+  opaque type Digits = String
+
+  object Digits {
+    def fromString(s: String): Option[Digits] =
+      if (s.forall(isDigit(_))) Some(s)
+      else None
+
+    def asString(d: Digits): String = d
+  }
+}
+```
+
+The code here is relatively comparable. However, when changing
+`String` to `Alphabetic` in code, the following types would be changed
+(i.e. boxed):
+
+ * `Array[Alphabetic]`
+ * `Option[Alphabetic]` (e.g. the result of `Alphabetic.fromString`)
+ * `Vector[Alphabetic]`
+ * `Alphabetic => Boolean`
+ * `Map[Alphabetic, Int]`
+ * `Ordering[Alphabetic]`
+ * `(Alphabetic, String)`
+ * `Monoid[Alphabetic]`
+
+In many cases users won't mind the fact that this code will box, but
+there will certainly be an impact on the bytecode produced (and
+possibly the runtime performance).
+
+By contrast, replacing `String` with `Digits` is guaranteed to have no
+impact (all occurances of `Digits` are guaranteed to be erased to
+`String`). Aside from the ergonomics of calling the `fromString` and
+`asString` methods, there's no runtime impact of any kind.
+
+### Default visibility
+
+By default, a value class' constructor and accessor are public. It
+*is* possible to restrict access, using a `private` constructor and
+`private` accessor, but this makes the comparison between opaque types
+and value classes less attractive:
+
+```scala
+package object pkg {
+  opaque type XCoord = Int
+
+  case class private[pkg] YCoord (private[pkg] val Int) extends AnyVal
+
+  // in both cases, we'd need public factory constructors
+  // to allow users to produce values of these types.
+}
+```
+
+### LUB differences
+
+Value classes extend `AnyVal` by virtue of the syntax used to define
+them. One reason this is necessary is that value classes cannot be
+`null` (otherwise this could create ambiguities between their boxed
+and unboxed representations when wrapping `AnyRef` values).
+
+By contrast, when seen from the "outside" opaque types extend
+`Any`. Their bounds are the same as those of a type parameter without
+explicit bounds (e.g. `A <: Any >: Nothing`).
+
+### Size of artifacts produced
+
+Since value classes do have a runtime reprsentation, they do increase
+the size of runtime artifacts produced (whether a JAR file, or a
+javascript file). Their methods are also compiled to multiple
+representations (i.e. they support both the boxed and unboxed forms
+via extensions methods). Again, this comes at a cost.
+
+By contrast, opaque types have no inherent runtime footprint. The
+opaque type's companion *is* present at runtime, but it usually
+contains validation and data transformation code which would have been
+required even if the author had just stuck to the underlying type.
 
 ## Implementation notes
 

--- a/_sips/sips/2017-09-20-opaque-types.md
+++ b/_sips/sips/2017-09-20-opaque-types.md
@@ -894,7 +894,7 @@ and value classes less attractive:
 package object pkg {
   opaque type XCoord = Int
 
-  case class private[pkg] YCoord (private[pkg] val Int) extends AnyVal
+  case class private[pkg] YCoord (private[pkg] val n: Int) extends AnyVal
 
   // in both cases, we'd need public factory constructors
   // to allow users to produce values of these types.
@@ -910,20 +910,21 @@ and unboxed representations when wrapping `AnyRef` values).
 
 By contrast, when seen from the "outside" opaque types extend
 `Any`. Their bounds are the same as those of a type parameter without
-explicit bounds (e.g. `A <: Any >: Nothing`).
+explicit bounds, i.e. `A <: Any >: Nothing`.
 
 ### Size of artifacts produced
 
-Since value classes do have a runtime reprsentation, they do increase
-the size of runtime artifacts produced (whether a JAR file, or a
-javascript file). Their methods are also compiled to multiple
-representations (i.e. they support both the boxed and unboxed forms
-via extensions methods). Again, this comes at a cost.
+Since value classes do have a runtime representation, they do increase
+the size of runtime artifacts produced (whether a JAR file, a
+javascript file, or something else). Their methods are also compiled
+to multiple representations (i.e. they support both the boxed and
+unboxed forms via extensions methods). Again, this comes at a cost.
 
 By contrast, opaque types have no inherent runtime footprint. The
 opaque type's companion *is* present at runtime, but it usually
 contains validation and data transformation code which would have been
-required even if the author had just stuck to the underlying type.
+required even if the author had just stuck to the underlying type, and
+doesn't add any extra extension methods.
 
 ## Implementation notes
 

--- a/_sips/sips/2017-09-20-opaque-types.md
+++ b/_sips/sips/2017-09-20-opaque-types.md
@@ -34,7 +34,7 @@ Some use cases for opaque types are:
  * New numeric classes, such as unsigned integers. There would no
    longer need to be a boxing overhead for such classes. So this is
    similar to value types in .NET and `newtype` in Haskell. Many APIs
-   currently use singed integers (to avoid overhead) but document that
+   currently use signed integers (to avoid overhead) but document that
    the values will be treated as unsigned.
 
  * Classes representing units of measure. Again, no boxing overhead


### PR DESCRIPTION
This PR does a few things:

 - Tries to add more motivation for opaque types
 - Adds another example (`IArray`) of how opaque types can be used
 - Adds a more detailed comparison of opaque types and value classes

Review by @jvican. Sorry it's so last-minute!