### PR TITLE
Bug in unapply

### DIFF
--- a/_tour/extractor-objects.md
+++ b/_tour/extractor-objects.md
@@ -45,10 +45,16 @@ val CustomerID(name) = customer2ID
 println(name)  // prints Nico
 ```
 
-This is equivalent to `val name = CustomerID.unapply(customer2ID).get`. If there is no match, a `scala.MatchError` is thrown:
+This is equivalent to `val name = CustomerID.unapply(customer2ID).get`.
+
+```tut
+val CustomerID(name2) = "--asdfasdfasdf"
+```
+
+If there is no match, a `scala.MatchError` is thrown:
 
 ```tut:fail
-val CustomerID(name2) = "--asdfasdfasdf"
+val CustomerID(name3) = "-asdfasdfasdf"
 ```
 
 The return type of an `unapply` should be chosen as follows:

--- a/_tour/extractor-objects.md
+++ b/_tour/extractor-objects.md
@@ -23,8 +23,8 @@ object CustomerID {
   def apply(name: String) = s"$name--${Random.nextLong}"
 
   def unapply(customerID: String): Option[String] = {
-    val name = customerID.split("--").head
-    if (name.nonEmpty) Some(name) else None
+    val stringArray: Array[String] = customerID.split("--")
+    if (stringArray.tail.nonEmpty) Some(stringArray.head) else None
   }
 }
 


### PR DESCRIPTION
Split always returns a head, so None is never returned in the original code. The proposed change checks whether there is more than one element.