### PR TITLE
Ignoring www.oracle.com links in htmlproofer in ci build

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,6 +10,6 @@ rm -r tut-tmp
 bundle exec jekyll build
 
 # Checking for docs.scala-lang/blob/master leads to a chicken and egg problem because of the edit links of new pages.
-bundle exec htmlproofer ./_site/ --only-4xx --http-status-ignore "401,429" --empty-alt-ignore --allow-hash-href --url-ignore '/https://github.com/scala/docs.scala-lang/blob/master/.*/'
+bundle exec htmlproofer ./_site/ --only-4xx --http-status-ignore "401,429" --empty-alt-ignore --allow-hash-href --url-ignore '/https://github.com/scala/docs.scala-lang/blob/master/.*/,/www.oracle.com/'
 
 exit 0


### PR DESCRIPTION
Fixes #1168 