### PR TITLE
Static members SIP is 30 not 25

### DIFF
--- a/_sips/minutes/2016-11-29-sip-minutes.md
+++ b/_sips/minutes/2016-11-29-sip-minutes.md
@@ -13,8 +13,8 @@ The following agenda was distributed to attendees:
 | --- | --- | --- |
 | [SIP-28 and SIP-29 - Inline and meta](http://docs.scala-lang.org/sips/inline-meta.html) | Josh Suereth and Iulian Dragos | Pending |
 | [SIP-24 - Repeated By Name Parameters](http://docs.scala-lang.org/sips/repeated-byname.html) | Heather Miller | Pending |
-| [SIP-25:Static](https://github.com/scala/docs.scala-lang/pull/491/files)| Adriaan Moors | Pending |
-|[SIP-27: Trailing commas](http://docs.scala-lang.org/sips/completed/trailing-commas.html)|Eugene Burkamo| Accepted |
+| [SIP-30 - Static members](https://github.com/scala/docs.scala-lang/pull/491/files) | Adriaan Moors | Pending |
+| [SIP-27 - Trailing commas](http://docs.scala-lang.org/sips/completed/trailing-commas.html) |Eugene Burkamo | Accepted |
 
 Jorge Vicente Cantero was the Process Lead and Travis Lee was the secretary.
 

--- a/_sips/minutes/2017-02-14-sip-minutes.md
+++ b/_sips/minutes/2017-02-14-sip-minutes.md
@@ -11,9 +11,9 @@ The following agenda was distributed to attendees:
 
 | Topic | Reviewer |
 | --- | --- |
-| [SIP-XX: Improving binary compatibility with @stableABI](http://docs.scala-lang.org/sips/binary-compatibility.html) | Dmitry Petrashko |
+| [SIP-XX - Improving binary compatibility with @stableABI](http://docs.scala-lang.org/sips/binary-compatibility.html) | Dmitry Petrashko |
 | [SIP-NN - Allow referring to other arguments in default parameters](http://docs.scala-lang.org/sips/refer-other-arguments-in-args.html) | Pathikrit Bhowmick |
-| [SIP 25 - @static fields and methods in Scala objects(SI-4581)](http://docs.scala-lang.org/sips/static-members.html) | Dmitry Petrashko, Sébastien Doeraene and Martin Odersky |
+| [SIP-30 - @static fields and methods in Scala objects(SI-4581)](http://docs.scala-lang.org/sips/static-members.html) | Dmitry Petrashko, Sébastien Doeraene and Martin Odersky |
 | [SIP-33 - Match infix & prefix types to meet expression rules](http://docs.scala-lang.org/sips/priority-based-infix-type-precedence.html) | Oron Port |
 
 Jorge Vicente Cantero was the Process Lead. Travis (@travissarles) was acting secretary of the meeting.
@@ -46,7 +46,7 @@ Absent:
 
 ### Opening Remarks
 
-### SIP 25 - @static fields and methods in Scala objects(SI-4581)
+### SIP 30 - @static fields and methods in Scala objects (SI-4581)
 Jorge asks Dmitry to explain the biggest changes since the last proposal.
 The biggest changes were addressing the feedback of the reader.
 **Dmitry** First, he covers whether the static annotation can behave like the tail recursive annotation, which doesn't actually impact compilation but only warns if it isn't possible to make something static. Dmitry doesn't think the static annotation should have the same semantics because it affects binary compatibility.

--- a/_sips/sips/2015-6-18-trait-parameters.md
+++ b/_sips/sips/2015-6-18-trait-parameters.md
@@ -1,6 +1,6 @@
 ---
 layout: sip
-title: SIP 25 - Trait Parameters
+title: SIP-25 - Trait Parameters
 discourse: true
 
 vote-status: "under-review"

--- a/_sips/sips/2016-01-11-static-members.md
+++ b/_sips/sips/2016-01-11-static-members.md
@@ -1,6 +1,6 @@
 ---
 layout: sip
-title: SIP 25 - @static fields and methods in Scala objects(SI-4581)
+title: SIP-30 - @static fields and methods in Scala objects (SI-4581)
 discourse: true
 
 vote-status: "under-review"


### PR DESCRIPTION
Fixes #1028

Fixed all references to static members SIP, including in SIP meeting minutes.