### PR TITLE
Output of doc data tool

### DIFF
--- a/_data/compiler-options.yml
+++ b/_data/compiler-options.yml
@@ -15,6 +15,20 @@
       arg: "plugin:opt"
       multiple: "true"
     description: "Pass an option to a plugin"
+  - option: "-V"
+    schema:
+      type: "Boolean"
+    description: "Print a synopsis of verbose options."
+  - option: "-W"
+    schema:
+      type: "Boolean"
+    description: "Print a synopsis of warning options."
+  - option: "-Werror"
+    schema:
+      type: "Boolean"
+    description: "Fail the compilation if there are any warnings."
+    abbreviations:
+    - "-Xfatal-warnings"
   - option: "-X"
     schema:
       type: "Boolean"
@@ -29,6 +43,8 @@
       arg: "path"
       default:
     description: "Override location of bootstrap class files."
+    abbreviations:
+    - "--boot-class-path"
   - option: "-classpath"
     schema:
       type: "Path"
@@ -37,6 +53,7 @@
     description: "Specify where to find user class files."
     abbreviations:
     - "-cp"
+    - "--class-path"
   - option: "-d"
     schema:
       type: "String"
@@ -49,30 +66,42 @@
       arg: "file"
       default: ".scala_dependencies"
     description: "Set dependency tracking file."
+    abbreviations:
+    - "--dependency-file"
   - option: "-deprecation"
     schema:
       type: "Boolean"
     description: "Emit warning and location for usages of deprecated APIs."
+    abbreviations:
+    - "--deprecation"
   - option: "-encoding"
     schema:
       type: "String"
       arg: "encoding"
       default: "UTF-8"
     description: "Specify character encoding used by source files."
+    abbreviations:
+    - "--encoding"
   - option: "-explaintypes"
     schema:
       type: "Boolean"
     description: "Explain type errors in more detail."
+    abbreviations:
+    - "--explain-types"
   - option: "-extdirs"
     schema:
       type: "Path"
       arg: "path"
       default:
     description: "Override location of installed extensions."
+    abbreviations:
+    - "--extension-directories"
   - option: "-feature"
     schema:
       type: "Boolean"
     description: "Emit warning and location for usages of features that should be imported explicitly."
+    abbreviations:
+    - "--feature"
   - option: "-g"
     schema:
       type: "Choice"
@@ -84,23 +113,29 @@
       - choice: "line"
       - choice: "vars"
       - choice: "notailcalls"
-    description: "Set level of generated debugging info. Choices: (none,source,line,vars,notailcalls), default: vars."
+    description: "Set level of generated debugging info. (none,source,line,[vars],notailcalls)"
   - option: "-help"
     schema:
       type: "Boolean"
     description: "Print a synopsis of standard options"
+    abbreviations:
+    - "--help"
   - option: "-javabootclasspath"
     schema:
       type: "Path"
       arg: "path"
-      default: "/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/resources.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/rt.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/sunrsasign.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jsse.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jce.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/charsets.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jfr.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/classes"
+      default: ""
     description: "Override java boot classpath."
+    abbreviations:
+    - "--java-boot-class-path"
   - option: "-javaextdirs"
     schema:
       type: "Path"
       arg: "path"
-      default: "/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext:/usr/java/packages/lib/ext"
+      default:
     description: "Override java extdirs classpath."
+    abbreviations:
+    - "--java-extension-directories"
   - option: "-language"
     schema:
       type: "Choice"
@@ -109,31 +144,39 @@
       choices:
       - choice: "dynamics"
         description: "Allow direct or indirect subclasses of scala.Dynamic"
-      - choice: "postfixOps"
-        description: "Allow postfix operator notation, such as `1 to 10 toList`"
-      - choice: "reflectiveCalls"
-        description: "Allow reflective access to members of structural types"
-      - choice: "implicitConversions"
-        description: "Allow definition of implicit functions called views"
-      - choice: "higherKinds"
-        description: "Allow higher-kinded types"
       - choice: "existentials"
         description: "Existential types (besides wildcard types) can be written and inferred"
+      - choice: "higherKinds"
+        description: "Allow higher-kinded types"
+      - choice: "implicitConversions"
+        description: "Allow definition of implicit functions called views"
+      - choice: "postfixOps"
+        description: "Allow postfix operator notation, such as `1 to 10 toList` (not recommended)"
+      - choice: "reflectiveCalls"
+        description: "Allow reflective access to members of structural types"
       - choice: "experimental.macros"
         description: "Allow macro definition (besides implementation and application)"
-    description: "Enable or disable language features: `_` for all, `-language:help` to list choices."
+    description: "Enable or disable language features"
+    abbreviations:
+    - "--language"
   - option: "-no-specialization"
     schema:
       type: "Boolean"
     description: "Ignore @specialize annotations."
+    abbreviations:
+    - "--no-specialization"
   - option: "-nobootcp"
     schema:
       type: "Boolean"
     description: "Do not use the boot classpath for the scala jars."
+    abbreviations:
+    - "--no-boot-class-path"
   - option: "-nowarn"
     schema:
       type: "Boolean"
     description: "Generate no warnings."
