### PR TITLE
Instruct --help command sintead of 404 manual page

### DIFF
--- a/_overviews/scaladoc/generate.md
+++ b/_overviews/scaladoc/generate.md
@@ -46,7 +46,7 @@ This will put the HTML in the current directory.  This is probably not what you 
 
     $ scaladoc -d build/ src/main/scala/App.scala
 
-For more information on the `scaladoc` command and what other command-line options it supports, see the [scaladoc man page](https://www.scala-lang.org/files/archive/nightly/docs/manual/html/scaladoc.html).
+For more information on the `scaladoc` command and what other command-line options it supports, see the `scaladoc --help`.
 
 This command is harder to operate with more complex projects containing both multiple Scala source files and library dependencies.  This is why using sbt (see above) is easier and better suited for generating Scaladoc.
 


### PR DESCRIPTION
Closes #1421 

[An extranal link to scaladoc manual](https://www.scala-lang.org/files/archive/nightly/docs/manual/html/scaladoc.html) is no longer available, since the entire `/files/archive/nightly/docs` directory for 2.11 nightly is removed https://github.com/scala/scala-lang/issues/453#issuecomment-510458550.

Until a new page for scaladoc manual is created, let user to user to know `scaladoc --help` command.