### PR TITLE
Bug in unapply

### DIFF
--- a/_tour/extractor-objects.md
+++ b/_tour/extractor-objects.md
@@ -23,8 +23,8 @@ object CustomerID {
   def apply(name: String) = s"$name--${Random.nextLong}"
 
   def unapply(customerID: String): Option[String] = {
-    val name = customerID.split("--").head
-    if (name.nonEmpty) Some(name) else None
+    val stringArray: Array[String] = customerID.split("--")
+    if (stringArray.tail.nonEmpty) Some(stringArray.head) else None
   }
 }
 


### PR DESCRIPTION
Split always returns a head, so None is never returned in the original code. The proposed change checks whether there is more than one element.