+    abbreviations:
+    - "--no-warnings"
   - option: "-opt"
     schema:
       type: "Choice"
@@ -156,6 +199,12 @@
         description: "Track nullness / non-nullness of local variables and apply optimizations."
       - choice: "closure-invocations"
         description: "Rewrite closure invocations to the implementation method."
+      - choice: "allow-skip-core-module-init"
+        description: "Allow eliminating unused module loads for core modules of the standard library (e.g., Predef, ClassTag)."
+      - choice: "assume-modules-non-null"
+        description: "Assume loading a module never results in null (happens if the module is accessed in its super constructor)."
+      - choice: "allow-skip-class-loading"
+        description: "Allow optimizations that can skip or delay class loading."
       - choice: "inline"
         description: "Inline method invocations according to -Yopt-inline-heuristics and -opt-inline-from."
       - choice: "l:none"
@@ -163,14 +212,10 @@
       - choice: "l:default"
         description: "Enable default optimizations: unreachable-code."
       - choice: "l:method"
-        description: "Enable intra-method optimizations: unreachable-code,simplify-jumps,compact-locals,copy-propagation,redundant-casts,box-unbox,nullness-tracking,closure-invocations."
+        description: "Enable intra-method optimizations: unreachable-code,simplify-jumps,compact-locals,copy-propagation,redundant-casts,box-unbox,nullness-tracking,closure-invocations,allow-skip-core-module-init,assume-modules-non-null,allow-skip-class-loading."
       - choice: "l:inline"
         description: "Enable cross-method optimizations (note: inlining requires -opt-inline-from): l:method,inline."
-      - choice: "l:project"
-        description: "[deprecated, use -opt:l:inline, -opt-inline-from] Enable cross-method optimizations within the current project."
-      - choice: "l:classpath"
-        description: "[deprecated, use -opt:l:inline, -opt-inline-from] Enable cross-method optimizations across the entire classpath."
-    description: "Enable optimizations: `_` for all, `-opt:help` to list choices."
+    description: "Enable optimizations"
   - option: "-opt-inline-from"
     schema:
       type: "String"
@@ -197,70 +242,93 @@
         description: "Warn if an inlining decision cannot be made because a the bytecode of a class or member cannot be found on the compilation classpath."
       - choice: "no-inline-missing-attribute"
         description: "Warn if an inlining decision cannot be made because a Scala classfile does not have a ScalaInlineInfo attribute."
-    description: "Enable optimizer warnings: `_` for all, `-opt-warnings:help` to list choices."
-  - option: "-optimise"
+    description: "Enable optimizer warnings"
+  - option: "-optimize"
     schema:
       type: "Boolean"
-    description: "Compiler flag for the optimizer in Scala 2.11"
+    description: "Enables optimizations."
     abbreviations:
-    - "-optimize"
+    - "-optimise"
   - option: "-print"
     schema:
       type: "Boolean"
     description: "Print program with Scala-specific features removed."
+    abbreviations:
+    - "--print"
   - option: "-release"
     schema:
       type: "String"
       arg: "release"
       default:
     description: "Compile for a specific version of the Java platform. Supported targets: 6, 7, 8, 9"
+    abbreviations:
+    - "--release"
   - option: "-sourcepath"
     schema:
       type: "Path"
       arg: "path"
       default:
     description: "Specify location(s) of source files."
+    abbreviations:
+    - "--source-path"
   - option: "-target"
     schema:
       type: "Choice"
       arg: "target"
-      default: "jvm-1.8"
+      default: "8"
       choices:
-      - choice: "jvm-1.5"
-      - choice: "jvm-1.6"
-      - choice: "jvm-1.7"
-      - choice: "jvm-1.8"
-    description: "Target platform for object files. All JVM 1.5 - 1.7 targets are deprecated. Choices: (jvm-1.5,jvm-1.6,jvm-1.7,jvm-1.8), default: jvm-1.8."
+      - choice: "8"
+      - choice: "9"
+      - choice: "10"
+      - choice: "11"
+      - choice: "12"
+    description: "Target platform for object files. ([8],9,10,11,12)"
+    abbreviations:
+    - "--target"
   - option: "-toolcp"
     schema:
       type: "Path"
       arg: "path"
       default:
     description: "Add to the runner classpath."
+    abbreviations:
+    - "--tool-class-path"
   - option: "-unchecked"
     schema:
       type: "Boolean"
     description: "Enable additional warnings where generated code depends on assumptions."
+    abbreviations:
+    - "--unchecked"
   - option: "-uniqid"
     schema:
       type: "Boolean"
     description: "Uniquely tag all identifiers in debugging output."
+    abbreviations:
+    - "--unique-id"
   - option: "-usejavacp"
     schema:
       type: "Boolean"
     description: "Utilize the java.class.path in classpath resolution."
+    abbreviations:
+    - "--use-java-class-path"
   - option: "-usemanifestcp"
     schema:
       type: "Boolean"
     description: "Utilize the manifest in classpath resolution."
+    abbreviations:
+    - "--use-manifest-class-path"
   - option: "-verbose"
     schema:
       type: "Boolean"
     description: "Output messages about what the compiler is doing."
