### PR TITLE
Fix(Algolia): guard the algolia search script execution if div does not exist

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -100,13 +100,16 @@ $(document).ready(function() {
 
 <!-- Alogolia search for doc -->
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-<script type="text/javascript"> docsearch({
-apiKey: 'fbc439670f5d4e3730cdcb715c359391',
-indexName: 'scala-lang',
-inputSelector: '#doc-search-bar',
-algoliaOptions: { 'facetFilters': ["language:en"] },
-debug: false // Set debug to true if you want to inspect the dropdown
-});
+<script type="text/javascript">
+if ($("#doc-search-bar").length) {
+  docsearch({
+    apiKey: 'fbc439670f5d4e3730cdcb715c359391',
+    indexName: 'scala-lang',
+    inputSelector: '#doc-search-bar',
+    algoliaOptions: { 'facetFilters': ["language:en"] },
+    debug: false // Set debug to true if you want to inspect the dropdown
+  });
+}
 </script>
 </body>
 


### PR DESCRIPTION
## Desctiption

Many pages has JavaScript error `No input element in the page matches #doc-search-bar` caused by not found `<div class="search-container">`.

![js-error](https://user-images.githubusercontent.com/11273093/65980363-eee77000-e4b1-11e9-9b5f-45e5c25475ef.jpg)

Because current all pages include JavaScipt for `Algolia search`. But, many pages hasn't `<div class="search-container">`.

That script is no need if a page hasn't following the search field.

![search-input](https://user-images.githubusercontent.com/11273093/65980372-f73fab00-e4b1-11e9-8f62-1ea291d99e56.jpg)

## Solution

Divide JavaScipt and CSS for Algolia into other `_includes` template.

## Question

I created `_scripts` and `_styles` directory under the `_includes` directory and I put the Algolia's JavaScript and CSS to these directories. Is it no problem? Should I put them to under the `_includes` directly? Which is better?

---

Thanks :)