### PR TITLE
Clarifying first limitation of value-classes

### DIFF
--- a/_overviews/core/value-classes.md
+++ b/_overviews/core/value-classes.md
@@ -140,7 +140,7 @@ Full details on the implementation of value classes and their limitations may be
 
 A value class ...
 
-1. ... must have only a primary constructor with exactly one public, val parameter whose type is not a value class. (From Scala 2.11.0, the parameter may be non-public.)
+1. ... must have only a primary constructor with exactly one public, val parameter whose type is not a user-defined value class. (From Scala 2.11.0, the parameter may be non-public.)
 2. ... may not have specialized type parameters.
 3. ... may not have nested or local classes, traits, or objects
 4. ... may not define a equals or hashCode method.


### PR DESCRIPTION
Phrase "... val parameter whose type is not a value class" seems wrong. You actually can have value class as a parameter if it is a standard value class. I suggest adding term "user-defined value class".