+    abbreviations:
+    - "--verbose"
   - option: "-version"
     schema:
       type: "Boolean"
     description: "Print product version and exit."
+    abbreviations:
+    - "--version"
   - option: "@<file>"
     schema:
       type: "Boolean"
@@ -288,19 +356,11 @@
   - option: "-Xexperimental"
     schema:
       type: "Boolean"
-    description: "Enable experimental extensions."
-  - option: "-Xfatal-warnings"
-    schema:
-      type: "Boolean"
-    description: "Fail the compilation if there are any warnings."
-  - option: "-Xfull-lubs"
-    schema:
-      type: "Boolean"
-    description: "Retains pre 2.10 behavior of less aggressive truncation of least upper bounds."
+    description: "Former graveyard for language-forking extensions."
   - option: "-Xfuture"
     schema:
       type: "Boolean"
-    description: "Turn on future language features."
+    description: "Replaced by -Xsource."
   - option: "-Xgenerate-phase-graph"
     schema:
       type: "String"
@@ -337,39 +397,29 @@
         description: "Option.apply used implicit view."
       - choice: "delayedinit-select"
         description: "Selecting member of DelayedInit."
-      - choice: "by-name-right-associative"
-        description: "By-name parameter of right associative operator."
       - choice: "package-object-classes"
         description: "Class or object defined in package object."
-      - choice: "unsound-match"
-        description: "Pattern match may not be typesafe."
       - choice: "stars-align"
         description: "Pattern sequence wildcard must align with sequence component."
       - choice: "constant"
         description: "Evaluation of a constant arithmetic expression results in an error."
       - choice: "unused"
-        description: "Enable -Ywarn-unused:imports,privates,locals,implicits."
-    description: "Enable or disable specific warnings: `_` for all, `-Xlint:help` to list choices."
-  - option: "-Xlog-free-terms"
-    schema:
-      type: "Boolean"
-    description: "Print a message when reification creates a free term."
-  - option: "-Xlog-free-types"
-    schema:
-      type: "Boolean"
-    description: "Print a message when reification resorts to generating a free type."
-  - option: "-Xlog-implicit-conversions"
-    schema:
-      type: "Boolean"
-    description: "Print a message whenever an implicit conversion is inserted."
-  - option: "-Xlog-implicits"
-    schema:
-      type: "Boolean"
-    description: "Show more detail on why some implicits are not applicable."
-  - option: "-Xlog-reflective-calls"
-    schema:
-      type: "Boolean"
-    description: "Print a message when a reflective method call is generated"
+        description: "Enable -Wunused:imports,privates,locals,implicits."
+      - choice: "nonlocal-return"
+        description: "A return statement used an exception for flow control."
+      - choice: "implicit-not-found"
+        description: "Check @implicitNotFound and @implicitAmbiguous messages."
+      - choice: "serial"
+        description: "@SerialVersionUID on traits and non-serializable classes."
+      - choice: "valpattern"
+        description: "Enable pattern checks in val definitions."
+      - choice: "eta-zero"
+        description: "Warn on eta-expansion (rather than auto-application) of zero-ary method."
+      - choice: "eta-sam"
+        description: "Warn on eta-expansion to meet a Java-defined functional interface that is not explicitly annotated with @FunctionalInterface."
+      - choice: "deprecation"
+        description: "Enable linted deprecations."
+    description: "Enable recommended warnings"
   - option: "-Xmacro-settings"
     schema:
       type: "String"
@@ -382,13 +432,6 @@
       arg: "path"
       default:
     description: "Class for manifest's Main-Class entry (only useful with -d jar)"
-  - option: "-Xmax-classfile-name"
-    schema:
-      type: "Int"
-      default: "255"
-      min: "72"
-      max: "255"
-    description: "Maximum filename length for generated classes"
   - option: "-Xmaxerrs"
     schema:
       type: "Int"
@@ -460,25 +503,8 @@
     schema:
       type: "String"
       arg: "path"
-      default: "misc/scala-devel/plugins"
+      default: ""
     description: "Path to search for plugin archives."
-  - option: "-Xprint"
-    schema:
-      type: "Phases"
-      default:
-    description: "Print out program after phases"
-  - option: "-Xprint-args"
-    schema:
-      type: "Boolean"
-    description: "Print all compiler arguments and exit."
-  - option: "-Xprint-pos"
-    schema:
-      type: "Boolean"
-    description: "Print tree positions, as offsets."
-  - option: "-Xprint-types"
-    schema:
-      type: "Boolean"
-    description: "Print tree types (debugging option)."
   - option: "-Xprompt"
     schema:
       type: "Boolean"
@@ -499,27 +525,11 @@
       arg: "object"
       default:
     description: "Treat the source file as a script and wrap it in a main method."
-  - option: "-Xshow-class"
-    schema:
-      type: "String"
-      arg: "class"
-      default:
-    description: "Show internal representation of class."
-  - option: "-Xshow-object"
-    schema:
-      type: "String"
-      arg: "object"
-      default:
-    description: "Show internal representation of object."
-  - option: "-Xshow-phases"
-    schema:
-      type: "Boolean"
-    description: "Print a synopsis of compiler phases."
   - option: "-Xsource"
     schema:
       type: "ScalaVersion"
       arg: "version"
