### PR TITLE
Fix incorrect verb form (Spanish)

### DIFF
--- a/_es/tour/tour-of-scala.md
+++ b/_es/tour/tour-of-scala.md
@@ -31,7 +31,7 @@ Scala cuenta con un expresivo sistema de tipado que fuerza estáticamente las ab
 * [implicit conversions](implicit-conversions.html)
 * [métodos polimórficos](polymorphic-methods.html)
 
-El [mecanismo de inferencia de tipos locales](type-inference.html) se encarga de que el usuario no tengan que anotar el programa con información redundante de tipado. Combinadas, estas características proveen una base poderosa para el reuso seguro de abstracciones de programación y para la extensión segura (en cuanto a tipos) de software.
+El [mecanismo de inferencia de tipos locales](type-inference.html) se encarga de que el usuario no tenga que anotar el programa con información redundante de tipado. Combinadas, estas características proveen una base poderosa para el reuso seguro de abstracciones de programación y para la extensión segura (en cuanto a tipos) de software.
 
 ## Scala es extensible ##
 


### PR DESCRIPTION
I've found an incorrect form implementation of the verb 'tener' in spanish version of Introduction | Tour of Scala page.