### PR TITLE
Update scala-for-java-programmers.md

### DIFF
--- a/_overviews/tutorials/scala-for-java-programmers.md
+++ b/_overviews/tutorials/scala-for-java-programmers.md
@@ -330,7 +330,7 @@ We can call overridden `toString` method as below.
     object ComplexNumbers {
       def main(args: Array[String]): Unit = {
         val c = new Complex(1.2, 3.4)
-        println("Overridden toString(): " + c.toString)
+        println("Overridden toString(): " + c.toString())
       }
     }
 


### PR DESCRIPTION
In line 333, shouldn't the call to method "tostring" include parenthesis since the redefinition of "tostring" method in Class "Complex" includes parenthesis? This is in regard to be consistent with lines 294-305.