### PR TITLE
remove Object extending App from example

### DIFF
--- a/_tour/mixin-class-composition.md
+++ b/_tour/mixin-class-composition.md
@@ -72,11 +72,9 @@ This trait implements `foreach` by continually calling the provided function `f:
 We would like to combine the functionality of `StringIterator` and `RichIterator` into a single class.
 
 ```tut
-object StringIteratorTest extends App {
-  class RichStringIter extends StringIterator("Scala") with RichIterator
-  val richStringIter = new RichStringIter
-  richStringIter foreach println
-}
+class RichStringIter extends StringIterator("Scala") with RichIterator
+val richStringIter = new RichStringIter
+richStringIter foreach println
 ```
 The new class `RichStringIter` has `StringIterator` as a superclass and `RichIterator` as a mixin.
 


### PR DESCRIPTION
App has not been introduced in the tutorial up to this point. This code does not execute as-is in ScalaFiddle. Removing to achieve consistency with tutorials up to this point and to work out of the box for those following along from the beginning.