### PR TITLE
Fixing SalaryRaiser

### DIFF
--- a/_tour/higher-order-functions.md
+++ b/_tour/higher-order-functions.md
@@ -90,7 +90,7 @@ object SalaryRaiser {
   def smallPromotion(salaries: List[Double]): List[Double] =
     promotion(salaries, salary => salary * 1.1)
 
-  def bigPromotion(salaries: List[Double]): List[Double] =
+  def greatPromotion(salaries: List[Double]): List[Double] =
     promotion(salaries, salary => salary * math.log(salary))
 
   def hugePromotion(salaries: List[Double]): List[Double] =


### PR DESCRIPTION
First SalaryRaiser class had smallPromotion, greatPromotion, hugePromotion.
Second one had smallPromotion, bigPromotion, hugePromotion.
So I changed the second class to match the functions in the first class.