### PR TITLE
Resolve duplicate id attribute value

### DIFF
--- a/_includes/glossary-header.html
+++ b/_includes/glossary-header.html
@@ -75,9 +75,9 @@
     <script type="text/javascript">
   	  $(window).load(function(){
 
-		  $('#filter').focus();
+		  $('#filter-glossary-terms').focus();
 
-	      $("#filter").keydown(function(){
+	      $("#filter-glossary-terms").keydown(function(){
 
 	          // Retrieve the input field text and reset the count to zero
 	          var filter = $(this).val(), count = 0;

--- a/glossary/index.md
+++ b/glossary/index.md
@@ -9,7 +9,7 @@ title: Glossary
   <div class="icon-search">
     <i class="fa fa-search"></i>
   </div>
-  <input type="text" id="filter" placeholder="Look up a term...">
+  <input type="text" id="filter-glossary-terms" placeholder="Look up a term...">
   <!-- <input class="field" id="filter" type="text" /> -->
   <span id="filter-count">&nbsp;</span>
 </div>

--- a/resources/js/functions.js
+++ b/resources/js/functions.js
@@ -476,9 +476,9 @@ function updatePointer() {
 // Glossary search
 $(document).ready(function() {
 
-$('#filter').focus();
+$('#filter-glossary-terms').focus();
 
-  $("#filter").keyup(function(){
+  $("#filter-glossary-terms").keyup(function(){
 
       // Retrieve the input field text and reset the count to zero
       var filter = $(this).val(), count = 0;


### PR DESCRIPTION
This PR changes the `id` attribute value of the `input` element on the glossary page to resolve a naming conflict with the `id` value of the heading element for the term "filter".

Resolves: #1295 