### PR TITLE
Use println() rather than print()

### DIFF
--- a/_tour/for-comprehensions.md
+++ b/_tour/for-comprehensions.md
@@ -42,7 +42,7 @@ def foo(n: Int, v: Int) =
 
 foo(10, 10) foreach {
   case (i, j) =>
-    print(s"($i, $j) ")  // prints (1, 9) (2, 8) (3, 7) (4, 6) (5, 5)
+    println(s"($i, $j) ")  // prints (1, 9) (2, 8) (3, 7) (4, 6) (5, 5)
 }
 
 ```
@@ -60,7 +60,7 @@ You can omit `yield` in a comprehension. In that case, comprehension will return
 def foo(n: Int, v: Int) =
    for (i <- 0 until n;
         j <- i until n if i + j == v)
-   print(s"($i, $j)")
+   println(s"($i, $j)")
 
 foo(10, 10)
 ```


### PR DESCRIPTION
Hi there,

Not sure if there is any specific reason to use `print()` here, but it doesn't print out anything in the console of **Scalafiddle**. This may be confusing/misleading to beginners like myself.

So I would like to suggest to use `println()` here in the sample code, which can print properly, rather than print().

Please let me know your thought.