-      default: "2.12.0"
+      default: "2.13.0"
     description: "Treat compiler input as Scala source for the specified version, see scala/bug#8126."
   - option: "-Xsource-reader"
     schema:
@@ -527,10 +537,6 @@
       arg: "classname"
       default:
     description: "Specify a custom method for reading source files."
-  - option: "-Xstrict-inference"
-    schema:
-      type: "Boolean"
-    description: "Don't infer known-unsound types"
   - option: "-Xverify"
     schema:
       type: "Boolean"
@@ -543,10 +549,237 @@
       choices:
       - choice: "coalescing"
         description: "Convert PCData to Text and coalesce sibling nodes"
-    description: "Configure XML parsing.: `_` for all, `-Xxml:help` to list choices."
+    description: "Configure XML parsing."
 - category: "Verbose Settings"
   description:
   options:
+  - option: "-Vbrowse"
+    schema:
+      type: "Phases"
+      default:
+    description: "Browse the abstract syntax tree after phases"
+    abbreviations:
+    - "-Ybrowse"
+  - option: "-Vclasspath"
+    schema:
+      type: "Boolean"
+    description: "Output information about what classpath is being applied."
+    abbreviations:
+    - "-Ylog-classpath"
+  - option: "-Vdebug"
+    schema:
+      type: "Boolean"
+    description: "Increase the quantity of debugging output."
+    abbreviations:
+    - "-Ydebug"
+  - option: "-Vdoc"
+    schema:
+      type: "Boolean"
+    description: "Trace scaladoc activity."
+    abbreviations:
+    - "-Ydoc-debug"
+  - option: "-Vfree-terms"
+    schema:
+      type: "Boolean"
+    description: "Print a message when reification creates a free term."
+    abbreviations:
+    - "-Xlog-free-terms"
+  - option: "-Vfree-types"
+    schema:
+      type: "Boolean"
+    description: "Print a message when reification resorts to generating a free type."
+    abbreviations:
+    - "-Xlog-free-types"
+  - option: "-Vhot-statistics"
+    schema:
+      type: "Boolean"
+    description: "Enable `-Vstatistics` to also print hot statistics."
+    abbreviations:
+    - "-Yhot-statistics"
+  - option: "-Vide"
+    schema:
+      type: "Boolean"
+    description: "Generate, validate and output trees using the interactive compiler."
+    abbreviations:
+    - "-Yide-debug"
+  - option: "-Vimplicit-conversions"
+    schema:
+      type: "Boolean"
+    description: "Print a message whenever an implicit conversion is inserted."
+    abbreviations:
+    - "-Xlog-implicit-conversions"
+  - option: "-Vimplicits"
+    schema:
+      type: "Boolean"
+    description: "Show more detail on why some implicits are not applicable."
+    abbreviations:
+    - "-Xlog-implicits"
+  - option: "-Vinline"
+    schema:
+      type: "String"
+      arg: "package/Class.method"
+      default:
+    description: "Print a summary of inliner activity; `_` to print all, prefix match to select."
+    abbreviations:
+    - "-Yopt-log-inline"
+  - option: "-Vissue"
+    schema:
+      type: "Boolean"
+    description: "Print stack traces when a context issues an error."
+    abbreviations:
+    - "-Yissue-debug"
+  - option: "-Vlog"
+    schema:
+      type: "Phases"
+      default:
+    description: "Log operations during phases"
+    abbreviations:
+    - "-Ylog"
+  - option: "-Vmacro"
+    schema:
+      type: "Boolean"
+    description: "Trace macro activities: compilation, generation of synthetics, classloading, expansion, exceptions."
+    abbreviations:
+    - "-Ymacro-debug-verbose"
+  - option: "-Vmacro-lite"
+    schema:
+      type: "Boolean"
+    description: "Trace macro activities with less output."
+    abbreviations:
+    - "-Ymacro-debug-lite"
+  - option: "-Vopt"
+    schema:
+      type: "String"
+      arg: "package/Class.method"
+      default:
+    description: "Trace the optimizer progress for methods; `_` to print all, prefix match to select."
+    abbreviations:
+    - "-Yopt-trace"
+  - option: "-Vpatmat"
+    schema:
+      type: "Boolean"
+    description: "Trace pattern matching translation."
+    abbreviations:
+    - "-Ypatmat-debug"
+  - option: "-Vphases"
+    schema:
+      type: "Boolean"
+    description: "Print a synopsis of compiler phases."
+    abbreviations:
+    - "-Xshow-phases"
+  - option: "-Vpos"
+    schema:
+      type: "Boolean"
+    description: "Trace position validation."
+    abbreviations:
+    - "-Ypos-debug"
+  - option: "-Vprint"
+    schema:
+      type: "Phases"
+      default:
+    description: "Print out program after phases"
+    abbreviations:
+    - "-Xprint"
+  - option: "-Vprint-args"
+    schema:
+      type: "String"
+      arg: "file"
+      default: "-"
+    description: "Print all compiler arguments to the specified location. Use - to echo to the reporter."
+    abbreviations:
+    - "-Xprint-args"
+  - option: "-Vprint-pos"
+    schema:
+      type: "Boolean"
+    description: "Print tree positions, as offsets."
+    abbreviations:
+    - "-Xprint-pos"
+  - option: "-Vprint-types"
+    schema:
+      type: "Boolean"
+    description: "Print tree types (debugging option)."
+    abbreviations:
+    - "-Xprint-types"
+  - option: "-Vquasiquote"
+    schema:
+      type: "Boolean"
+    description: "Trace quasiquotations."
+    abbreviations:
+    - "-Yquasiquote-debug"
+  - option: "-Vreflective-calls"
+    schema:
+      type: "Boolean"
+    description: "Print a message when a reflective method call is generated"
+    abbreviations:
+    - "-Xlog-reflective-calls"
+  - option: "-Vreify"
+    schema:
+      type: "Boolean"
+    description: "Trace reification."
+    abbreviations:
+    - "-Yreify-debug"
+  - option: "-Vshow"
+    schema:
+      type: "Phases"
+      default:
+    description: "(Requires -Xshow-class or -Xshow-object) Show after phases"
+    abbreviations:
+    - "-Yshow"
+  - option: "-Vshow-class"
+    schema:
+      type: "String"
+      arg: "class"
+      default:
+    description: "Show internal representation of class."
+    abbreviations:
+    - "-Xshow-class"
+  - option: "-Vshow-member-pos"
+    schema:
+      type: "String"
+      arg: "output style"
+      default:
+    description: "Show start and end positions of members (implies -Yrangepos)"
+    abbreviations:
+    - "-Yshow-member-pos"
+  - option: "-Vshow-object"
+    schema:
+      type: "String"
+      arg: "object"
+      default:
+    description: "Show internal representation of object."
+    abbreviations:
+    - "-Xshow-object"
+  - option: "-Vshow-symkinds"
+    schema:
+      type: "Boolean"
+    description: "Print abbreviated symbol kinds next to symbol names."
+    abbreviations:
+    - "-Yshow-symkinds"
+  - option: "-Vshow-symowners"
+    schema:
+      type: "Boolean"
+    description: "Print owner identifiers next to symbol names."
+    abbreviations:
+    - "-Yshow-symowners"
+  - option: "-Vstatistics"
+    schema:
+      type: "Phases"
+      default: "parser,typer,patmat,erasure,cleanup,jvm"
+    description: "Print compiler statistics for specific phases phases (default: parser,typer,patmat,erasure,cleanup,jvm)"
+    abbreviations:
+    - "-Ystatistics"
+  - option: "-Vsymbols"
+    schema:
+      type: "Boolean"
+    description: "Print the AST symbol hierarchy after each phase."
+    abbreviations:
+    - "-Yshow-syms"
+  - option: "-Vtyper"
+    schema:
+      type: "Boolean"
+    description: "Trace type assignments."
+    abbreviations:
+    - "-Ytyper-debug"
 - category: "Private Settings"
   description:
   options:
