### PR TITLE
Add Twitter card/OGProtocol for sharing pages on SNS

### DIFF
--- a/_includes/headertop.html
+++ b/_includes/headertop.html
@@ -12,6 +12,19 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <meta property="og:site_name" content="{{ site.title }}"/>
+    <meta property="og:type" content="{% if page.url == '/' %}website{% else %}article{% endif %}"/>
+    <meta property="og:url" content="{{ site.url }}{{ page.url }}"/>
+    <meta property="og:image" content="{{ site.url }}/resources/img/scala-spiral-3d-2-toned-down.png"/>
+    <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{site.title}}{% endif %}"/>
+    {% if page.description %}<meta property="og:description" content="{{ page.description }}"/>{% endif %}
+
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:site" content="@scala_lang"/>
+    <meta name="twitter:creator" content="@scala_lang"/>
+    {% if page.title %}<meta property="twitter:title" content="{{ page.title }}"/>{% endif %}
+    {% if page.description %}<meta property="twitter:description" content="{{ page.description }}"/>{% endif %}
+
     <link rel="icon" type="image/png" href="{{ site.baseurl }}/resources/favicon.ico">
     <link rel="shortcut icon" type="image/png" href="{{ site.baseurl }}/resources/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/resources/apple-touch-icon.png">


### PR DESCRIPTION
Add Twitter card & OG Protocol (for Facebook or other SNS) to docs.scala-lang.org.
Those are a rich preview of pages that may attract readers than ordinal text link, and easy to click on touch screen since bigger area.
Those are aledy included in [scala-lang repo](https://github.com/scala/scala-lang/blob/c63ea9892628a3e37ddcea6fa999132b8d42fff3/_includes/headertop.html)

![image](https://user-images.githubusercontent.com/127635/62167449-37719880-b35e-11e9-89f4-c273874b99dc.png)

