### PR TITLE
grammar and consistency fix

### DIFF
--- a/_getting-started/sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.md
+++ b/_getting-started/sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.md
@@ -36,13 +36,13 @@ create a project called "hello-world".
 
 ```
 - hello-world
-    - project (sbt uses this to install manage plugins and dependencies)
+    - project (sbt uses this to install and manage plugins and dependencies)
         - build.properties
     - src
         - main
             - scala (All of your scala code goes here)
-                -Main.scala (Entry point of program) <-- this is all we need for now
-    build.sbt (sbt's build definition file)
+                - Main.scala (Entry point of program) <-- this is all we need for now
+    - build.sbt (sbt's build definition file)
 ```
 
 After you build your project, sbt will create more `target` directories


### PR DESCRIPTION
line 39: `- project (sbt uses this to install manage plugins and dependencies)` should be:
              `- project (sbt uses this to install and manage plugins and dependencies)`
still doesn't sound quite good (too many "and"s), but is accurate.

Lines 44-45: Each file/function starts with a `- ` followed by a space.  Line 44 has a `-` but no space, line 45 doesn't have any `- `