### PR TITLE
Addresses #941: Increase contrast of title & link 

### DIFF
--- a/_sass/components/dropdown.scss
+++ b/_sass/components/dropdown.scss
@@ -34,7 +34,7 @@
     }
     /* Styles */
     // background: #fff;
-    background: rgba(255, 255, 255, 0.4);
+    background: rgba(255, 255, 255, 0.75);
     // border: 1px solid rgba(0,0,0,0.15);
     box-shadow: 0 1px 1px rgba(50,50,50,0.1);
     cursor: pointer;

--- a/_sass/layout/documentation.scss
+++ b/_sass/layout/documentation.scss
@@ -25,7 +25,7 @@
         text-transform: uppercase;
         font-weight: $font-black;
         font-size: 20px;
-        color: darken(#53b6d3, 15%);
+        color: #0F313B;
       }
 
       h1 {

--- a/_sass/utils/_variables.scss
+++ b/_sass/utils/_variables.scss
@@ -6,11 +6,11 @@
 //------------------------------------------------
 $brand-primary: #DC322F;
 $brand-secondary: #859900;
-$brand-tertiary: #5CC6E4;
+$brand-tertiary: #0080A3;
 //-------------------------------------------------
 $gray-darker: #002B36;
 $gray-dark: #073642;
-$gray: #15414C;
+$gray: #133942;
 $gray-li: #244E58;
 $gray-light: #E5EAEA;
 $gray-lighter: #F0F3F3;
@@ -53,7 +53,7 @@ $font-black: 900;
 
 // Link Colors
 //------------------------------------------------
-$base-link-color: darken($brand-tertiary, 15%);
+$base-link-color: $brand-tertiary;
 $hover-link-color: $brand-primary;
 
 // Border


### PR DESCRIPTION
Addresses #941.

Increased contrast of 

* Titles
   * also, Super Title & Language Dropdown
* `#doc-header`
* `<a>` link text

# Before
![2018-05-03-213912](https://user-images.githubusercontent.com/127635/39576828-7aaf3f48-4f1a-11e8-9c94-0a7e5b9014c2.jpg)

# After
![subheader-and-language-dropdown](https://user-images.githubusercontent.com/127635/39576788-523b9674-4f1a-11e8-9aee-8025a14ae0fa.jpg)


# Contrast Measurements

Contrast requirements are measured using http://wave.webaim.org/ mentioned in the issue.

