### PR TITLE
Calc example, add note on calc object

### DIFF
--- a/_overviews/tutorials/scala-for-java-programmers.md
+++ b/_overviews/tutorials/scala-for-java-programmers.md
@@ -532,7 +532,9 @@ computes its derivative relative to `x` and then `y`.
       println("Derivative relative to y:\n " + derive(exp, "y"))
     }
 
-Executing this program, we get the expected output:
+You will need to wrap the `Environment` type and `eval`, `derive`, and
+`main` methods in a `Calc` object before compiling.  Executing this
+program, we get the expected output:
 
     Expression: Sum(Sum(Var(x),Var(x)),Sum(Const(7),Var(y)))
     Evaluation with x=5, y=7: 24


### PR DESCRIPTION
The code for the Calc example will not compile as is.  It can be very frustrating to someone trying to learn a new language to figure out how to get the example code to compile.  I added a note about wrapping some of the code in a Calc object.  There is probably a better way to include that in the tutorial, but I think this is better than nothing.