### PR TITLE
Fix definition of narrow in SIP-23

### DIFF
--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -99,7 +99,7 @@ Lightbend Scala compiler.
   ```
   def wide[T](t: T): T = t
   wide(13)                           // result is 13: Int
-  def narrow[T <: Singleton](t: T): T = t
+  def narrow[T <: Singleton](t: T): T {} = t
   narrow(23)                         // result is 23: 23
   ```
 
@@ -471,7 +471,7 @@ applications which work with large datasets.
   ```
   def wide[T](t: T): T = t
   wide(13)                           // result is 13: Int
-  def narrow[T <: Singleton](t: T): T = t
+  def narrow[T <: Singleton](t: T): T {} = t
   narrow(23)                         // result is 23: 23
   ```
 


### PR DESCRIPTION
In SIP-23 there is a function defined:
```scala
def narrow[T <: Singleton](t: T): T = t
```
Using it to form a tuple appears to still return a wide type:
```
scala> val xt = (narrow(23), narrow(42))
xt: (Int, Int) = (23,42)
```
But if one changes the return type from `T` to `T {}` in, say, a `narrower` function:
```scala
def narrower[T <: Singleton](t: T): T {} = t
```
A tuple of literal types appears:
```
scala> val yt = (narrower(23), narrower(42))
yt: (23, 42) = (23,42)
```

Additionally the `T {}` return type is used in [sip23-narrow.scala](https://github.com/scala/scala/blob/4c6c6768e1511e1b62ef5302589f4aca8654015a/test/files/pos/sip23-narrow.scala#L6).