### PR TITLE
Update upper-type-bounds.md

### DIFF
--- a/_tour/upper-type-bounds.md
+++ b/_tour/upper-type-bounds.md
@@ -44,7 +44,8 @@ val catContainer = new PetContainer[Cat](new Cat)
 ```
 
 ```tut:fail
-val lionContainer = new PetContainer[Lion](new Lion) // this would not compile
+// this would not compile
+val lionContainer = new PetContainer[Lion](new Lion)
 ```
 The `class PetContainer` take a type parameter `P` which must be a subtype of `Pet`. `Dog` and `Cat` are subtypes of `Pet` so we can create a new `PetContainer[Dog]` and `PetContainer[Cat]`. However, if we tried to create a `PetContainer[Lion]`, we would get the following Error:
 


### PR DESCRIPTION
Char with for html container is smaller than line length, can't see comment on website 
https://docs.scala-lang.org/tour/upper-type-bounds.html