### PR TITLE
Naming convention exception generating/deriving formats

### DIFF
--- a/_style/naming-conventions.md
+++ b/_style/naming-conventions.md
@@ -40,6 +40,12 @@ Classes should be named in upper camel case:
 
 This mimics the Java naming convention for classes.
 
+Sometimes traits and classes as well as their members are used to describe
+formats, documentation or protocols and generate/derive them. 
+In these cases it is desirable to be close to a 1:1 relation to the output format
+and the naming conventions don't apply. In this case, they should only be used
+for that specific purpose and not throughout the rest of the code.
+
 ## Objects
 
 Object names are like class names (upper camel case).


### PR DESCRIPTION
Added the exceptions for types that have the sole purpose of describing and/or generating formats, typeclass instances etc.

Hope this is a good location for that addition, please feel free to improve. :)

Closes #1439