### PR TITLE
fix mismatching explanation: it is about currying itself, not the …

### DIFF
--- a/_tour/multiple-parameter-lists.md
+++ b/_tour/multiple-parameter-lists.md
@@ -47,7 +47,7 @@ numbers.foldLeft(0, {(m: Int, n: Int) => m + n})
 ```
 numbers.foldLeft(0)(_ + _)
 ```
-   Above statement `numbers.foldLeft(0)(_ + _)` allows us to fix the parameter `z` and pass around a partial function and reuse it as shown below:
+   Also it allows us to fix the parameter `z` and pass around a partial function and reuse it as shown below:
 ```tut
 val numbers = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 val numberFunc = numbers.foldLeft(List[Int]())_


### PR DESCRIPTION
At [Multiple Prameter Lists](https://docs.scala-lang.org/tour/multiple-parameter-lists.html) in Tour Of Scala, it seems that the explanation is about "currying" itself, not about the code snippet above. It might have been mistakenly edited about 6 months ago.