### PR TITLE
Remove 'new' keyword when creating instances of case class

### DIFF
--- a/_ba/tour/inner-classes.md
+++ b/_ba/tour/inner-classes.md
@@ -22,7 +22,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Node] = Nil
     def connectTo(node: Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }
@@ -75,7 +75,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Graph#Node] = Nil
     def connectTo(node: Graph#Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }

--- a/_ba/tour/lower-type-bounds.md
+++ b/_ba/tour/lower-type-bounds.md
@@ -68,6 +68,6 @@ case class EuropeanSwallow() extends Bird
 
 val africanSwallowList= ListNode[AfricanSwallow](AfricanSwallow(), Nil())
 val birdList: Node[Bird] = africanSwallowList
-birdList.prepend(new EuropeanSwallow)
+birdList.prepend(EuropeanSwallow())
 ```
 `Node[Bird]` može biti dodijeljena `africanSwallowList` ali onda prihvatiti `EuropeanSwallow`e.

--- a/_es/tour/inner-classes.md
+++ b/_es/tour/inner-classes.md
@@ -16,7 +16,7 @@ En Scala es posible que las clases tengan como miembro otras clases. A diferenci
       class Node {
         var connectedNodes: List[Node] = Nil
         def connectTo(node: Node) {
-          if (connectedNodes.find(node.equals).isEmpty) {
+          if (!connectedNodes.exists(node.equals)) {
             connectedNodes = node :: connectedNodes
           }
         }
@@ -71,7 +71,7 @@ Por favor note que en Java la última linea del ejemplo anterior hubiese sido co
       class Node {
         var connectedNodes: List[Graph#Node] = Nil   // Graph#Node en lugar de Node
         def connectTo(node: Graph#Node) {
-          if (connectedNodes.find(node.equals).isEmpty) {
+          if (!connectedNodes.exists(node.equals)) {
             connectedNodes = node :: connectedNodes
           }
         }

--- a/_ja/tour/inner-classes.md
+++ b/_ja/tour/inner-classes.md
@@ -25,7 +25,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Node] = Nil
     def connectTo(node: Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }
@@ -75,7 +75,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Graph#Node] = Nil
     def connectTo(node: Graph#Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }

--- a/_ja/tour/lower-type-bounds.md
+++ b/_ja/tour/lower-type-bounds.md
@@ -69,7 +69,7 @@ case class EuropeanSwallow() extends Bird
 
 val africanSwallowList= ListNode[AfricanSwallow](AfricanSwallow(), Nil())
 val birdList: Node[Bird] = africanSwallowList
-birdList.prepend(new EuropeanSwallow)
+birdList.prepend(EuropeanSwallow())
 ```
 `Node[Bird]`は`africanSwallowList`をアサインできますが、その後`EuropeanSwallow`を受け入れられます。
 

--- a/_ja/tour/singleton-objects.md
+++ b/_ja/tour/singleton-objects.md
@@ -76,7 +76,7 @@ object Circle {
   private def calculateArea(radius: Double): Double = Pi * pow(radius, 2.0)
 }
 
-val circle1 = new Circle(5.0)
+val circle1 = Circle(5.0)
 
 circle1.area
 ```

--- a/_ko/tour/inner-classes.md
+++ b/_ko/tour/inner-classes.md
@@ -16,7 +16,7 @@ previous-page: lower-type-bounds
       class Node {
         var connectedNodes: List[Node] = Nil
         def connectTo(node: Node) {
-          if (connectedNodes.find(node.equals).isEmpty) {
+          if (!connectedNodes.exists(node.equals)) {
             connectedNodes = node :: connectedNodes
           }
         }
@@ -70,7 +70,7 @@ previous-page: lower-type-bounds
       class Node {
         var connectedNodes: List[Graph#Node] = Nil
         def connectTo(node: Graph#Node) {
-          if (connectedNodes.find(node.equals).isEmpty) {
+          if (!connectedNodes.exists(node.equals)) {
             connectedNodes = node :: connectedNodes
           }
         }

--- a/_pl/tour/inner-classes.md
+++ b/_pl/tour/inner-classes.md
@@ -16,7 +16,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Node] = Nil
     def connectTo(node: Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }
@@ -79,7 +79,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Graph#Node] = Nil
     def connectTo(node: Graph#Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }

--- a/_pt-br/tour/inner-classes.md
+++ b/_pt-br/tour/inner-classes.md
@@ -16,7 +16,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Node] = Nil
     def connectTo(node: Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }
@@ -78,7 +78,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Graph#Node] = Nil
     def connectTo(node: Graph#Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }

--- a/_ru/tour/inner-classes.md
+++ b/_ru/tour/inner-classes.md
@@ -22,7 +22,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Node] = Nil
     def connectTo(node: Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }
@@ -66,7 +66,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Graph#Node] = Nil
     def connectTo(node: Graph#Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }

--- a/_ru/tour/lower-type-bounds.md
+++ b/_ru/tour/lower-type-bounds.md
@@ -65,6 +65,6 @@ case class EuropeanSwallow() extends Bird
 
 val africanSwallowList= ListNode[AfricanSwallow](AfricanSwallow(), Nil())
 val birdList: Node[Bird] = africanSwallowList
-birdList.prepend(new EuropeanSwallow)
+birdList.prepend(EuropeanSwallow())
 ```
 `Node[Bird]` может быть присвоен `africanSwallowList` , но затем может добавлять и `EuropeanSwallow`.

--- a/_ru/tour/singleton-objects.md
+++ b/_ru/tour/singleton-objects.md
@@ -66,7 +66,7 @@ object Circle {
   private def calculateArea(radius: Double): Double = Pi * pow(radius, 2.0)
 }
 
-val circle1 = new Circle(5.0)
+val circle1 = Circle(5.0)
 
 circle1.area
 ```

--- a/_tour/inner-classes.md
+++ b/_tour/inner-classes.md
@@ -19,7 +19,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Node] = Nil
     def connectTo(node: Node): Unit = {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }
@@ -63,7 +63,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Graph#Node] = Nil
     def connectTo(node: Graph#Node): Unit = {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }

--- a/_tour/lower-type-bounds.md
+++ b/_tour/lower-type-bounds.md
@@ -62,6 +62,6 @@ case class EuropeanSwallow() extends Bird
 
 val africanSwallowList= ListNode[AfricanSwallow](AfricanSwallow(), Nil())
 val birdList: Node[Bird] = africanSwallowList
-birdList.prepend(new EuropeanSwallow)
+birdList.prepend(EuropeanSwallow())
 ```
 The `Node[Bird]` can be assigned the `africanSwallowList` but then accept `EuropeanSwallow`s.

--- a/_tour/singleton-objects.md
+++ b/_tour/singleton-objects.md
@@ -66,7 +66,7 @@ object Circle {
   private def calculateArea(radius: Double): Double = Pi * pow(radius, 2.0)
 }
 
-val circle1 = new Circle(5.0)
+val circle1 = Circle(5.0)
 
 circle1.area
 ```

--- a/_zh-cn/tour/inner-classes.md
+++ b/_zh-cn/tour/inner-classes.md
@@ -20,7 +20,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Node] = Nil
     def connectTo(node: Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }
@@ -64,7 +64,7 @@ class Graph {
   class Node {
     var connectedNodes: List[Graph#Node] = Nil
     def connectTo(node: Graph#Node) {
-      if (connectedNodes.find(node.equals).isEmpty) {
+      if (!connectedNodes.exists(node.equals)) {
         connectedNodes = node :: connectedNodes
       }
     }

--- a/_zh-cn/tour/lower-type-bounds.md
+++ b/_zh-cn/tour/lower-type-bounds.md
@@ -62,6 +62,6 @@ case class EuropeanSwallow() extends Bird
 
 val africanSwallowList= ListNode[AfricanSwallow](AfricanSwallow(), Nil())
 val birdList: Node[Bird] = africanSwallowList
-birdList.prepend(new EuropeanSwallow)
+birdList.prepend(EuropeanSwallow())
 ```
 可以为 `Node[Bird]` 赋值 `africanSwallowList`，然后再加入一个 `EuropeanSwallow`。

--- a/_zh-cn/tour/singleton-objects.md
+++ b/_zh-cn/tour/singleton-objects.md
@@ -68,7 +68,7 @@ object Circle {
   private def calculateArea(radius: Double): Double = Pi * pow(radius, 2.0)
 }
 
-val circle1 = new Circle(5.0)
+val circle1 = Circle(5.0)
 
 circle1.area
 ```


### PR DESCRIPTION
Remove 'new' keyword when creating instances of 'Circle' class in 'Singleton Objects' section.

Class 'Circle' is defined as case class in given code segment.
Using 'new' keyword is redundant when creating instances of case class
as explained in section 'Case Classes'.