### PR TITLE
Double dollar syntax in string interpolation docs

### DIFF
--- a/_overviews/core/string-interpolation.md
+++ b/_overviews/core/string-interpolation.md
@@ -42,6 +42,11 @@ String interpolators can also take arbitrary expressions.  For example:
 
 will print the string `1 + 1 = 2`.  Any arbitrary expression can be embedded in `${}`.
 
+To represent an actual dollar sign you can double it `$$`, like here:
+
+    println(s"New offers starting at $$14.99")
+    
+which will print the string `New offers starting at $14.99`.
 
 ### The `f` Interpolator
 


### PR DESCRIPTION
Hey, I realized the feature of Scala with the double dollar signs to produce a single dollar sign in an interpolated string is not documented anywhere as far as I can tell. So I think it should be mentioned in the docs here to give developers that stumble upon it in the wild a change to decipher it.