### PR TITLE
Add "build project" step and misc. improvements

### DIFF
--- a/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -8,7 +8,8 @@ previous-page: building-a-scala-project-with-intellij-and-sbt
 There are multiple libraries and testing methodologies for Scala,
 but in this tutorial, we'll demonstrate one popular option from the ScalaTest framework
 called [FunSuite](http://www.scalatest.org/getting_started_with_fun_suite).
-We assume you know [how to build a project in IntelliJ](building-a-scala-project-with-intellij-and-sbt.html).
+
+This assumes you know [how to build a project in IntelliJ](building-a-scala-project-with-intellij-and-sbt.html).
 
 ## Setup
 1. Create an sbt project in IntelliJ.

--- a/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -12,12 +12,13 @@ We assume you know [how to build a project in IntelliJ](building-a-scala-project
 
 ## Setup
 1. Create an sbt project in IntelliJ.
-1.  Add the ScalaTest dependency to your build.sbt file
-    ```
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
-    ```
-1. this will cause sbt to pull down the ScalaTest library
-1. If you get a notification "build.sbt was changed", select **auto-import**.
+1. Add the ScalaTest dependency:
+    1. Add the ScalaTest dependency to your `build.sbt` file:
+        ```
+        libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+        ```
+    1. If you get a notification "build.sbt was changed", select **auto-import**.
+    1. These two actions will cause `sbt` to download the ScalaTest library.
 1. On the project pane on the left, expand `src` => `main`.
 1. Right-click on `scala` and select **New** => **Scala class**.
 1. Call it `CubeCalculator`, change the **Kind** to `object`, and click **OK**.
@@ -49,7 +50,7 @@ We assume you know [how to build a project in IntelliJ](building-a-scala-project
 
 ## Understanding the code
 
-Let's go over this line by line.
+Let's go over this line by line:
 
 * `class CubeCalculatorTest` means we are testing the object `CubeCalculator`
 * `extends FunSuite` lets us use functionality of ScalaTest's FunSuite class

--- a/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -20,6 +20,8 @@ This assumes you know [how to build a project in IntelliJ](building-a-scala-proj
         ```
     1. If you get a notification "build.sbt was changed", select **auto-import**.
     1. These two actions will cause `sbt` to download the ScalaTest library.
+    1. Build the project to compile/index the ScalaTest library by selecting the
+        **Build** menu and then **Build Project**.
 1. On the project pane on the left, expand `src` => `main`.
 1. Right-click on `scala` and select **New** => **Scala class**.
 1. Call it `CubeCalculator`, change the **Kind** to `object`, and click **OK**.

--- a/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -46,8 +46,8 @@ This assumes you know [how to build a project in IntelliJ](building-a-scala-proj
       }
     }
     ```
-1. In the source code, right-click `CubeCalculatorTest` and select **Run
-'CubeCalculatorTest'**.
+1. In the source code, right-click `CubeCalculatorTest` and select
+    **Run 'CubeCalculatorTest'**.
 
 ## Understanding the code
 
@@ -66,10 +66,10 @@ indeed 27. The `===` is part of ScalaTest and provides clean error messages.
 
 ## Adding another test case
 1. Add another `assert` statement after the first one that checks for the cube
-of `0`.
+    of `0`.
 1. Re-run the test again by right-clicking `CubeCalculatorTest` and selecting
-'Run **CubeCalculatorTest**'.
+    'Run **CubeCalculatorTest**'.
 
 ## Conclusion
-You've seen one way to test your Scala code. You can learn more about
-ScalaTest's FunSuite on the [official website](http://www.scalatest.org/getting_started_with_fun_suite).
+You've seen one way to test your Scala code. You can learn more about ScalaTest's
+FunSuite on the [official website](http://www.scalatest.org/getting_started_with_fun_suite).

--- a/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -12,11 +12,10 @@ We assume you know [how to build a project in IntelliJ](building-a-scala-project
 
 ## Setup
 1. Create an sbt project in IntelliJ.
-* Add the ScalaTest dependency to your build.sbt file
+1.  Add the ScalaTest dependency to your build.sbt file
     ```
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
     ```
-
 1. this will cause sbt to pull down the ScalaTest library
 1. If you get a notification "build.sbt was changed", select **auto-import**.
 1. On the project pane on the left, expand `src` => `main`.
@@ -45,7 +44,6 @@ We assume you know [how to build a project in IntelliJ](building-a-scala-project
       }
     }
     ```
-
 1. In the source code, right-click `CubeCalculatorTest` and select **Run
 'CubeCalculatorTest'**.
 

--- a/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -20,8 +20,8 @@ This assumes you know [how to build a project in IntelliJ](building-a-scala-proj
         ```
     1. If you get a notification "build.sbt was changed", select **auto-import**.
     1. These two actions will cause `sbt` to download the ScalaTest library.
-    1. Build the project to compile/index the ScalaTest library by selecting the
-        **Build** menu and then **Build Project**.
+    1. Wait for the `sbt` sync to finish; otherwise, `FunSuite` and `test()` will be
+        unrecognized.
 1. On the project pane on the left, expand `src` => `main`.
 1. Right-click on `scala` and select **New** => **Scala class**.
 1. Call it `CubeCalculator`, change the **Kind** to `object`, and click **OK**.

--- a/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/getting-started-intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -12,11 +12,10 @@ We assume you know [how to build a project in IntelliJ](building-a-scala-project
 
 ## Setup
 1. Create an sbt project in IntelliJ.
-* Add the ScalaTest dependency to your build.sbt file:
-
-```
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
-```
+* Add the ScalaTest dependency to your build.sbt file
+    ```
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+    ```
 
 1. this will cause sbt to pull down the ScalaTest library
 1. If you get a notification "build.sbt was changed", select **auto-import**.
@@ -24,30 +23,28 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 1. Right-click on `scala` and select **New** => **Scala class**.
 1. Call it `CubeCalculator`, change the **Kind** to `object`, and click **OK**.
 1. Replace the code with the following:
-
-```
-object CubeCalculator extends App {
-  def cube(x: Int) = {
-    x * x * x
-  }
-}
-```
+    ```
+    object CubeCalculator extends App {
+      def cube(x: Int) = {
+        x * x * x
+      }
+    }
+    ```
 
 ## Creating a test
 1. On the project pane on the left, expand `src` => `test`.
 1. Right-click on `scala` and select **New** => **Scala class**.
 1. Name the class `CubeCalculatorTest` and click **OK**.
 1. Replace the code with the following:
-
-```
-import org.scalatest.FunSuite
-
-class CubeCalculatorTest extends FunSuite {
-  test("CubeCalculator.cube") {
-    assert(CubeCalculator.cube(3) === 27)
-  }
-}
-```
+    ```
+    import org.scalatest.FunSuite
+    
+    class CubeCalculatorTest extends FunSuite {
+      test("CubeCalculator.cube") {
+        assert(CubeCalculator.cube(3) === 27)
+      }
+    }
+    ```
 
 1. In the source code, right-click `CubeCalculatorTest` and select **Run
 'CubeCalculatorTest'**.


### PR DESCRIPTION
 For me, after `sbt` downloads ScalaTest the `CubeCalculatorTest` class
will still have several errors because ScalaTest has not been
compiled/indexed by IntelliJ IDEA so this explicitly adds a
"build project" step to trigger that.

Before I did that I wanted to fix a few other issues I noticed as I reviewed
the Markdown.