### PR TITLE
Added contributors widget

### DIFF
--- a/_includes/contributors-list.html
+++ b/_includes/contributors-list.html
@@ -1,0 +1,4 @@
+<div class="content-contributors">
+    <h3>Contributors to this page:</h3>
+    <div id="contributors" class="contributors-container"></div>
+</div>

--- a/_includes/inner-page-main-content.html
+++ b/_includes/inner-page-main-content.html
@@ -3,6 +3,8 @@
 		<div class="content-primary">
 			<div class="inner-box">
 				{{content}}
+
+				{% include contributors-list.html %}
 			</div>
 		</div>
 

--- a/_layouts/cheatsheet.html
+++ b/_layouts/cheatsheet.html
@@ -30,6 +30,8 @@ layout: inner-page-parent-dropdown
             {% endfor %}
           </ul>
         {% endif %}
+
+        {% include contributors-list.html %}
 			</div>
 		</div>
 	</div>

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -8,6 +8,8 @@ includeTOC: true
 		<div class="content-primary documentation glossary">
 			<div class="inner-box">
 				{{content}}
+
+				{% include contributors-list.html %}
 			</div>
 		</div>
 

--- a/_layouts/multipage-overview.html
+++ b/_layouts/multipage-overview.html
@@ -9,6 +9,8 @@ includeCollectionTOC: true
 		<div class="content-primary documentation">
 			<div class="inner-box">
 				{{content}}
+
+				{% include contributors-list.html %}
 			</div>
 		</div>
 

--- a/_layouts/singlepage-overview.html
+++ b/_layouts/singlepage-overview.html
@@ -8,6 +8,8 @@ includeTOC: true
 		<div class="content-primary documentation">
 			<div class="inner-box">
 				{{content}}
+
+				{% include contributors-list.html %}
 			</div>
 		</div>
 

--- a/_layouts/style-guide.html
+++ b/_layouts/style-guide.html
@@ -9,6 +9,8 @@ includeTOC: true
 		<div class="content-primary documentation style-guide">
 			<div class="inner-box">
 				{{content}}
+
+				{% include contributors-list.html %}
 			</div>
 		</div>
 

--- a/_layouts/tour.html
+++ b/_layouts/tour.html
@@ -20,6 +20,11 @@ includeCollectionTOC: true
                     <a href="{{page.next-page}}.html"><strong>next</strong> &rarr;</a>
                     {% endif %}
                 </div>
+
+                <div class="content-contributors">
+                    <h3>Contributors to this page:</h3>
+                    <div id="contributors" class="contributors-container"></div>
+                </div>
             </div>
 		</div>
 

--- a/_layouts/tour.html
+++ b/_layouts/tour.html
@@ -21,10 +21,7 @@ includeCollectionTOC: true
                     {% endif %}
                 </div>
 
-                <div class="content-contributors">
-                    <h3>Contributors to this page:</h3>
-                    <div id="contributors" class="contributors-container"></div>
-                </div>
+                {% include contributors-list.html %}
             </div>
 		</div>
 

--- a/_sass/layout/content-contributors.scss
+++ b/_sass/layout/content-contributors.scss
@@ -1,0 +1,22 @@
+.content-contributors {
+    .contributors-container {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        div {
+            margin: 5px;
+            a {
+                vertical-align: middle;
+                padding: 3px;
+                text-decoration: none;
+            }
+            img {
+                vertical-align: middle;
+                width: 35px;
+                height: 35px;
+                margin-bottom: 0;
+                border-radius: 7px;
+            }
+        }
+    }
+}

--- a/_sass/layout/inner-main.scss
+++ b/_sass/layout/inner-main.scss
@@ -51,6 +51,29 @@
       }
     }
 
+    .content-contributors {
+      .contributors-container {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        div {
+          margin: 5px;
+          a {
+            vertical-align: middle;
+            padding: 3px;
+            text-decoration: none;
+          }
+          img {
+            vertical-align: middle;
+            width: 35px;
+            height: 35px;
+            margin-bottom: 0;
+            border-radius: 7px;
+          }
+        }
+      }
+    }
+
     .content-primary {
       .documentation,
       .tools {

--- a/_sass/layout/inner-main.scss
+++ b/_sass/layout/inner-main.scss
@@ -51,29 +51,6 @@
       }
     }
 
-    .content-contributors {
-      .contributors-container {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        div {
-          margin: 5px;
-          a {
-            vertical-align: middle;
-            padding: 3px;
-            text-decoration: none;
-          }
-          img {
-            vertical-align: middle;
-            width: 35px;
-            height: 35px;
-            margin-bottom: 0;
-            border-radius: 7px;
-          }
-        }
-      }
-    }
-
     .content-primary {
       .documentation,
       .tools {

--- a/resources/css/style.scss
+++ b/resources/css/style.scss
@@ -54,7 +54,8 @@
 @import 'layout/books';
 @import 'layout/training-events';
 @import 'layout/blog';
-@import 'layout/download'; // COMPONENTS
+@import 'layout/download';
+@import 'layout/content-contributors'; // COMPONENTS
 //------------------------------------------------
 //------------------------------------------------
 @import 'components/buttons';

--- a/resources/js/functions.js
+++ b/resources/js/functions.js
@@ -522,3 +522,57 @@ $(document).ready(function(){
         return false; 
     }); 
 });
