### PR TITLE
Add information about unapply method

### DIFF
--- a/_tour/extractor-objects.md
+++ b/_tour/extractor-objects.md
@@ -32,7 +32,7 @@ customer1ID match {
 }
 ```
 
-The `apply` method creates a `CustomerID` string from a `name`. The `unapply` does the inverse to get the `name` back. When we call `CustomerID("Sukyoung")`, this is shorthand syntax for calling `CustomerID.apply("Sukyoung")`. When we call `case CustomerID(name) => println(name)`, we're calling the unapply method.
+The `apply` method creates a `CustomerID` string from a `name`. The `unapply` does the inverse to get the `name` back. When we call `CustomerID("Sukyoung")`, this is shorthand syntax for calling `CustomerID.apply("Sukyoung")`. When we call `case CustomerID(name) => println(name)`, we're calling the unapply method with `CustomerID.unapply(customer1ID)`.
 
 Since a value definition can use a pattern to introduce a new variable, an extractor can be used to initialize the variable, where the unapply method supplies the value.
 


### PR DESCRIPTION
The documentation currently just states "we're calling the unapply method", without giving any indication to *how* it's being called initially.  Saying something like "we're calling the unapply method with `CustomerID.unapply(customer1ID)`" or "we're calling the unapply method with `name=CustomerID.unapply(customer1ID)`" earlier, while maybe not strictly accurate, helps give readers a better understanding of what's going on.  I think we should move (or copy) the section that starts with "This is equivalent to..." up above, and reiterate the point below.  I know for me personally I found this very confusing, and a line or two about this earlier would have been very helpful.