### PR TITLE
Make 'More Resources' label translatable, with ja and zh-cn translations.

### DIFF
--- a/_includes/masthead-documentation.html
+++ b/_includes/masthead-documentation.html
@@ -47,7 +47,7 @@
           </div>
           <div class="more-resources">&nbsp;
             {% if section.more-resources %}
-              <span class="heading">More Resources: </span>
+              <span class="heading">{{ page.more-resources-label }}: </span>
               <ul>
               {% for resource in section.more-resources %}
                 <li><a href="{{ site.baseurl }}{{ resource.url }}">{{ resource.title }}</a></li>

--- a/_ja/index.md
+++ b/_ja/index.md
@@ -6,6 +6,7 @@ partof: documentation
 discourse: true
 
 # Content masthead links
+more-resources-label: その他のリソース
 sections:
 
   - title: "最初のステップ"

--- a/_zh-cn/index.md
+++ b/_zh-cn/index.md
@@ -6,6 +6,7 @@ partof: documentation
 discourse: true
 
 # Content masthead links
+more-resources-label: 更多资源
 sections:
 
   - title: "第一步..."

--- a/index.md
+++ b/index.md
@@ -5,8 +5,8 @@ languages: [ja, zh-cn]
 namespace: root
 partof: documentation
 discourse: true
-
 # Content masthead links
+more-resources-label: More Resources
 sections:
 
   - title: "First Steps..."


### PR DESCRIPTION
![index_more_resources_label](https://user-images.githubusercontent.com/4261431/63224334-2ac1c100-c1f5-11e9-805f-6c349409bf7e.gif)
