### PR TITLE
add a missing word 'million'.

### DIFF
--- a/_tour/tuples.md
+++ b/_tour/tuples.md
@@ -64,7 +64,7 @@ val planets =
        ("Mars", 227.9), ("Jupiter", 778.3))
 planets.foreach{
   case ("Earth", distance) =>
-    println(s"Our planet is $distance kilometers from the sun")
+    println(s"Our planet is $distance million kilometers from the sun")
   case _ =>
 }
 ```


### PR DESCRIPTION
In the example code in [TOUR OF SCALA - TUPLES](https://docs.scala-lang.org/tour/tuples.html), there is a missing word, 'million'. 