### PR TITLE
use correct package name in package object docs

### DIFF
--- a/_tour/package-objects.md
+++ b/_tour/package-objects.md
@@ -42,7 +42,7 @@ Here's how this is done:
 
 ```
 // in file gardening/fruits/package.scala
-package gardening.fruits
+package gardening
 package object fruits {
   val planted = List(Apple, Plum, Banana)
   def showFruit(fruit: Fruit): Unit = {

--- a/_tour/package-objects.md
+++ b/_tour/package-objects.md
@@ -37,12 +37,12 @@ object Plum extends Fruit("Plum", "blue")
 object Banana extends Fruit("Banana", "yellow")
 ```
 
-Now assume you want to place a variable `planted` and a method `showFruit` directly into package `gardening`.
+Now assume you want to place a variable `planted` and a method `showFruit` directly into package `gardening.fruits`.
 Here's how this is done:
 
 ```
 // in file gardening/fruits/package.scala
-package gardening
+package gardening.fruits
 package object fruits {
   val planted = List(Apple, Plum, Banana)
   def showFruit(fruit: Fruit): Unit = {


### PR DESCRIPTION
~~These 2 occurrences of 'gardening' were probably meant to be 'gardening.fruits'. Let me know if I'm missing something.~~

Edit: the code I changed in my first commit was actually correct, so I reverted that. But `planted` and `showFruit` are being added to the package object for `gardening.fruits`, not `gardening`, so I think the text change is correct.