### PR TITLE
Make immutable point clearer

### DIFF
--- a/_tour/case-classes.md
+++ b/_tour/case-classes.md
@@ -25,7 +25,7 @@ Notice how the keyword `new` was not used to instantiate the `Book` case class. 
 When you create a case class with parameters, the parameters are public `val`s.
 ```
 case class Message(sender: String, recipient: String, body: String)
-val message1 = Message("guillaume@quebec.ca", "jorge@catalonia.es", "Ça va ?")
+var message1 = Message("guillaume@quebec.ca", "jorge@catalonia.es", "Ça va ?")
 
 println(message1.sender)  // prints guillaume@quebec.ca
 message1.sender = "travis@washington.us"  // this line does not compile


### PR DESCRIPTION
I think having `message1` be a mutable `var` makes the point clearer that case classes' elements are immutable `val`s by default.  If `message1` is a `val`, readers may think the immutability comes from the larger instance `message1` being immutable.

P.S. You could also make a point that the opposite is true too.  If you define `Message` like
```
case class Message(var sender: String, recipient: String, Body: String)
```
and instantiate `message1` to be a `val`, then `message1.sender` is still a mutable `var`