### PR TITLE
Clarifications for List blocks

### DIFF
--- a/_overviews/scaladoc/for-library-authors.md
+++ b/_overviews/scaladoc/for-library-authors.md
@@ -181,8 +181,28 @@ Some of the standard markup available:
   subheadings. E.g. `=Heading=`, `==Sub-Heading==`, etc.
 - **List blocks** are a sequence of list items with the same style and level,
   with no interruptions from other block styles. Unordered lists can be bulleted
-  using `-`, while numbered lists can be denoted using `1.`, `i.`, `I.`, `a.` for
-  the various numbering styles.
+  using `-`; numbered lists can be denoted using `1.`, `i.`, `I.`, or `a.` for the
+  various numbering styles. In both cases, you must have extra space in front, and
+  more space makes a sub-level. 
+  
+The markup for list blocks looks like:
+
+    /** Here is an unordered list:
+      * 
+      *   - First item
+      *   - Second item
+      *     - Sub-item to the second
+      *     - Another sub-item
+      *   - Third item
+      *
+      * Here is an ordered list:
+      *
+      *   1. First numbered item
+      *   1. Second numbered item
+      *     i. Sub-item to the second
+      *     i. Another sub-item
+      *   1. Third item
+      */
 
 ## General Notes for Writing Scaladoc Comments ##
 


### PR DESCRIPTION
Having just spent a couple of hours trying to figure out how to make list blocks work, here's a tweak to provide the information that would have made my life easier.  It was previously taking for granted a few details that may be obvious if you are experienced in specific wikitext languages, but aren't otherwise.

(In particular, the fact that you *must* have extra space before the bullets, that you may *only* use, eg, `1.` as a lead-in identifier, not `2.`, and that additional spaces create sub-levels.  None of those are true of [standard Markdown](https://daringfireball.net/projects/markdown/syntax), which is the most common such language.)