### PR TITLE
Fix a word from 'variable' to 'value'

### DIFF
--- a/_tour/unified-types.md
+++ b/_tour/unified-types.md
@@ -40,7 +40,7 @@ val list: List[Any] = List(
 list.foreach(element => println(element))
 ```
 
-It defines a variable `list` of type `List[Any]`. The list is initialized with elements of various types, but they all are instance of `scala.Any`, so you can add them to the list.
+It defines a value `list` of type `List[Any]`. The list is initialized with elements of various types, but they all are instance of `scala.Any`, so you can add them to the list.
 
 Here is the output of the program:
 

--- a/_tour/unified-types.md
+++ b/_tour/unified-types.md
@@ -40,7 +40,7 @@ val list: List[Any] = List(
 list.foreach(element => println(element))
 ```
 
-It defines a value `list` of type `List[Any]`. The list is initialized with elements of various types, but they all are instance of `scala.Any`, so you can add them to the list.
+It defines a value `list` of type `List[Any]`. The list is initialized with elements of various types, but each is an instance of `scala.Any`, so you can add them to the list.
 
 Here is the output of the program:
 


### PR DESCRIPTION
At 6th paragraph in [Tour of Scala - Unified Types](https://docs.scala-lang.org/tour/unified-types.html), it seems that the wording 'variable' is actually meant to be 'value'.  