@@ -568,11 +801,6 @@
     schema:
       type: "Boolean"
     description: "Attempt to break cycles encountered during typing"
-  - option: "-Ybrowse"
-    schema:
-      type: "Phases"
-      default:
-    description: "Browse the abstract syntax tree after phases"
   - option: "-Ycache-macro-class-loader"
     schema:
       type: "Choice"
@@ -583,6 +811,8 @@
         description: "Don't cache class loader"
       - choice: "last-modified"
         description: "Cache class loader, using file last-modified time to invalidate"
+      - choice: "always"
+        description: "Cache class loader with no invalidation"
     description: "Policy for caching class loaders for macros that are dynamically loaded. Default: `none`, `help` to list choices."
   - option: "-Ycache-plugin-class-loader"
     schema:
@@ -594,6 +824,8 @@
         description: "Don't cache class loader"
       - choice: "last-modified"
         description: "Cache class loader, using file last-modified time to invalidate"
+      - choice: "always"
+        description: "Cache class loader with no invalidation"
     description: "Policy for caching class loaders for compiler plugins that are dynamically loaded. Default: `none`, `help` to list choices."
   - option: "-Ycheck"
     schema:
@@ -604,10 +836,6 @@
     schema:
       type: "Boolean"
     description: "Use compact tree printer when displaying trees."
-  - option: "-Ydebug"
-    schema:
-      type: "Boolean"
-    description: "Increase the quantity of debugging output."
   - option: "-Ydelambdafy"
     schema:
       type: "Choice"
@@ -616,15 +844,7 @@
       choices:
       - choice: "inline"
       - choice: "method"
-    description: "Strategy used for translating lambdas into JVM code. Choices: (inline,method), default: method."
-  - option: "-YdisableFlatCpCaching"
-    schema:
-      type: "Boolean"
-    description: "Do not cache flat classpath representation of classpath elements from jars across compiler instances."
-  - option: "-Ydoc-debug"
-    schema:
-      type: "Boolean"
-    description: "Trace all scaladoc activity."
+    description: "Strategy used for translating lambdas into JVM code. (inline,[method])"
   - option: "-Ydump-classes"
     schema:
       type: "String"
@@ -637,22 +857,12 @@
       arg: "dir"
       default:
     description: "Generate a parallel output directory of .asmp files (ie ASM Textifier output)."
