### PR TITLE
upgrade nokogiri, because security

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     mercenary (0.3.6)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.0)
     pathutil (0.14.0)


### PR DESCRIPTION
GitHub's "vulnerability alerts" feature recommended this change,
at https://github.com/scala/docs.scala-lang/network/dependencies