### PR TITLE
Move Scaladoc interface in menu as second

### DIFF
--- a/_overviews/scaladoc/for-library-authors.md
+++ b/_overviews/scaladoc/for-library-authors.md
@@ -7,7 +7,7 @@ discourse: true
 partof: scaladoc
 overview-name: Scaladoc
 
-num: 2
+num: 3
 
 permalink: /overviews/scaladoc/:title.html
 ---

--- a/_overviews/scaladoc/interface.md
+++ b/_overviews/scaladoc/interface.md
@@ -7,7 +7,7 @@ discourse: true
 partof: scaladoc
 overview-name: Scaladoc
 
-num: 3
+num: 2
 
 permalink: /overviews/scaladoc/:title.html
 ---


### PR DESCRIPTION
Seems the table of contents should match the listing on the overview page:

https://docs.scala-lang.org/overviews/scaladoc/overview.html