### PR TITLE
Add a newer version notice in Collections (Legacy)

### DIFF
--- a/_layouts/inner-page-parent-dropdown.html
+++ b/_layouts/inner-page-parent-dropdown.html
@@ -1,5 +1,6 @@
 {% include headertop.html %}
 {% include headerbottom.html %}
+{% if page.new-version %}<a class="new-version-notice" href="{{ page.new-version }}">This page has a new version.</a>{% endif %}
 
 <div class="navigation-fade-screen"></div>
 

--- a/_layouts/inner-page-parent.html
+++ b/_layouts/inner-page-parent.html
@@ -1,4 +1,5 @@
  {% include headertop.html %} {% include headerbottom.html %}
+ {% if page.new-version %}<a class="new-version-notice" href="{{ page.new-version }}">This page has a new version.</a>{% endif %}
 
 <div class="navigation-fade-screen"></div>
 
@@ -20,7 +21,6 @@
 					<ul class="result-container" id="result-container" style="display: none;"></ul>
 				</div>
 			</div>
-
 		</div>
 	</section>
 

--- a/_overviews/collections/arrays.md
+++ b/_overviews/collections/arrays.md
@@ -5,7 +5,7 @@ title: Arrays
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 10
 

--- a/_overviews/collections/arrays.md
+++ b/_overviews/collections/arrays.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/arrays.html
 
 num: 10
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 [Array](http://www.scala-lang.org/api/{{ site.scala-212-version }}/scala/Array.html) is a special kind of collection in Scala. On the one hand, Scala arrays correspond one-to-one to Java arrays. That is, a Scala array `Array[Int]` is represented as a Java `int[]`, an `Array[Double]` is represented as a Java `double[]` and a `Array[String]` is represented as a Java `String[]`. But at the same time, Scala arrays offer much more than their Java analogues. First, Scala arrays can be _generic_. That is, you can have an `Array[T]`, where `T` is a type parameter or abstract type. Second, Scala arrays are compatible with Scala sequences - you can pass an `Array[T]` where a `Seq[T]` is required. Finally, Scala arrays also support all sequence operations. Here's an example of this in action:
 

--- a/_overviews/collections/arrays.md
+++ b/_overviews/collections/arrays.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 [Array](http://www.scala-lang.org/api/{{ site.scala-212-version }}/scala/Array.html) is a special kind of collection in Scala. On the one hand, Scala arrays correspond one-to-one to Java arrays. That is, a Scala array `Array[Int]` is represented as a Java `int[]`, an `Array[Double]` is represented as a Java `double[]` and a `Array[String]` is represented as a Java `String[]`. But at the same time, Scala arrays offer much more than their Java analogues. First, Scala arrays can be _generic_. That is, you can have an `Array[T]`, where `T` is a type parameter or abstract type. Second, Scala arrays are compatible with Scala sequences - you can pass an `Array[T]` where a `Seq[T]` is required. Finally, Scala arrays also support all sequence operations. Here's an example of this in action:
 
     scala> val a1 = Array(1, 2, 3)

--- a/_overviews/collections/concrete-immutable-collection-classes.md
+++ b/_overviews/collections/concrete-immutable-collection-classes.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/concrete-immutable-collection-classes.html
 
 num: 8
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 Scala provides many concrete immutable collection classes for you to choose from. They differ in the traits they implement (maps, sets, sequences), whether they can be infinite, and the speed of various operations. Here are some of the most common immutable collection types used in Scala.
 

--- a/_overviews/collections/concrete-immutable-collection-classes.md
+++ b/_overviews/collections/concrete-immutable-collection-classes.md
@@ -5,7 +5,7 @@ title: Concrete Immutable Collection Classes
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 8
 

--- a/_overviews/collections/concrete-immutable-collection-classes.md
+++ b/_overviews/collections/concrete-immutable-collection-classes.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 Scala provides many concrete immutable collection classes for you to choose from. They differ in the traits they implement (maps, sets, sequences), whether they can be infinite, and the speed of various operations. Here are some of the most common immutable collection types used in Scala.
 
 ## Lists

--- a/_overviews/collections/concrete-mutable-collection-classes.md
+++ b/_overviews/collections/concrete-mutable-collection-classes.md
@@ -5,7 +5,7 @@ title: Concrete Mutable Collection Classes
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 9
 

--- a/_overviews/collections/concrete-mutable-collection-classes.md
+++ b/_overviews/collections/concrete-mutable-collection-classes.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/concrete-mutable-collection-classes.html
 
 num: 9
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 You've now seen the most commonly used immutable collection classes that Scala provides in its standard library. Take a look now at the mutable collection classes.
 

--- a/_overviews/collections/concrete-mutable-collection-classes.md
+++ b/_overviews/collections/concrete-mutable-collection-classes.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 You've now seen the most commonly used immutable collection classes that Scala provides in its standard library. Take a look now at the mutable collection classes.
 
 ## Array Buffers

--- a/_overviews/collections/conversions-between-java-and-scala-collections.md
+++ b/_overviews/collections/conversions-between-java-and-scala-collections.md
@@ -13,6 +13,11 @@ languages: [zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 Like Scala, Java also has a rich collections library. There are many similarities between the two. For instance, both libraries know iterators, iterables, sets, maps, and sequences. But there are also important differences. In particular, the Scala libraries put much more emphasis on immutable collections, and provide many more operations that transform a collection into a new one.
 
 Sometimes you might need to pass from one collection framework to the other. For instance, you might want to access an existing Java collection as if it were a Scala collection. Or you might want to pass one of Scala's collections to a Java method that expects its Java counterpart. It is quite easy to do this, because Scala offers implicit conversions between all the major collection types in the [JavaConverters](http://www.scala-lang.org/api/{{ site.scala-212-version }}/scala/collection/JavaConverters$.html) object. In particular, you will find bidirectional conversions between the following types.

--- a/_overviews/collections/conversions-between-java-and-scala-collections.md
+++ b/_overviews/collections/conversions-between-java-and-scala-collections.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/conversions-between-java-and-scala-collections.html
 
 num: 17
 
 languages: [zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 Like Scala, Java also has a rich collections library. There are many similarities between the two. For instance, both libraries know iterators, iterables, sets, maps, and sequences. But there are also important differences. In particular, the Scala libraries put much more emphasis on immutable collections, and provide many more operations that transform a collection into a new one.
 

--- a/_overviews/collections/conversions-between-java-and-scala-collections.md
+++ b/_overviews/collections/conversions-between-java-and-scala-collections.md
@@ -5,7 +5,7 @@ title: Conversions Between Java and Scala Collections
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 17
 

--- a/_overviews/collections/creating-collections-from-scratch.md
+++ b/_overviews/collections/creating-collections-from-scratch.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/creating-collections-from-scratch.html
 
 num: 16
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 You have syntax `List(1, 2, 3)` to create a list of three integers and `Map('A' -> 1, 'C' -> 2)` to create a map with two bindings. This is actually a universal feature of Scala collections. You can take any collection name and follow it by a list of elements in parentheses. The result will be a new collection with the given elements. Here are some more examples:
 

--- a/_overviews/collections/creating-collections-from-scratch.md
+++ b/_overviews/collections/creating-collections-from-scratch.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 You have syntax `List(1, 2, 3)` to create a list of three integers and `Map('A' -> 1, 'C' -> 2)` to create a map with two bindings. This is actually a universal feature of Scala collections. You can take any collection name and follow it by a list of elements in parentheses. The result will be a new collection with the given elements. Here are some more examples:
 
     Traversable()             // An empty traversable object

--- a/_overviews/collections/creating-collections-from-scratch.md
+++ b/_overviews/collections/creating-collections-from-scratch.md
@@ -5,7 +5,7 @@ title: Creating Collections From Scratch
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 16
 

--- a/_overviews/collections/equality.md
+++ b/_overviews/collections/equality.md
@@ -5,7 +5,7 @@ title: Equality
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 13
 

--- a/_overviews/collections/equality.md
+++ b/_overviews/collections/equality.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 The collection libraries have a uniform approach to equality and hashing. The idea is, first, to divide collections into sets, maps, and sequences. Collections in different categories are always unequal. For instance, `Set(1, 2, 3)` is unequal to `List(1, 2, 3)` even though they contain the same elements. On the other hand, within the same category, collections are equal if and only if they have the same elements (for sequences: the same elements in the same order). For example, `List(1, 2, 3) == Vector(1, 2, 3)`, and `HashSet(1, 2) == TreeSet(2, 1)`.
 
 It does not matter for the equality check whether a collection is mutable or immutable. For a mutable collection one simply considers its current elements at the time the equality test is performed. This means that a mutable collection might be equal to different collections at different times, depending what elements are added or removed. This is a potential trap when using a mutable collection as a key in a hashmap. Example:

--- a/_overviews/collections/equality.md
+++ b/_overviews/collections/equality.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/creating-collections-from-scratch.html
 
 num: 13
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 The collection libraries have a uniform approach to equality and hashing. The idea is, first, to divide collections into sets, maps, and sequences. Collections in different categories are always unequal. For instance, `Set(1, 2, 3)` is unequal to `List(1, 2, 3)` even though they contain the same elements. On the other hand, within the same category, collections are equal if and only if they have the same elements (for sequences: the same elements in the same order). For example, `List(1, 2, 3) == Vector(1, 2, 3)`, and `HashSet(1, 2) == TreeSet(2, 1)`.
 

--- a/_overviews/collections/introduction.md
+++ b/_overviews/collections/introduction.md
@@ -5,7 +5,7 @@ title: Introduction
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 1
 

--- a/_overviews/collections/introduction.md
+++ b/_overviews/collections/introduction.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/introduction.html
 
 num: 1
 
 languages: [ja, zh-cn, ru]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 **Martin Odersky, and Lex Spoon**
 

--- a/_overviews/collections/introduction.md
+++ b/_overviews/collections/introduction.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn, ru]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 **Martin Odersky, and Lex Spoon**
 
 In the eyes of many, the new collections framework is the most significant

--- a/_overviews/collections/iterators.md
+++ b/_overviews/collections/iterators.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 An iterator is not a collection, but rather a way to access the elements of a collection one by one. The two basic operations on an iterator `it` are `next` and `hasNext`. A call to `it.next()` will return the next element of the iterator and advance the state of the iterator. Calling `next` again on the same iterator will then yield the element one beyond the one returned previously. If there are no more elements to return, a call to `next` will throw a `NoSuchElementException`. You can find out whether there are more elements to return using [Iterator](http://www.scala-lang.org/api/{{ site.scala-212-version }}/scala/collection/Iterator.html)'s `hasNext` method.
 
 The most straightforward way to "step through" all the elements returned by an iterator `it` uses a while-loop:

--- a/_overviews/collections/iterators.md
+++ b/_overviews/collections/iterators.md
@@ -5,7 +5,7 @@ title: Iterators
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 15
 

--- a/_overviews/collections/iterators.md
+++ b/_overviews/collections/iterators.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/iterators.html
 
 num: 15
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 An iterator is not a collection, but rather a way to access the elements of a collection one by one. The two basic operations on an iterator `it` are `next` and `hasNext`. A call to `it.next()` will return the next element of the iterator and advance the state of the iterator. Calling `next` again on the same iterator will then yield the element one beyond the one returned previously. If there are no more elements to return, a call to `next` will throw a `NoSuchElementException`. You can find out whether there are more elements to return using [Iterator](http://www.scala-lang.org/api/{{ site.scala-212-version }}/scala/collection/Iterator.html)'s `hasNext` method.
 

--- a/_overviews/collections/maps.md
+++ b/_overviews/collections/maps.md
@@ -5,7 +5,7 @@ title: Maps
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 7
 

--- a/_overviews/collections/maps.md
+++ b/_overviews/collections/maps.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 A [Map](http://www.scala-lang.org/api/current/scala/collection/Map.html) is an [Iterable](http://www.scala-lang.org/api/current/scala/collection/Iterable.html) consisting of pairs of keys and values (also named _mappings_ or _associations_). Scala's [Predef](http://www.scala-lang.org/api/current/scala/Predef$.html) object offers an implicit conversion that lets you write `key -> value` as an alternate syntax for the pair `(key, value)`. For instance `Map("x" -> 24, "y" -> 25, "z" -> 26)` means exactly the same as `Map(("x", 24), ("y", 25), ("z", 26))`, but reads better.
 
 The fundamental operations on maps are similar to those on sets. They are summarized in the following table and fall into the following categories:

--- a/_overviews/collections/maps.md
+++ b/_overviews/collections/maps.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/maps.html
 
 num: 7
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 A [Map](http://www.scala-lang.org/api/current/scala/collection/Map.html) is an [Iterable](http://www.scala-lang.org/api/current/scala/collection/Iterable.html) consisting of pairs of keys and values (also named _mappings_ or _associations_). Scala's [Predef](http://www.scala-lang.org/api/current/scala/Predef$.html) object offers an implicit conversion that lets you write `key -> value` as an alternate syntax for the pair `(key, value)`. For instance `Map("x" -> 24, "y" -> 25, "z" -> 26)` means exactly the same as `Map(("x", 24), ("y", 25), ("z", 26))`, but reads better.
 

--- a/_overviews/collections/migrating-from-scala-27.md
+++ b/_overviews/collections/migrating-from-scala-27.md
@@ -13,11 +13,6 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
-
 Porting your existing Scala applications to use the new collections should be almost automatic. There are only a couple of possible issues to take care of.
 
 Generally, the old functionality of Scala 2.7 collections has been left in place. Some features have been deprecated, which means they will removed in some future release. You will get a _deprecation warning_ when you compile code that makes use of these features in Scala 2.8. In a few places deprecation was unfeasible, because the operation in question was retained in 2.8, but changed in meaning or performance characteristics. These cases will be flagged with _migration warnings_ when compiled under 2.8. To get full deprecation and migration warnings with suggestions how to change your code, pass the `-deprecation` and `-Xmigration` flags to `scalac` (note that `-Xmigration` is an extended option, so it starts with an `X`). You can also pass the same options to the `scala` REPL to get the warnings in an interactive session. Example:

--- a/_overviews/collections/migrating-from-scala-27.md
+++ b/_overviews/collections/migrating-from-scala-27.md
@@ -5,7 +5,7 @@ title: Migrating from Scala 2.7
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 18
 

--- a/_overviews/collections/migrating-from-scala-27.md
+++ b/_overviews/collections/migrating-from-scala-27.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 Porting your existing Scala applications to use the new collections should be almost automatic. There are only a couple of possible issues to take care of.
 
 Generally, the old functionality of Scala 2.7 collections has been left in place. Some features have been deprecated, which means they will removed in some future release. You will get a _deprecation warning_ when you compile code that makes use of these features in Scala 2.8. In a few places deprecation was unfeasible, because the operation in question was retained in 2.8, but changed in meaning or performance characteristics. These cases will be flagged with _migration warnings_ when compiled under 2.8. To get full deprecation and migration warnings with suggestions how to change your code, pass the `-deprecation` and `-Xmigration` flags to `scalac` (note that `-Xmigration` is an extended option, so it starts with an `X`). You can also pass the same options to the `scala` REPL to get the warnings in an interactive session. Example:

--- a/_overviews/collections/overview.md
+++ b/_overviews/collections/overview.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/overview.html
 
 num: 2
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 Scala collections systematically distinguish between mutable and
 immutable collections. A _mutable_ collection can be updated or

--- a/_overviews/collections/overview.md
+++ b/_overviews/collections/overview.md
@@ -5,7 +5,7 @@ title: Mutable and Immutable Collections
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 2
 

--- a/_overviews/collections/overview.md
+++ b/_overviews/collections/overview.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 Scala collections systematically distinguish between mutable and
 immutable collections. A _mutable_ collection can be updated or
 extended in place. This means you can change, add, or remove elements

--- a/_overviews/collections/performance-characteristics.md
+++ b/_overviews/collections/performance-characteristics.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 The previous explanations have made it clear that different collection types have different performance characteristics. That's often the primary reason for picking one collection type over another. You can see the performance characteristics of some common operations on collections summarized in the following two tables.
 
 Performance characteristics of sequence types:

--- a/_overviews/collections/performance-characteristics.md
+++ b/_overviews/collections/performance-characteristics.md
@@ -5,7 +5,7 @@ title: Performance Characteristics
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 12
 

--- a/_overviews/collections/performance-characteristics.md
+++ b/_overviews/collections/performance-characteristics.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/performance-characteristics.html
 
 num: 12
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 The previous explanations have made it clear that different collection types have different performance characteristics. That's often the primary reason for picking one collection type over another. You can see the performance characteristics of some common operations on collections summarized in the following two tables.
 

--- a/_overviews/collections/seqs.md
+++ b/_overviews/collections/seqs.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/seqs.html
 
 num: 5
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 The [Seq](http://www.scala-lang.org/api/current/scala/collection/Seq.html) trait represents sequences. A sequence is a kind of iterable that has a `length` and whose elements have fixed index positions, starting from `0`.
 

--- a/_overviews/collections/seqs.md
+++ b/_overviews/collections/seqs.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 The [Seq](http://www.scala-lang.org/api/current/scala/collection/Seq.html) trait represents sequences. A sequence is a kind of iterable that has a `length` and whose elements have fixed index positions, starting from `0`.
 
 The operations on sequences, summarized in the table below, fall into the following categories:

--- a/_overviews/collections/seqs.md
+++ b/_overviews/collections/seqs.md
@@ -5,7 +5,7 @@ title: The sequence traits Seq, IndexedSeq, and LinearSeq
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 5
 

--- a/_overviews/collections/sets.md
+++ b/_overviews/collections/sets.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 `Set`s are `Iterable`s that contain no duplicate elements. The operations on sets are summarized in the following table for general sets and in the table after that for mutable sets. They fall into the following categories:
 
 * **Tests** `contains`, `apply`, `subsetOf`. The `contains` method asks whether a set contains a given element. The `apply` method for a set is the same as `contains`, so `set(elem)` is the same as `set contains elem`. That means sets can also be used as test functions that return true for the elements they contain.

--- a/_overviews/collections/sets.md
+++ b/_overviews/collections/sets.md
@@ -5,7 +5,7 @@ title: Sets
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 6
 

--- a/_overviews/collections/sets.md
+++ b/_overviews/collections/sets.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/sets.html
 
 num: 6
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 `Set`s are `Iterable`s that contain no duplicate elements. The operations on sets are summarized in the following table for general sets and in the table after that for mutable sets. They fall into the following categories:
 

--- a/_overviews/collections/strings.md
+++ b/_overviews/collections/strings.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/strings.html
 
 num: 11
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 Like arrays, strings are not directly sequences, but they can be converted to them, and they also support all sequence operations on strings. Here are some examples of operations you can invoke on strings.
 

--- a/_overviews/collections/strings.md
+++ b/_overviews/collections/strings.md
@@ -5,7 +5,7 @@ title: Strings
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 11
 

--- a/_overviews/collections/strings.md
+++ b/_overviews/collections/strings.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 Like arrays, strings are not directly sequences, but they can be converted to them, and they also support all sequence operations on strings. Here are some examples of operations you can invoke on strings.
 
     scala> val str = "hello"

--- a/_overviews/collections/trait-iterable.md
+++ b/_overviews/collections/trait-iterable.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 The next trait from the top in the collections hierarchy is `Iterable`. All methods in this trait are defined in terms of an abstract method, `iterator`, which yields the collection's elements one by one. The `foreach` method from trait `Traversable` is implemented in `Iterable` in terms of `iterator`. Here is the actual implementation:
 
     def foreach[U](f: Elem => U): Unit = {

--- a/_overviews/collections/trait-iterable.md
+++ b/_overviews/collections/trait-iterable.md
@@ -6,17 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/trait-iterable.html
 
 num: 4
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 The next trait from the top in the collections hierarchy is `Iterable`. All methods in this trait are defined in terms of an abstract method, `iterator`, which yields the collection's elements one by one. The `foreach` method from trait `Traversable` is implemented in `Iterable` in terms of `iterator`. Here is the actual implementation:
 

--- a/_overviews/collections/trait-iterable.md
+++ b/_overviews/collections/trait-iterable.md
@@ -5,7 +5,7 @@ title: Trait Iterable
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 4
 

--- a/_overviews/collections/trait-traversable.md
+++ b/_overviews/collections/trait-traversable.md
@@ -13,11 +13,6 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
-<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
-
 At the top of the collection hierarchy is trait `Traversable`. Its only abstract operation is `foreach`:
 
     def foreach[U](f: Elem => U)

--- a/_overviews/collections/trait-traversable.md
+++ b/_overviews/collections/trait-traversable.md
@@ -5,7 +5,7 @@ title: Trait Traversable
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 3
 

--- a/_overviews/collections/trait-traversable.md
+++ b/_overviews/collections/trait-traversable.md
@@ -13,6 +13,11 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version"  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 At the top of the collection hierarchy is trait `Traversable`. Its only abstract operation is `foreach`:
 
     def foreach[U](f: Elem => U)

--- a/_overviews/collections/views.md
+++ b/_overviews/collections/views.md
@@ -6,18 +6,13 @@ discourse: true
 
 partof: collections
 overview-name: Collections (Scala 2.8 - 2.12)
+new-version: /overviews/collections-2.13/views.html
 
 num: 14
 
 languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
-
-<a class="link-to-newer-version" 
-  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
-  See this in Scala 2.13
-  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-</a>
 
 Collections have quite a few methods that construct new collections. Examples are `map`, `filter` or `++`. We call such methods transformers because they take at least one collection as their receiver object and produce another collection as their result.
 

--- a/_overviews/collections/views.md
+++ b/_overviews/collections/views.md
@@ -5,7 +5,7 @@ title: Views
 discourse: true
 
 partof: collections
-overview-name: Collections
+overview-name: Collections (Scala 2.8 - 2.12)
 
 num: 14
 

--- a/_overviews/collections/views.md
+++ b/_overviews/collections/views.md
@@ -13,6 +13,12 @@ languages: [ja, zh-cn]
 permalink: /overviews/collections/:title.html
 ---
 
+<a class="link-to-newer-version" 
+  href="{{ page.url | replace_first: '/collections/', '/collections-2.13/'}}" >
+  See this in Scala 2.13
+  <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+</a>
+
 Collections have quite a few methods that construct new collections. Examples are `map`, `filter` or `++`. We call such methods transformers because they take at least one collection as their receiver object and produce another collection as their result.
 
 There are two principal ways to implement transformers. One is _strict_, that is a new collection with all its elements is constructed as a result of the transformer. The other is non-strict or _lazy_, that is one constructs only a proxy for the result collection, and its elements get constructed only as one demands them.

--- a/_sass/layout/documentation.scss
+++ b/_sass/layout/documentation.scss
@@ -57,3 +57,8 @@
     padding: 1px 5px;
   }
 }
+
+.link-to-newer-version {
+  float: right;
+  padding: 0 0 1em 1em;
+}

--- a/_sass/layout/documentation.scss
+++ b/_sass/layout/documentation.scss
@@ -58,7 +58,9 @@
   }
 }
 
-.link-to-newer-version {
-  float: right;
-  padding: 0 0 1em 1em;
+a.new-version-notice {
+  display: block;
+  background: rgb(255, 255, 200);
+  font-size: large;
+  text-align: center;
 }


### PR DESCRIPTION
Fixes #1121 

There is 2 version of  **"Overviews => Collections"**: one is for Scala 2.13, and the other is for legacy (Scala 2.12 and older).
I think it requires a lot attention to distinguish both of them, since page header are identical.

This PR adds 

- `(Scala 2.8 - 2.12)` to sub title
- A link to newer version of corresponding page

so readers (and search crawlers) know it is old and there is new version.

![link-to-newer](https://user-images.githubusercontent.com/127635/61680147-7d69a380-ad43-11e9-9ac8-633918b842b8.gif)
