### PR TITLE
Removed redundant Note in inner-classes.md

### DIFF
--- a/_tour/inner-classes.md
+++ b/_tour/inner-classes.md
@@ -79,5 +79,3 @@ class Graph {
   }
 }
 ```
-
-> Note that this program doesn't allow us to attach a node to two different graphs. If we want to remove this restriction as well, we have to change the type of variable nodes to `Graph#Node`.


### PR DESCRIPTION
The removed Note is either misplaced and meant to be beneath the first snipped or should be removed entirely like I proposed, because the information in the note is contained in the text anyways.