### PR TITLE
Give more visibility to the Scala book

### DIFF
--- a/_data/doc-nav-header.yml
+++ b/_data/doc-nav-header.yml
@@ -14,12 +14,12 @@
       url: "/getting-started/index.html"
     - title: Tour of Scala
       url: "/tour/tour-of-scala.html"
+    - title: Scala Book
+      url: "/overviews/scala-book/introduction.html"
     - title: Scala for Java Programmers
       url: "/tutorials/scala-for-java-programmers.html"
     - title: Online Resources
       url: "/learn.html"
-    - title: Scala Book
-      url: "/overviews/scala-book/introduction.html"
 - title: Reference
   url: "#"
   submenu:

--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -58,6 +58,7 @@ Scala project. -->
 Once you've finished these tutorials, check out
 
 * [The Tour of Scala](/tour/tour-of-scala.html) for bite-sized introductions to Scala's features.
+* [The Scala Book](/overviews/scala-book/introduction.html), which provides a set of short lessons introducing Scala’s main features.
 * [Learning Resources](/learn.html), which includes online interactive tutorials and courses.
 * [Our list of some popular Scala books](/books.html).
 

--- a/index.md
+++ b/index.md
@@ -19,10 +19,10 @@ sections:
         description: "Bite-sized introductions to core language features."
         icon: "fa fa-flag"
         link: /tour/tour-of-scala.html
-      - title: "Scala for Java Programmers"
-        description: "A quick introduction to Scala for those with a Java background."
-        icon: "fa fa-coffee"
-        link: /tutorials/scala-for-java-programmers.html
+      - title: "Scala Book"
+        description: "An online book introducing the main language features."
+        icon: "fa fa-book"
+        link: /overviews/scala-book/introduction.html
     more-resources:
       - title: Online Courses, Exercises, & Blogs
         url: /learn.html


### PR DESCRIPTION
- Replace the “Scala for Java Programmers” tutorial link in the front page with a link to the Scala book,
  ![Screenshot from 2019-10-29 15-24-35](https://user-images.githubusercontent.com/332812/67776243-5c120500-fa60-11e9-93a7-79e0f07d784f.png)
- Move higher up the Scala book entry in the Learn menu,
  ![Screenshot from 2019-10-29 15-24-09](https://user-images.githubusercontent.com/332812/67776278-659b6d00-fa60-11e9-837d-611df3ca4334.png)
- Mention the Scala book as a next learning resource to read, in the Getting Started page.
  ![Screenshot from 2019-10-29 15-23-54](https://user-images.githubusercontent.com/332812/67776302-6cc27b00-fa60-11e9-84a9-9ecf0bc8ab12.png)
