### PR TITLE
Fix the sentence that says how SIP committee members are elected.

### DIFF
--- a/_sips/sip-submission.md
+++ b/_sips/sip-submission.md
@@ -190,8 +190,9 @@ Committee members should be either individuals responsible for a specific part
 of the Scala codebase, committers or contributors of the Scala compiler.
 Exceptionally, members may also be important representatives of the community
 with a high technical knowledge to understand the implications of every proposal
-and participate into the discussions. The members are elected by the Process
-Lead based on their expertise and implication in the community.
+and participate into the discussions. New members are elected by existing
+members of the SIP Committee, based on their expertise and involvement in the
+community.
 
 The current committee members are:
 


### PR DESCRIPTION
This is not a change of the actual process. We've always done it that way (or least as far as I've been in the committee).

I wanted to cite that page from https://contributors.scala-lang.org/t/scala-governance/3218, but then discovered the existing wording did not fit the reality.