+
+//Contributors widget
+// see https://stackoverflow.com/a/19200303/4496364
+$(document).ready(function () {
+  let githubApiUrl = 'https://api.github.com/repos/scala/docs.scala-lang/commits';
+  // transform "/tour/basics.html" to "_ba/tour/basics.md";
+  let thisPageUrl = window.location.pathname;
+  thisPageUrl = thisPageUrl.substring(1, thisPageUrl.lastIndexOf('.'));
+  thisPageUrl = '_' + thisPageUrl + '.md';
+  // e.g. https://api.github.com/repos/scala/docs.scala-lang/commits?path=README
+  let url = githubApiUrl + '?path=' + thisPageUrl;
+  $.get(url, function (data, status) {
+    
+    let contributorsUnique = [];
+    let res = data.forEach(commit => {
+      // add if not already in array
+      let addedToList = contributorsUnique.find(c => {
+        let matches = c.authorName == commit.commit.committer.name;
+        if (!matches && commit.author) {
+          matches = c.authorName == commit.author.login;
+        }
+        return matches;
+      });
+
+      if (!addedToList) {
+        // first set fallback properties
+        let authorName = commit.commit.committer.name;
+        let authorLink = 'mailto:' + commit.commit.committer.email;
+        let authorImageLink = 'https://github.com/identicons/' + commit.commit.committer.name + '.png';
+        // if author present, fill these preferably
+        if (commit.author) {
+          authorName = commit.author.login;
+          authorLink = commit.author.html_url;
+          authorImageLink = commit.author.avatar_url;
+        }
+        contributorsUnique.push({
+          'authorName': authorName,
+          'authorLink': authorLink,
+          'authorImageLink': authorImageLink
+        });
+      }
+    });
+
+    let contributorsHtml = '';
+    contributorsUnique.forEach(contributor => {
+      let contributorHtml = '<div>';
+      contributorHtml += '<img src="' + contributor.authorImageLink + '">';
+      contributorHtml += '<a href="' + contributor.authorLink + '">' + contributor.authorName + '</a>';
+      contributorHtml += '</div>';
+      contributorsHtml += contributorHtml;
+    });
+    $('#contributors').html(contributorsHtml);
+  });
+});

--- a/resources/js/functions.js
+++ b/resources/js/functions.js
@@ -534,12 +534,11 @@ $(document).ready(function () {
   // e.g. https://api.github.com/repos/scala/docs.scala-lang/commits?path=README
   let url = githubApiUrl + '?path=' + thisPageUrl;
   $.get(url, function (data, status) {
-    
     let contributorsUnique = [];
     let res = data.forEach(commit => {
       // add if not already in array
       let addedToList = contributorsUnique.find(c => {
-        let matches = c.authorName == commit.commit.committer.name;
+        let matches = c.authorName == commit.commit.author.name;
         if (!matches && commit.author) {
           matches = c.authorName == commit.author.login;
         }
@@ -548,9 +547,9 @@ $(document).ready(function () {
 
       if (!addedToList) {
         // first set fallback properties
-        let authorName = commit.commit.committer.name;
-        let authorLink = 'mailto:' + commit.commit.committer.email;
-        let authorImageLink = 'https://github.com/identicons/' + commit.commit.committer.name + '.png';
+        let authorName = commit.commit.author.name;
+        let authorLink = '';
+        let authorImageLink = 'https://github.com/identicons/' + commit.commit.author.name + '.png';
         // if author present, fill these preferably
         if (commit.author) {
           authorName = commit.author.login;
@@ -569,7 +568,10 @@ $(document).ready(function () {
     contributorsUnique.forEach(contributor => {
       let contributorHtml = '<div>';
       contributorHtml += '<img src="' + contributor.authorImageLink + '">';
-      contributorHtml += '<a href="' + contributor.authorLink + '">' + contributor.authorName + '</a>';
+      if (contributor.authorLink)
+        contributorHtml += '<a href="' + contributor.authorLink + '">' + contributor.authorName + '</a>';
+      else
+        contributorHtml += '<a>' + contributor.authorName + '</a>';
       contributorHtml += '</div>';
       contributorsHtml += contributorHtml;
     });


### PR DESCRIPTION
Fixes #44 

Following [this answer](https://stackoverflow.com/a/19200303/4496364) I managed to get this via Github API:

![](https://upload.cc/i1/2018/07/04/n4zkhJ.png)

I roughly followed Mozilla's [docs page](https://developer.mozilla.org/en-US/docs/Web/HTML) design and their contributors listing.
Some users don't have the "author" field. Probably deleted their profile?  
So, the fallback is `commit.commit.committer.name` which is, I suppose, always present because of Git...  

Also, if the author isn't present, image icon is generated with https://github.com/identicons. Example here is Ghildiyal user.

Currently, I added this to tour only. IDK did you guys intend to put these on each page?  
If so, there could be some problems with getting page URL from Github. IDK if all of them follow same pattern as "tours"..