-  - option: "-Yhot-statistics-enabled"
+  - option: "-Yimports"
     schema:
-      type: "Boolean"
-    description: "Enable `-Ystatistics` to print hot statistics."
-  - option: "-Yide-debug"
-    schema:
-      type: "Boolean"
-    description: "Generate, validate and output trees using the interactive compiler."
-  - option: "-Yinfer-argument-types"
-    schema:
-      type: "Boolean"
-    description: "Infer types for arguments of overridden methods."
-  - option: "-Yissue-debug"
-    schema:
-      type: "Boolean"
-    description: "Print stack traces when a context issues an error."
+      type: "String"
+      arg: "import"
+      multiple: "true"
+    description: "Custom root imports, default is `java.lang,scala,scala.Predef`."
   - option: "-Yjar-compression-level"
     schema:
       type: "Int"
@@ -660,23 +870,16 @@
       min: "-1"
       max: "9"
     description: "compression level to use when writing jar files"
-  - option: "-Ylog"
+  - option: "-Ymacro-annotations"
     schema:
-      type: "Phases"
+      type: "Boolean"
+    description: "Enable support for macro annotations, formerly in macro paradise."
+  - option: "-Ymacro-classpath"
+    schema:
+      type: "Path"
+      arg: "path"
       default:
-    description: "Log operations during phases"
-  - option: "-Ylog-classpath"
-    schema:
-      type: "Boolean"
-    description: "Output information about what classpath is being applied."
-  - option: "-Ymacro-debug-lite"
-    schema:
-      type: "Boolean"
-    description: "Trace essential macro-related activities."
-  - option: "-Ymacro-debug-verbose"
-    schema:
-      type: "Boolean"
-    description: "Trace all macro-related activities: compilation, generation of synthetics, classloading, expansion, exceptions."
+    description: "The classpath used to reflectively load macro implementations, default is the compilation classpath."
   - option: "-Ymacro-expand"
     schema:
       type: "Choice"
@@ -686,19 +889,21 @@
       - choice: "normal"
       - choice: "none"
       - choice: "discard"
-    description: "Control expansion of macros, useful for scaladoc and presentation compiler. Choices: (normal,none,discard), default: normal."
-  - option: "-Ymacro-no-expand"
+    description: "Control expansion of macros, useful for scaladoc and presentation compiler. ([normal],none,discard)"
+  - option: "-Ymacro-global-fresh-names"
     schema:
       type: "Boolean"
-    description: "Don't expand macros. Might be useful for scaladoc and presentation compiler, but will crash anything which uses macros and gets past typer."
-  - option: "-Yno-adapted-args"
-    schema:
-      type: "Boolean"
-    description: "Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver."
+    description: "Should fresh names in macros be unique across all compilation units"
   - option: "-Yno-completion"
     schema:
       type: "Boolean"
     description: "Disable tab-completion in the REPL."
+  - option: "-Yno-flat-classpath-cache"
+    schema:
+      type: "Boolean"
+    description: "Do not cache flat classpath representation of classpath elements from jars across compiler instances."
+    abbreviations:
+    - "-YdisableFlatCpCaching"
   - option: "-Yno-generic-signatures"
     schema:
       type: "Boolean"
@@ -720,35 +925,7 @@
       - choice: "at-inline-annotated"
       - choice: "everything"
       - choice: "default"
-    description: "Set the heuristics for inlining decisions. Choices: (at-inline-annotated,everything,default), default: default."
-  - option: "-Yopt-log-inline"
-    schema:
-      type: "String"
-      arg: "package/Class.method"
-      default:
-    description: "Print a summary of inliner activity; `_` to print all, prefix match to select."
-  - option: "-Yopt-trace"
-    schema:
-      type: "String"
-      arg: "package/Class.method"
-      default:
-    description: "Trace the optimizer progress for methods; `_` to print all, prefix match to select."
-  - option: "-Yoverride-objects"
-    schema:
-      type: "Boolean"
-    description: "Allow member objects to be overridden."
-  - option: "-Yoverride-vars"
-    schema:
-      type: "Boolean"
-    description: "Allow vars to be overridden."
-  - option: "-Ypartial-unification"
-    schema:
-      type: "Boolean"
-    description: "Enable partial unification in type constructor inference"
-  - option: "-Ypatmat-debug"
-    schema:
-      type: "Boolean"
-    description: "Trace pattern matching translation."
+    description: "Set the heuristics for inlining decisions. (at-inline-annotated,everything,[default])"
   - option: "-Ypatmat-exhaust-depth"
     schema:
       type: "Int"
@@ -756,16 +933,23 @@
       min: "10"
       max: "2147483647"
     description: "off"
-  - option: "-Ypos-debug"
+  - option: "-Yprint-trees"
     schema:
-      type: "Boolean"
-    description: "Trace position validation."
+      type: "Choice"
+      arg: "style"
+      default: "text"
+      choices:
+      - choice: "text"
+      - choice: "compact"
+      - choice: "format"
+      - choice: "text+format"
+    description: "How to print trees when -Vprint is enabled. ([text],compact,format,text+format)"
   - option: "-Yprofile-destination"
     schema:
       type: "String"
       arg: "file"
       default:
