### PR TITLE
More precise wording regarding 'pairs' example

### DIFF
--- a/_tour/for-comprehensions.md
+++ b/_tour/for-comprehensions.md
@@ -37,19 +37,19 @@ Here is a more complicated example using two generators. It computes all pairs o
 ```tut
 def foo(n: Int, v: Int) =
    for (i <- 0 until n;
-        j <- i until n if i + j == v)
+        j <- 0 until n if i + j == v)
    yield (i, j)
 
 foo(10, 10) foreach {
   case (i, j) =>
-    println(s"($i, $j) ")  // prints (1, 9) (2, 8) (3, 7) (4, 6) (5, 5)
+    println(s"($i, $j) ")  // prints (1, 9) (2, 8) (3, 7) (4, 6) (5, 5) (6, 4) (7, 3) (8, 2) (9, 1)
 }
 
 ```
 Here `n == 10` and `v == 10`. On the first iteration, `i == 0` and `j == 0` so `i + j != v` and therefore nothing is yielded. `j` gets incremented 9 more times before `i` gets incremented to `1`. Without the `if` guard, this would simply print the following:
 ```
 
-(0, 0) (0, 1) (0, 2) (0, 3) (0, 4) (0, 5) (0, 6) (0, 7) (0, 8) (0, 9) (1, 1) ...
+(0, 0) (0, 1) (0, 2) (0, 3) (0, 4) (0, 5) (0, 6) (0, 7) (0, 8) (0, 9) (1, 0) ...
 ```
 
 Note that comprehensions are not restricted to lists. Every datatype that supports the operations `withFilter`, `map`, and `flatMap` (with the proper types) can be used in sequence comprehensions.
@@ -59,7 +59,7 @@ You can omit `yield` in a comprehension. In that case, comprehension will return
 ```tut
 def foo(n: Int, v: Int) =
    for (i <- 0 until n;
-        j <- i until n if i + j == v)
+        j <- 0 until n if i + j == v)
    println(s"($i, $j)")
 
 foo(10, 10)


### PR DESCRIPTION
The second example is stated as "computes all pair ..." however the pair (9, 1), among other valid pairs, is not withing the results. Although (1, 9)  is listed, (1, 9) is different than (9, 1). Just remembering that pairs are tuples of size 2 and are ordered, as opposed to a 'pair' in natural language. I changed the code accordingly and tested prior to submission.