### PR TITLE
Make the landing page translatable and add its Japanese translation

### DIFF
--- a/_includes/masthead-documentation.html
+++ b/_includes/masthead-documentation.html
@@ -1,6 +1,34 @@
 <section class="table-of-content">
 	<div class="wrap">
 		<div class="inner-box">
+
+			<div class="language-dropdown inverted">
+				<div id="dd" class="wrapper-dropdown" tabindex="1">
+					<span>Language</span>
+					<ul class="dropdown"></ul>
+				</div>
+			</div>
+
+			<ul id="available-languages" style="display: none;">
+				{% if page.languages %}
+					<li><a href="{{ site.baseurl }}{{ page.url }}">English</a></li>
+					{% for l in page.languages %}
+						{% capture intermediate %}{{ page.url }}{% endcapture %}
+						{% capture rootTutorialURL %}{{ intermediate | remove_first: '/' }}{% endcapture %}
+						{% assign lang = site.data.languages[l] %}
+						<li><a href="{{ site.baseurl }}/{{ l }}/{{ rootTutorialURL }}" class="lang">{{ lang.name }}</a></li>
+					{% endfor %}
+				{% elsif page.language %}
+					{% assign engPath = page.url | remove_first: "/" | remove_first: page.language | remove_first: "index.html" %}
+					{% assign engPg = site.pages | where: 'partof', page.partof | first %}
+					<li><a href="{{ site.baseurl }}{{ engPath }}">English</a></li>
+					{% for l in engPg.languages %}
+						{% assign lang = site.data.languages[l] %}
+						<li><a href="{{ site.baseurl }}/{{ l }}{{ engPath }}" class="lang">{{ lang.name }}</a></li>
+					{% endfor %}
+				{% endif %}
+			</ul>
+
 			<div class="documentation">
 				{% for section in page.sections %}
           <div class="section">

--- a/_ja/index.md
+++ b/_ja/index.md
@@ -1,0 +1,70 @@
+---
+layout: inner-page-documentation
+title: ドキュメント
+language: ja
+partof: documentation
+discourse: true
+
+# Content masthead links
+sections:
+
+  - title: "最初のステップ"
+    links:
+      - title: "入門"
+        description: "あなたのコンピューターに Scala をインストールして、Scala コードを書きはじめよう！（英語のみ）"
+        icon: "fa fa-rocket"
+        link: /getting-started.html
+      - title: "Scala ツアー"
+        description: "コア言語機能をひと口大で紹介"
+        icon: "fa fa-flag"
+        link: /ja/tour/tour-of-scala.html
+      - title: "Java プログラマーのための Scala"
+        description: "Java 経験者向けのすばやい紹介"
+        icon: "fa fa-coffee"
+        link: /ja/tutorials/scala-for-java-programmers.html
+    more-resources:
+      - title: オンラインリソース（英語のみ）
+        url: /learn.html
+      - title: 書籍（英語のみ）
+        url: /books.html           
+
+  - title: "リピーター向け"      
+    links:
+      - title: "API"
+        description: "Scala の全バージョンの API ドキュメント（英語のみ）"
+        icon: "fa fa-file-text"
+        link: /api/all.html
+      - title: "Overviews"
+        description: "Scala の多くの機能を網羅する詳細ドキュメント"
+        icon: "fa fa-database"
+        # TODO: 日本語訳はあるがリニューアル前のもの。要修正
+        link: /ja/overviews/index.html
+      - title: "スタイルガイド"
+        description: "Scala らしいコードを書くための詳細なガイド（英語のみ）"
+        icon: "fa fa-bookmark"
+        link: /style/index.html
+      - title: "チートシート"
+        description: "Scala 構文の基礎を網羅する便利なチートシート"
+        icon: "fa fa-list"
+        link: /ja/cheatsheets/index.html    
+      - title: "Scala よくある質問"
+        description: "Scala 言語機能についてよく聞かれる質問＆回答集（英語のみ）"
+        icon: "fa fa-question-circle"
+        link: /tutorials/FAQ/index.html
+      - title: "言語仕様"
+        description: "Scala の形式的言語仕様（英語のみ）"
+        icon: "fa fa-book"
+        link: http://scala-lang.org/files/archive/spec/2.12/
+
+  - title: "Scala の進化"      
+    links:
+      - title: "SIP"
+        description: "Scala Improvement Process（Scala 改善プロセス）。言語とコンパイラの進化（英語のみ）"
+        icon: "fa fa-cogs"
+        link: sips/index.html
+      - title: "SPP"
+        description: "Scala Platform Process（Scala プラットフォームプロセス）。コミュニティ主導型のライブラリの進化（英語のみ）"
+        icon: "fa fa-users"
+        link: https://platform.scala-lang.org
+
+---

