### PR TITLE
Added missing argument when calling extension method equals

### DIFF
--- a/_sips/sips/2012-01-30-value-classes.md
+++ b/_sips/sips/2012-01-30-value-classes.md
@@ -163,7 +163,7 @@ In our example, the `Meter` class would be expanded as follows:
         override def toString: String =
            Meter.extension$toString(this)
         override def equals(other: Any) =
-           Meter.extension$equals(this)
+           Meter.extension$equals(this, other)
         override def hashCode =
            Meter.extension$hashCode(this)
     }
@@ -333,7 +333,7 @@ After all 4 steps the `Meter` class is translated to the following code.
        override def toString: String =
          Meter.extension$toString(this.underlying)
        override def equals(other: Any) =
-         Meter.extension$equals(this)
+         Meter.extension$equals(this, other)
        override def hashCode =
          Meter.extension$hashCode(this)
     }


### PR DESCRIPTION
Examples of how classes are translated to method extensions are missing an argument to the equals extension method