### PR TITLE
Prevented TOC from capturing unwanted headings

### DIFF
--- a/_includes/inner-page-main-content.html
+++ b/_includes/inner-page-main-content.html
@@ -2,7 +2,9 @@
 	<div class="wrap">
 		<div class="content-primary">
 			<div class="inner-box">
-				{{content}}
+				<div class="toc-context">
+					{{content}}
+				</div>
 
 				{% include contributors-list.html %}
 			</div>

--- a/_layouts/cheatsheet.html
+++ b/_layouts/cheatsheet.html
@@ -6,7 +6,10 @@ layout: inner-page-parent-dropdown
 	<div class="wrap">
 		<div class="content-primary cheatsheet">
 			<div class="inner-box">
-				{{content}}
+				<div class="toc-context">
+					{{content}}
+				</div>
+
         {% if page.languages %}
           <ul id="available-languages" style="display: none;">
             <li><a href="{{site.baseurl}}{{ page.url }}">English</a></li>

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -7,7 +7,9 @@ includeTOC: true
 	<div class="wrap">
 		<div class="content-primary documentation glossary">
 			<div class="inner-box">
-				{{content}}
+				<div class="toc-context">
+					{{content}}
+				</div>
 
 				{% include contributors-list.html %}
 			</div>

--- a/_layouts/inner-page.html
+++ b/_layouts/inner-page.html
@@ -5,7 +5,7 @@ layout: inner-page-parent
 <section class="full-width">
 	<div class="wrap">
 		<div class="content-primary">
-			<div class="inner-box">
+			<div class="inner-box toc-context">
 				{{content}}
 			</div>
 		</div>

--- a/_layouts/multipage-overview.html
+++ b/_layouts/multipage-overview.html
@@ -8,7 +8,9 @@ includeCollectionTOC: true
 	<div class="wrap">
 		<div class="content-primary documentation">
 			<div class="inner-box">
-				{{content}}
+				<div class="toc-context">
+					{{content}}
+				</div>
 
 				{% include contributors-list.html %}
 			</div>

--- a/_layouts/overviews.html
+++ b/_layouts/overviews.html
@@ -5,7 +5,7 @@ layout: inner-page-parent
 <section class="full-width">
 	<div class="wrap">
 		<div class="content-primary overviews">
-			<div class="inner-box">
+			<div class="inner-box toc-context">
 				{{content}}
 			</div>
 		</div>

--- a/_layouts/singlepage-overview.html
+++ b/_layouts/singlepage-overview.html
@@ -7,7 +7,9 @@ includeTOC: true
 	<div class="wrap">
 		<div class="content-primary documentation">
 			<div class="inner-box">
-				{{content}}
+				<div class="toc-context">
+					{{content}}
+				</div>
 
 				{% include contributors-list.html %}
 			</div>

--- a/_layouts/sip.html
+++ b/_layouts/sip.html
@@ -6,7 +6,7 @@ includeTOC: true
 <section class="content">
 	<div class="wrap">
 		<div class="content-primary documentation">
-			<div class="inner-box">
+			<div class="inner-box toc-context">
 				{{content}}
 			</div>
 		</div>

--- a/_layouts/sips.html
+++ b/_layouts/sips.html
@@ -5,7 +5,7 @@ layout: inner-page-parent-dropdown
 <section class="content">
 	<div class="wrap">
 		<div class="content-primary sips">
-			<div class="inner-box">
+			<div class="inner-box toc-context">
 				{{content}}
 			</div>
 		</div>

--- a/_layouts/style-guide.html
+++ b/_layouts/style-guide.html
@@ -8,7 +8,9 @@ includeTOC: true
 	<div class="wrap">
 		<div class="content-primary documentation style-guide">
 			<div class="inner-box">
-				{{content}}
+				<div class="toc-context">
+					{{content}}
+				</div>
 
 				{% include contributors-list.html %}
 			</div>

--- a/_layouts/tour.html
+++ b/_layouts/tour.html
@@ -8,7 +8,9 @@ includeCollectionTOC: true
 	<div class="wrap">
 		<div class="content-primary documentation">
 			<div class="inner-box">
-				{{content}}
+                <div class="toc-context">
+                    {{content}}
+                </div>
 
                 <div class="two-columns">
                     {% if page.previous-page %}

--- a/resources/js/functions.js
+++ b/resources/js/functions.js
@@ -300,13 +300,13 @@ $(document).ready(function() {
   if ($("#sidebar-toc").length) {
     $('#toc').toc({
       exclude: 'h1, h5, h6',
-      context: '.inner-box',
+      context: '.toc-context',
       autoId: true,
       numerate: false
     });
     toggleStickyToc();
   }
-})
+});
 
 $(window).resize(function() {
   toggleStickyToc();


### PR DESCRIPTION
Fixes #1148 

Used `toc-context` class to identify where TOC should look for headings. Code was using `inner-box`, but `inner-box` divs often contain content not wanted on the TOC (e.g. the contributors list).

Nested `toc-context` div doesn't add padding or margin or appear to change the layout in any way.

Checked all the pages, comparing them to the currently live site to make sure everything still works.