### PR TITLE
Drop support for Symbol literals

### DIFF
--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -22,6 +22,7 @@ Sabin**
 | TBD            | Dormant because original authors are not available for its review  |
 | Feb 9th 2017   | New author volunteered to update the SIP for review                |
 | Nov 16th 2017  | Updated following implementation experience in Typelevel Scala     |
+| Aug 7th 2018   | Updated to remove Symbol literals, which won't be supported in 3   |
 
 ## Introduction
 
@@ -122,10 +123,6 @@ Lightbend Scala compiler.
   foo[13]                            // result is 13: 13
   ```
 
-+ Support for `scala.Symbol` literal types has been added.
-  ```
-  valueOf['foo]                      // result is 'foo: 'foo
-  ```
 
 ### Motivating examples
 
@@ -557,21 +554,6 @@ applications which work with large datasets.
   it is the view of the authors of this SIP that there is nothing to be gained from enabling this
   construction and that default initializer should be forbidden.
 
-+ Support for `scala.Symbol` literal types has been added.
-
-  The `scala.Symbol` type has first class syntax support, like `String`. Despite having syntactic
-  literals, it does not have semantic literals in the same way that `String` does. This SIP adds
-  semantic literal types corresponding to the syntactic literals in the interest of consistency and
-  on the grounds that if a type is important enough to warrant first class syntax it is important
-  enough to warrant first class singleton types.
-
-  Note that shapeless in current Scala provides an encoding of singleton types for `Symbol` as the
-  type `Symbol` tagged with the literal type of its corresponding `String`.
-
-  Example,
-  ```
-  valueOf['foo]                      // result is 'foo: 'foo
-  ```
 
 ## Follow on work from this SIP
 
@@ -593,13 +575,8 @@ terms.
 
 ### Byte and short literals
 
-As discussed in the proposal above, an important motivation for including first class literal
-types for Scala `Symbol` literals is that they have first class syntax -- if something is important
-enough to warrant syntax then it should be important enough to warrant a corresponding literal type.
-
-The converse also holds, and here we have two notable missing cases: `Byte` and `Short`. These have
-singleton types, but lack any corresponding syntax either at the type or at the term level. These
-types are important in libraries which deal with low level numerics and protocol implementation
+`Byte` and `Short` have singleton types, but lack any corresponding syntax either at the type or at the term level. 
+These types are important in libraries which deal with low level numerics and protocol implementation
 (see eg. [Spire](https://github.com/non/spire) and [Scodec](https://github.com/scodec/scodec)) and
 elsewhere, and the ability to, for instance, index a type class by a byte or short literal would be
 valuable.


### PR DESCRIPTION
Since we already know they won't be part of Scala 3, it does not make sense to incorporate them into new features, only to remove them after two releases.

TBD at next SIP meeting. The corresponding code change is already in 2.13.0-M5, to reduce the period of time of exposure.