### PR TITLE
Scala 2.10.0 and 2.10.1 does not support Java 8

### DIFF
--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -18,7 +18,7 @@ This table shows the first Scala release in each series that functions on each J
 | JDK version | First Scala release supporting JDK version per series |
 |:-----------:|:-----------------------------------------------------|
 | 9           | 2.12.4, 2.11.12, 2.10.7                              |
-| 8           | 2.12.0, 2.11.0, 2.10.0                               |
+| 8           | 2.12.0, 2.11.0, 2.10.2                               |
 | 7           | 2.11.0, 2.10.0                                       |
 | 6           | 2.11.0, 2.10.0                                       |
 


### PR DESCRIPTION
- https://github.com/scala/scala/commit/b2c67b328daeaf51e
- https://github.com/scala/scala/commit/28a6574554799ec4

```
$ scala
Welcome to Scala version 2.10.0 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_151).
Type in expressions to have them evaluated.
Type :help for more information.

scala> [init] error: error while loading AnnotatedElement, class file '/Library/Java/JavaVirtualMachines/jdk1.8.0_151.jdk/Contents/Home/jre/lib/rt.jar(java/lang/reflect/AnnotatedElement.class)' is broken
(class java.lang.RuntimeException/bad constant pool tag 18 at byte 76)
[init] error: error while loading CharSequence, class file '/Library/Java/JavaVirtualMachines/jdk1.8.0_151.jdk/Contents/Home/jre/lib/rt.jar(java/lang/CharSequence.class)' is broken
(class java.lang.RuntimeException/bad constant pool tag 18 at byte 10)
```