### PR TITLE
Add redirect for partest-guide

### DIFF
--- a/_overviews/tutorials/partest-guide.md
+++ b/_overviews/tutorials/partest-guide.md
@@ -1,0 +1,6 @@
+---
+layout: inner-page-no-masthead
+sitemap: false
+permalink: /tutorials/partest-guide.html
+redirect_to: https://github.com/scala/scala-partest
+---


### PR DESCRIPTION
Link to GitHub repo, even though it is obsolete after 2.12.  Partest is part of compiler repo for 2.13 and later.

Fixes #1328.