### PR TITLE
Updated page metadata to include in tour

### DIFF
--- a/_tour/abstract-types.md
+++ b/_tour/abstract-types.md
@@ -4,13 +4,14 @@ title: Abstract Types
 
 discourse: true
 
-tutorial: scala-tour
-categories: tour
+partof: scala-tour
 num: 23
 next-page: compound-types
 previous-page: inner-classes
+topics: abstract types
 prerequisite-knowledge: variance, upper-type-bound
 
+redirect_from: "/tutorials/tour/abstract-types.html"
 ---
 
 Traits and abstract classes can have an abstract type member. This means that the concrete implementations define the actual type. Here's an example:

--- a/_tour/self-types.md
+++ b/_tour/self-types.md
@@ -4,12 +4,15 @@ title: Self-type
 
 discourse: true
 
-tutorial: scala-tour
-categories: tour
+partof: scala-tour
+
 num: 25
 next-page: implicit-parameters
 previous-page: compound-types
+topics: self-types
 prerequisite-knowledge: nested-classes, mixin-class-composition
+
+redirect_from: "/tutorials/tour/self-types.html"
 ---
 Self-types are a way to declare that a trait must be mixed into another trait, even though it doesn't directly extend it. That makes the members of the dependency available without imports.
 

--- a/_tour/traits.md
+++ b/_tour/traits.md
@@ -4,12 +4,15 @@ title: Traits
 
 discourse: true
 
-tutorial: scala-tour
-categories: tour
+partof: scala-tour
+
 num: 5
 next-page: mixin-class-composition
 previous-page: classes
-assumed-knowledge: expressions, classes, generics, objects, companion-objects
+topics: traits
+prerequisite-knowledge: expressions, classes, generics, objects, companion-objects
+
+redirect_from: "/tutorials/tour/traits.html"
 ---
 
 Traits are used to share interfaces and fields between classes. They are similar to Java 8's interfaces. Classes and objects can extend traits but traits cannot be instantiated and therefore have no parameters.


### PR DESCRIPTION
The Traits page wasn't being included in the tour TOC, but was being referenced by the tour pages before and after it, Classes and Class Composition with Mixins respectively. Updated the page metadata to include it in the tour, and fix the other tags.