### PR TITLE
Support “next” and “previous” links between pages of overviews

### DIFF
--- a/_data/overviews.yml
+++ b/_data/overviews.yml
@@ -15,6 +15,7 @@
         - title: Trait Iterable
           url: "collections-2.13/trait-iterable.html"
         - title: The sequence traits Seq, IndexedSeq, and LinearSeq
+          url: "collections-2.13/seqs.html"
         - title: Concrete Immutable Collection Classes
           url: "collections-2.13/concrete-immutable-collection-classes.html"
         - title: Concrete Mutable Collection Classes

--- a/_layouts/multipage-overview.html
+++ b/_layouts/multipage-overview.html
@@ -12,6 +12,17 @@ includeCollectionTOC: true
 					{{content}}
 				</div>
 
+				<div class="two-columns">
+					{% if page.previous-page %}
+					<a href="{{page.previous-page}}.html">&larr; <strong>previous</strong></a>
+					{% else %}
+					<div></div>
+					{% endif %}
+					{% if page.next-page %}
+					<a href="{{page.next-page}}.html"><strong>next</strong> &rarr;</a>
+					{% endif %}
+				</div>
+
 				{% include contributors-list.html %}
 			</div>
 		</div>

--- a/_overviews/collections-2.13/arrays.md
+++ b/_overviews/collections-2.13/arrays.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 10
+previous-page: concrete-mutable-collection-classes
+next-page: strings
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/concrete-immutable-collection-classes.md
+++ b/_overviews/collections-2.13/concrete-immutable-collection-classes.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 8
+previous-page: maps
+next-page: concrete-mutable-collection-classes
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/concrete-mutable-collection-classes.md
+++ b/_overviews/collections-2.13/concrete-mutable-collection-classes.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 9
+previous-page: concrete-immutable-collection-classes
+next-page: arrays
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/conversions-between-java-and-scala-collections.md
+++ b/_overviews/collections-2.13/conversions-between-java-and-scala-collections.md
@@ -8,6 +8,7 @@ partof: collections-213
 overview-name: Collections
 
 num: 17
+previous-page: creating-collections-from-scratch
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/creating-collections-from-scratch.md
+++ b/_overviews/collections-2.13/creating-collections-from-scratch.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 16
+previous-page: iterators
+next-page: conversions-between-java-and-scala-collections
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/equality.md
+++ b/_overviews/collections-2.13/equality.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 13
+previous-page: performance-characteristics
+next-page: views
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/introduction.md
+++ b/_overviews/collections-2.13/introduction.md
@@ -8,6 +8,7 @@ partof: collections-213
 overview-name: Collections
 
 num: 1
+next-page: overview
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/iterators.md
+++ b/_overviews/collections-2.13/iterators.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 15
+previous-page: views
+next-page: creating-collections-from-scratch
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/maps.md
+++ b/_overviews/collections-2.13/maps.md
@@ -8,8 +8,10 @@ partof: collections-213
 overview-name: Collections
 
 num: 7
+previous-page: sets
+next-page: concrete-immutable-collection-classes
 
-permalink: /overviews/collections2.13/:title.html
+permalink: /overviews/collections-2.13/:title.html
 ---
 
 A [Map](http://www.scala-lang.org/api/current/scala/collection/Map.html) is an [Iterable](http://www.scala-lang.org/api/current/scala/collection/Iterable.html) consisting of pairs of keys and values (also named _mappings_ or _associations_). Scala's [Predef](http://www.scala-lang.org/api/current/scala/Predef$.html) object offers an implicit conversion that lets you write `key -> value` as an alternate syntax for the pair `(key, value)`. For instance `Map("x" -> 24, "y" -> 25, "z" -> 26)` means exactly the same as `Map(("x", 24), ("y", 25), ("z", 26))`, but reads better.

--- a/_overviews/collections-2.13/overview.md
+++ b/_overviews/collections-2.13/overview.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 2
+previous-page: introduction
+next-page: trait-iterable
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/performance-characteristics.md
+++ b/_overviews/collections-2.13/performance-characteristics.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 12
+previous-page: strings
+next-page: equality
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/seqs.md
+++ b/_overviews/collections-2.13/seqs.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 5
+previous-page: trait-iterable
+next-page: sets
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/sets.md
+++ b/_overviews/collections-2.13/sets.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 6
+previous-page: seqs
+next-page: maps
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/strings.md
+++ b/_overviews/collections-2.13/strings.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 11
+previous-page: arrays
+next-page: performance-characteristics
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/trait-iterable.md
+++ b/_overviews/collections-2.13/trait-iterable.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 4
+previous-page: overview
+next-page: seqs
 
 permalink: /overviews/collections-2.13/:title.html
 ---

--- a/_overviews/collections-2.13/views.md
+++ b/_overviews/collections-2.13/views.md
@@ -8,6 +8,8 @@ partof: collections-213
 overview-name: Collections
 
 num: 14
+previous-page: equality
+next-page: iterators
 
 permalink: /overviews/collections-2.13/:title.html
 ---


### PR DESCRIPTION
Pages of a multipage-overview can now have a `previous-page` property
or a `next-page` property, which generate a “previous” and a “next”
link, respectively, like it is currently done in the Tour.

Also, update the collections-2.13 overview to make use of this feature.

Example:
![image](https://user-images.githubusercontent.com/332812/61444565-e91acd80-a94b-11e9-8203-db6deb9600e5.png)
