### PR TITLE
fix typo in case-objects.md

### DIFF
--- a/_overviews/scala-book/case-objects.md
+++ b/_overviews/scala-book/case-objects.md
@@ -37,7 +37,7 @@ object FileUtils {
 }
 ```
 
-This is a common way way of using the Scala `object` construct.
+This is a common way of using the Scala `object` construct.
 
 
 


### PR DESCRIPTION
I have found typo in case-objects.md.
I'm sorry in advance if it's intended expression.