### PR TITLE
Give more visibility to EPFL’s Open edX instance that hosts our MOOCs

### DIFF
--- a/_data/doc-nav-header.yml
+++ b/_data/doc-nav-header.yml
@@ -16,6 +16,8 @@
       url: "/tour/tour-of-scala.html"
     - title: Scala for Java Programmers
       url: "/tutorials/scala-for-java-programmers.html"
+    - title: Online Resources
+      url: "/learn.html"
 - title: Reference
   url: "#"
   submenu:

--- a/_data/nav-header.yml
+++ b/_data/nav-header.yml
@@ -1,5 +1,5 @@
 - title: Documentation
-  url: ""
+  url: "/"
 - title: Download
   url: https://www.scala-lang.org/download/
 - title: Community

--- a/learn.md
+++ b/learn.md
@@ -1,16 +1,14 @@
 ---
-title: Learning Resources
+title: Online Resources
 layout: inner-page-no-masthead
 redirect_from:
   - /documentation/books.html
 ---
 
-## Online Learning
-
-### Quick Online Exercises
+## Quick Online Exercises
 [Scala Exercises](https://www.scala-exercises.org/) is a series of lessons and exercises created by [47 Degrees](https://www.47deg.com/). It's a great way to get a brief introduction to Scala while testing your knowledge along the way.
 
-### Online Courses from EPFL
+## Online Courses from EPFL
 
 The following courses are available for free. They teach you the main features of the Scala language and introduce you
 to functional programming. They are published on both [Coursera](https://www.coursera.org) and an EPFL-hosted Open edX
@@ -34,7 +32,7 @@ Note : On Coursera there is a paid version available. The only difference betwee
 you get a certificate of completion from Coursera on the paid version. You can learn more about coursera certificates in
 [this help document](https://learner.coursera.help/hc/en-us/articles/209819053-Get-a-Course-Certificate).
 
-### Dr.Mark C Lewis's Lectures from Trinity University
+## Dr.Mark C Lewis's Lectures from Trinity University
 
  * [Dr.Mark C Lewis](http://www.cs.trinity.edu/~mlewis/) from Trinity University, San Antonio, TX, teaches programming courses using the Scala language. Course videos are available in Youtube for free. Some of the courses below.
    * [Introduction to Programming and Problem Solving Using Scala](https://www.youtube.com/playlist?list=PLLMXbkbDbVt9MIJ9DV4ps-_trOzWtphYO)
@@ -43,11 +41,11 @@ you get a certificate of completion from Coursera on the paid version. You can l
  You can visit his [Youtube channel](https://www.youtube.com/user/DrMarkCLewis/featured) for more videos.
 
 
-### Try Scala In Your Browser!
+## Try Scala In Your Browser!
 There are a handful of websites where you can interactively run Scala code in your browser! Have a look at [ScalaFiddle](https://scalafiddle.io/) and [Scastie](http://scastie.org/).
 
-### allaboutscala
+## allaboutscala
 [allaboutscala](http://allaboutscala.com/) provides detailed tutorials for beginners.
 
-### ScalaCourses
+## ScalaCourses
 [Independent Courseware](http://getscala.com), online self-study or instructor-led Scala and Play courses for a fee.

--- a/learn.md
+++ b/learn.md
@@ -10,17 +10,29 @@ redirect_from:
 ### Quick Online Exercises
 [Scala Exercises](https://www.scala-exercises.org/) is a series of lessons and exercises created by [47 Degrees](https://www.47deg.com/). It's a great way to get a brief introduction to Scala while testing your knowledge along the way.
 
-### Coursera courses from EPFL
-There are a few interactive resources for trying out Scala, to get a look and feel of the language:
+### Online Courses from EPFL
 
- * [Functional Programming in Scala Specialization](https://www.coursera.org/specializations/scala), free on Coursera. The Specialization provides a hands-on introduction to functional programming using Scala. You can access the courses material and exercises by either signing up for the specialization or auditing the courses individually. The specialization has the following courses.
-    * [Functional Programming Principles in Scala](https://www.coursera.org/learn/progfun1)
-    * [Functional Program Design in Scala](https://www.coursera.org/learn/progfun2)
-    * [Parallel programming](https://www.coursera.org/learn/parprog1)
-    * [Big Data Analysis with Scala and Spark](https://www.coursera.org/learn/scala-spark-big-data)
-    * [Functional Programming in Scala Capstone](https://www.coursera.org/learn/scala-capstone)
+The following courses are available for free. They teach you the main features of the Scala language and introduce you
+to functional programming. They are published on both [Coursera](https://www.coursera.org) and an EPFL-hosted Open edX
+instance at [courseware.epfl.ch](https://courseware.epfl.ch/).
 
-Note : There is a paid version available. The only difference between the free and the paid version is that you get a certificate of completion from Coursera on the paid version. You can learn more about coursera certificates in [this help document](https://learner.coursera.help/hc/en-us/articles/209819053-Get-a-Course-Certificate).
+ * Functional Programming in Scala Specialization (on [Coursera](https://www.coursera.org/specializations/scala)).
+   The Specialization provides a hands-on introduction to functional programming using Scala. You can access the courses
+   material and exercises by either signing up for the specialization or auditing the courses individually. The
+   specialization has the following courses.
+    * Functional Programming Principles in Scala ([Coursera](https://www.coursera.org/learn/progfun1) and
+      [Open edX](https://courseware.epfl.ch/courses/course-v1:EPFL+progfun1+2018_T1/about)),
+    * Functional Program Design in Scala ([Coursera](https://www.coursera.org/learn/progfun2) and
+      [Open edX](https://courseware.epfl.ch/courses/course-v1:EPFL+progfun2+2018_T1/about)),
+    * Parallel programming ([Coursera](https://www.coursera.org/learn/parprog1) and
+      [Open edX](https://courseware.epfl.ch/courses/course-v1:EPFL+parprog1+2018_T1/about)),
+    * Big Data Analysis with Scala and Spark ([Coursera](https://www.coursera.org/learn/scala-spark-big-data) and
+      [Open edX](https://courseware.epfl.ch/courses/course-v1:EPFL+scala-spark-big-data+2018-T1/about)),
+    * Functional Programming in Scala Capstone ([Coursera](https://www.coursera.org/learn/scala-capstone) only).
+
+Note : On Coursera there is a paid version available. The only difference between the free and the paid version is that
+you get a certificate of completion from Coursera on the paid version. You can learn more about coursera certificates in
+[this help document](https://learner.coursera.help/hc/en-us/articles/209819053-Get-a-Course-Certificate).
 
 ### Dr.Mark C Lewis's Lectures from Trinity University
 


### PR DESCRIPTION
Adds links to EPFL hosted Open edX instance running our MOOCs:

![moocs](https://user-images.githubusercontent.com/332812/40613188-cd24603e-627d-11e8-9cd4-87358a817f9d.png)

Also, adds the `/learn.html` page to the navigation header:

![nav](https://user-images.githubusercontent.com/332812/40613212-e43b5eee-627d-11e8-9fdd-9532ef41fb1e.png)

And fixes the “Documentation” link of the top navigation bar to point to the documentation index (it was previously always pointing to the “current” page).