### PR TITLE
2.12.8

### DIFF
--- a/api/all.md
+++ b/api/all.md
@@ -5,14 +5,14 @@ includeTOC: true
 ---
 
 ## Latest releases
-* Scala 2.12.7
-  * [Library API](https://www.scala-lang.org/api/2.12.7/)
-  * [Compiler API](https://www.scala-lang.org/api/2.12.7/scala-compiler/scala/)
-  * [Reflection API](https://www.scala-lang.org/api/2.12.7/scala-reflect/scala/reflect/)
+* Scala 2.12.8
+  * [Library API](https://www.scala-lang.org/api/2.12.8/)
+  * [Compiler API](https://www.scala-lang.org/api/2.12.8/scala-compiler/scala/)
+  * [Reflection API](https://www.scala-lang.org/api/2.12.8/scala-reflect/scala/reflect/)
   * Scala Modules
-    * [XML API](https://www.scala-lang.org/api/2.12.7/scala-xml/scala/xml/)
-    * [Parser Combinators API](https://www.scala-lang.org/api/2.12.7/scala-parser-combinators/scala/util/parsing/)
-    * [Swing API](https://www.scala-lang.org/api/2.12.7/scala-swing/scala/swing/)
+    * [XML API](https://www.scala-lang.org/api/2.12.8/scala-xml/scala/xml/)
+    * [Parser Combinators API](https://www.scala-lang.org/api/2.12.8/scala-parser-combinators/scala/util/parsing/)
+    * [Swing API](https://www.scala-lang.org/api/2.12.8/scala-swing/scala/swing/)
 * Scala 2.11.12
   * [Library API](https://www.scala-lang.org/api/2.11.12/)
   * [Compiler API](https://www.scala-lang.org/api/2.11.12/scala-compiler/)
@@ -39,6 +39,14 @@ includeTOC: true
 
 ## Previous releases
 
+* Scala 2.12.7
+  * [Library API](https://www.scala-lang.org/api/2.12.7/)
+  * [Compiler API](https://www.scala-lang.org/api/2.12.7/scala-compiler/scala/)
+  * [Reflection API](https://www.scala-lang.org/api/2.12.7/scala-reflect/scala/reflect/)
+  * Scala Modules
+    * [XML API](https://www.scala-lang.org/api/2.12.7/scala-xml/scala/xml/)
+    * [Parser Combinators API](https://www.scala-lang.org/api/2.12.7/scala-parser-combinators/scala/util/parsing/)
+    * [Swing API](https://www.scala-lang.org/api/2.12.7/scala-swing/scala/swing/)
 * Scala 2.12.6
   * [Library API](https://www.scala-lang.org/api/2.12.6/)
   * [Compiler API](https://www.scala-lang.org/api/2.12.6/scala-compiler/scala/)


### PR DESCRIPTION
I didn't realize the API links page has moved from scala-lang to docs.scala-lang. In fact, in our release procedure we still keep updating https://www.scala-lang.org/documentation/reference.html (which mentions 2.12.8). However, that page seems to be inaccessible, clicking through the website directs you to https://docs.scala-lang.org/api/all.html (which is updated by this PR).

Should we remove the other one? We have to update our release procedure. Anyone remembers when this change happened?