### PR TITLE
Add subtitle in <title> so user/crawler know the group the page belongs to.

### DIFF
--- a/_includes/headertop.html
+++ b/_includes/headertop.html
@@ -1,7 +1,11 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+    <title>
+      {% if page.title %}{{ page.title }} | {% endif %}
+      {% if page.overview-name %}{{ page.overview-name }} | {% endif %}
+      {{ site.title }}
+    </title>
     {% if page.description %}
     <meta name="description" content="{{ page.description }}" />
     {% endif %}


### PR DESCRIPTION
Currently, HTML `<title>` in most pages are `{PageTitle} | Scala Documentation`.
However, there are many pages uses exact same page title.

One example is **"Overview"**. It is used 5 times in different contexts: `_overviews/scaladoc/overview.md`, `_overviews/paralllel-collections/overview.md`, `_overviews/reflections/overview.md`, `_overviews/repl/overview.md` and `_style/overview.md`

Another example is 2 version of docs for **"Collections"**, as mentioned in #1456.
Those 2 versions uses same titles.

This PR adds sub title in `<title>` to make it easy to distinguish pages.
I think this improves UX when they share/bookmark pages.
It is also good for SEO, since search crawlers may get confused if the site uses identical titles many times.





