### PR TITLE
Fix property name in Twitter card

### DIFF
--- a/_includes/headertop.html
+++ b/_includes/headertop.html
@@ -22,8 +22,8 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@scala_lang"/>
     <meta name="twitter:creator" content="@scala_lang"/>
-    {% if page.title %}<meta property="twitter:title" content="{{ page.title }}"/>{% endif %}
-    {% if page.description %}<meta property="twitter:description" content="{{ page.description }}"/>{% endif %}
+    {% if page.title %}<meta name="twitter:title" content="{{ page.title }}"/>{% endif %}
+    {% if page.description %}<meta name="twitter:description" content="{{ page.description }}"/>{% endif %}
 
     <link rel="icon" type="image/png" href="{{ site.baseurl }}/resources/favicon.ico">
     <link rel="shortcut icon" type="image/png" href="{{ site.baseurl }}/resources/favicon.ico">


### PR DESCRIPTION
Follow up of #1468 

Twitter card should use `<meta name="..." />`
https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary