### PR TITLE
Switch code blocks to GFM style

### DIFF
--- a/_sips/sip-template.md
+++ b/_sips/sip-template.md
@@ -42,7 +42,7 @@ want to get involved.
 
 Code heavy description of how the library functionality can be used.
 
-{% highlight scala %}
+```scala
 // here is some example scala code, highlighted nicely
 import scala.concurrent._
 
@@ -50,7 +50,7 @@ class Foo extends Bar {
   val x = 10
   def yo(name: String): String = s"hello $name"
 }
-{% endhighlight %}
+```
 
 ### Comparison Examples
 

--- a/_sips/sip-tutorial.md
+++ b/_sips/sip-tutorial.md
@@ -36,9 +36,9 @@ If you would like a starting point, clone the [SIP Template](./sip-template.html
 
 See the [source](https://github.com/scala/docs.scala-lang/blob/master/_sips/sip-template.md) for this document (`sip-tutorial.md`) for how to do syntax highlighting.
 
-{% highlight scala %}
+```scala
 class Foo
-{% endhighlight %}
+```
 
 
 ## Testing changes ##


### PR DESCRIPTION
The `{% highlight scala %} {code} {% endhighlight %}` construct is no longer needed, see https://github.com/scala/docs.scala-lang/issues/689.