-    description: "where to send profiling output - specify a file, default is to the console."
+    description: "Profiling output - specify a file or `-` for console."
   - option: "-Yprofile-enabled"
     schema:
       type: "Boolean"
@@ -780,10 +964,12 @@
       type: "Phases"
       default: "_"
     description: "Run a GC between phases - this allows heap size to be accurate at the expense of more time. Specify a list of phases, or all phases (default: _)"
-  - option: "-Yquasiquote-debug"
+  - option: "-Yprofile-trace"
     schema:
-      type: "Boolean"
-    description: "Trace quasiquote-related activities."
+      type: "String"
+      arg: "file"
+      default: "profile.trace"
+    description: "Capture trace of compilation in Chrome Trace format"
   - option: "-Yrangepos"
     schema:
       type: "Boolean"
@@ -799,10 +985,6 @@
     schema:
       type: "Boolean"
     description: "Dump the reified trees in copypasteable representation."
-  - option: "-Yreify-debug"
-    schema:
-      type: "Boolean"
-    description: "Trace reification."
   - option: "-Yrepl-class-based"
     schema:
       type: "Boolean"
@@ -813,10 +995,6 @@
       arg: "path"
       default:
     description: "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)"
-  - option: "-Yrepl-sync"
-    schema:
-      type: "Boolean"
-    description: "Do not use asynchronous code for repl startup"
   - option: "-Yresolve-term-conflict"
     schema:
       type: "Choice"
@@ -826,52 +1004,18 @@
       - choice: "package"
       - choice: "object"
       - choice: "error"
-    description: "Resolve term conflicts. Choices: (package,object,error), default: error."
-  - option: "-Yshow"
-    schema:
-      type: "Phases"
-      default:
-    description: "(Requires -Xshow-class or -Xshow-object) Show after phases"
-  - option: "-Yshow-member-pos"
+    description: "Resolve term conflicts. (package,object,[error])"
+  - option: "-Yscriptrunner"
     schema:
       type: "String"
-      arg: "output style"
-      default:
-    description: "Show start and end positions of members (implies -Yrangepos)"
-  - option: "-Yshow-symkinds"
-    schema:
-      type: "Boolean"
-    description: "Print abbreviated symbol kinds next to symbol names."
-  - option: "-Yshow-symowners"
-    schema:
-      type: "Boolean"
-    description: "Print owner identifiers next to symbol names."
-  - option: "-Yshow-syms"
-    schema:
-      type: "Boolean"
-    description: "Print the AST symbol hierarchy after each phase."
-  - option: "-Yshow-trees"
-    schema:
-      type: "Boolean"
-    description: "(Requires -Xprint:) Print detailed ASTs in formatted form."
-  - option: "-Yshow-trees-compact"
-    schema:
-      type: "Boolean"
-    description: "(Requires -Xprint:) Print detailed ASTs in compact form."
-  - option: "-Yshow-trees-stringified"
-    schema:
-      type: "Boolean"
-    description: "(Requires -Xprint:) Print stringifications along with detailed ASTs."
+      arg: "classname"
+      default: "default"
+    description: "Specify a scala.tools.nsc.ScriptRunner (default, resident, shutdown, or a class name)."
   - option: "-Yskip"
     schema:
       type: "Phases"
       default:
     description: "Skip phases"
-  - option: "-Ystatistics"
-    schema:
-      type: "Phases"
-      default: "parser,typer,patmat,erasure,cleanup,jvm"
-    description: "Print compiler statistics for specific phases phases (default: parser,typer,patmat,erasure,cleanup,jvm)"
   - option: "-Ystop-after"
     schema:
       type: "Phases"
@@ -884,40 +1028,27 @@
       type: "Phases"
       default:
     description: "Stop before phases"
-  - option: "-Ytyper-debug"
-    schema:
-      type: "Boolean"
-    description: "Trace all type assignments."
   - option: "-Yvalidate-pos"
     schema:
       type: "Phases"
       default:
     description: "Validate positions after the given phases (implies -Yrangepos) phases"
-  - option: "-Yvirtpatmat"
-    schema:
-      type: "Boolean"
-    description: "Enable pattern matcher virtualization"
-  - option: "-Ywarn-adapted-args"
-    schema:
-      type: "Boolean"
-    description: "Warn if an argument list is modified to match the receiver."
-  - option: "-Ywarn-dead-code"
+- category: "Warning Settings"
+  description:
+  options:
+  - option: "-Wdead-code"
     schema:
       type: "Boolean"
     description: "Warn when dead code is identified."
-  - option: "-Ywarn-extra-implicit"
+    abbreviations:
+    - "-Ywarn-dead-code"
+  - option: "-Wextra-implicit"
     schema:
       type: "Boolean"
     description: "Warn when more than one implicit parameter section is defined."
-  - option: "-Ywarn-inaccessible"
-    schema:
-      type: "Boolean"
-    description: "Warn about inaccessible types in method signatures."
-  - option: "-Ywarn-infer-any"
-    schema:
-      type: "Boolean"
-    description: "Warn when a type argument is inferred to be `Any`."
-  - option: "-Ywarn-macros"
+    abbreviations:
+    - "-Ywarn-extra-implicit"
+  - option: "-Wmacros"
     schema:
       type: "Choice"
       arg: "mode"