--- a/_ja/index.md
+++ b/_ja/index.md
@@ -61,7 +61,7 @@ sections:
       - title: "SIP"
         description: "Scala Improvement Process（Scala 改善プロセス）。言語とコンパイラの進化（英語のみ）"
         icon: "fa fa-cogs"
-        link: sips/index.html
+        link: /sips/index.html
       - title: "SPP"
         description: "Scala Platform Process（Scala プラットフォームプロセス）。コミュニティ主導型のライブラリの進化（英語のみ）"
         icon: "fa fa-users"

--- a/_sass/components/dropdown.scss
+++ b/_sass/components/dropdown.scss
@@ -18,12 +18,23 @@
   // }
   float: right;
 
+  .table-of-content & {
+    margin-top: 0;
+    margin-right: 0;
+  }
+
   .wrapper-dropdown {
     padding: 8px 18px 8px 40px;
     appearance: none;
     font-size: $base-font-size;
     border-radius: $border-radius-base;
     box-sizing: border-box;
+
+    .table-of-content & {
+      border: 1px solid rgba(128, 128, 128, 0.5);
+    }
+    .table-of-content &:focus {
+    }
 
     &:focus {
       outline: none;

--- a/index.md
+++ b/index.md
@@ -1,9 +1,10 @@
 ---
 layout: inner-page-documentation
 title: Documentation
-#redirect_from:
-#  - /what-is-scala/
-#includeTOC: true
+languages: [ja]
+namespace: root
+partof: documentation
+discourse: true
 
 # Content masthead links
 sections:

--- a/index.md
+++ b/index.md
@@ -61,7 +61,7 @@ sections:
       - title: "SIPs"
         description: "The Scala Improvement Process. Language & compiler evolution."
         icon: "fa fa-cogs"
-        link: sips/index.html
+        link: /sips/index.html
       - title: "SPP"
         description: "The Scala Platform Process. Community-driven library evolution."
         icon: "fa fa-users"


### PR DESCRIPTION
Closes #1324
Cc: @eed3si9n 

* Add a language dropdown to [the landing page](https://docs.scala-lang.org/) 
* Add Japanese translation of landing page.  Some links guides reader to Japanese translation if available, otherwise guide to English pages.
![japanese-landing-page](https://user-images.githubusercontent.com/127635/61267573-6ec73d80-a7d3-11e9-9ccb-7378d1121fc9.gif)

Unfortunately, current template is not considered to have the seach bar and language dropdown at same time.
I gave a try but it is not easy to add language dropdown (both from design POV and coding POV).
![image](https://user-images.githubusercontent.com/127635/61267082-4a6a6180-a7d1-11e9-96a4-477f34d1c9d2.png)

Honestly, I don't want to contribute my time into *redesign*-ish issues.
Because I am afraid that PRs get rejected [because those who responsible for docs prohibit community to get involved in redesign](https://github.com/scala/scala-lang/pull/891#issuecomment-386555832).

However, because I beleive #1324 is a key to improve UX for non-English learners, I propose this change.
Even though a design incosistency, I think this is a good start.
Allowing community to translate langing page will improves UX very much.
If needed, those who are resnponsible for docs may consider hiring a professional to redesign in later.

