### PR TITLE
Fix htmlproofer errors relating 429 no error

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,6 +10,6 @@ rm -r tut-tmp
 bundle exec jekyll build
 
 # Checking for docs.scala-lang/blob/master leads to a chicken and egg problem because of the edit links of new pages.
-bundle exec htmlproofer ./_site/ --only-4xx --http-status-ignore "401" --empty-alt-ignore --allow-hash-href --url-ignore '/https://github.com/scala/docs.scala-lang/blob/master/.*/'
+bundle exec htmlproofer ./_site/ --only-4xx --http-status-ignore "401,429" --empty-alt-ignore --allow-hash-href --url-ignore '/https://github.com/scala/docs.scala-lang/blob/master/.*/'
 
 exit 0


### PR DESCRIPTION
CI occurred `429 no error`. I found #1035 that solved the same issue and did the same solution :D

@jvican, you should merge this PR first.