@@ -932,23 +1063,27 @@
       - choice: "both"
         description: "Inspect both user-written code and expanded trees when generating unused symbol warnings."
     description: "Enable lint warnings on macro expansions. Default: `before`, `help` to list choices."
-  - option: "-Ywarn-nullary-override"
-    schema:
-      type: "Boolean"
-    description: "Warn when non-nullary `def f()` overrides nullary `def f`."
-  - option: "-Ywarn-nullary-unit"
-    schema:
-      type: "Boolean"
-    description: "Warn when nullary methods return Unit."
-  - option: "-Ywarn-numeric-widen"
+    abbreviations:
+    - "-Ywarn-macros"
+  - option: "-Wnumeric-widen"
     schema:
       type: "Boolean"
     description: "Warn when numerics are widened."
-  - option: "-Ywarn-self-implicit"
+    abbreviations:
+    - "-Ywarn-numeric-widen"
+  - option: "-Woctal-literal"
+    schema:
+      type: "Boolean"
+    description: "Warn on obsolete octal syntax."
+    abbreviations:
+    - "-Ywarn-octal-literal"
+  - option: "-Wself-implicit"
     schema:
       type: "Boolean"
     description: "Warn when an implicit resolves to an enclosing self-definition."
-  - option: "-Ywarn-unused"
+    abbreviations:
+    - "-Ywarn-self-implicit"
+  - option: "-Wunused"
     schema:
       type: "Choice"
       arg: "warning"
@@ -967,21 +1102,18 @@
       - choice: "implicits"
         description: "Warn if an implicit parameter is unused."
       - choice: "params"
-        description: "Enable -Ywarn-unused:explicits,implicits."
+        description: "Enable -Wunused:explicits,implicits."
       - choice: "linted"
         description: "-Xlint:unused."
-    description: "Enable or disable specific `unused` warnings: `_` for all, `-Ywarn-unused:help` to list choices."
-  - option: "-Ywarn-unused-import"
-    schema:
-      type: "Boolean"
-    description: "Warn when imports are unused."
-  - option: "-Ywarn-value-discard"
+    description: "Enable or disable specific `unused` warnings"
+    abbreviations:
+    - "-Ywarn-unused"
+  - option: "-Wvalue-discard"
     schema:
       type: "Boolean"
     description: "Warn when non-Unit expression results are unused."
-- category: "Warning Settings"
-  description:
-  options:
+    abbreviations:
+    - "-Ywarn-value-discard"
   - option: "-Xlint"
     schema:
       type: "Choice"
@@ -1012,19 +1144,29 @@
         description: "Option.apply used implicit view."
       - choice: "delayedinit-select"
         description: "Selecting member of DelayedInit."
-      - choice: "by-name-right-associative"
-        description: "By-name parameter of right associative operator."
       - choice: "package-object-classes"
         description: "Class or object defined in package object."
-      - choice: "unsound-match"
-        description: "Pattern match may not be typesafe."
       - choice: "stars-align"
         description: "Pattern sequence wildcard must align with sequence component."
       - choice: "constant"
         description: "Evaluation of a constant arithmetic expression results in an error."
       - choice: "unused"
-        description: "Enable -Ywarn-unused:imports,privates,locals,implicits."
-    description: "Enable or disable specific warnings: `_` for all, `-Xlint:help` to list choices."
+        description: "Enable -Wunused:imports,privates,locals,implicits."
+      - choice: "nonlocal-return"
+        description: "A return statement used an exception for flow control."
+      - choice: "implicit-not-found"
+        description: "Check @implicitNotFound and @implicitAmbiguous messages."
+      - choice: "serial"
+        description: "@SerialVersionUID on traits and non-serializable classes."
+      - choice: "valpattern"
+        description: "Enable pattern checks in val definitions."
+      - choice: "eta-zero"
+        description: "Warn on eta-expansion (rather than auto-application) of zero-ary method."
+      - choice: "eta-sam"
+        description: "Warn on eta-expansion to meet a Java-defined functional interface that is not explicitly annotated with @FunctionalInterface."
+      - choice: "deprecation"
+        description: "Enable linted deprecations."
+    description: "Enable recommended warnings"
 - category: "IDE-specific Settings"
   description:
   options:
@@ -1063,3 +1205,4 @@
     schema:
       type: "Boolean"
     description: "Print information about presentation compiler tasks."
+

--- a/_overviews/compiler-options/index.md
+++ b/_overviews/compiler-options/index.md
@@ -49,6 +49,11 @@ scalac [ <options> ] <source files>
 
 E.g. `scalac -encoding utf8 -Xfatal-warnings Hello.scala`
 
+Default paths can be listed by running a command line tool:
+```
+scala scala.tools.util.PathResolver [ <options> ]
+```
+
 
 
 ### Use compiler options with sbt


### PR DESCRIPTION
Run under 2.13, but with local paths elided from output.

More work is needed on the tool side to restore useful text and be convenient to run.

Fixes: https://github.com/scala/docs.scala-lang/issues/1444