### PR TITLE
Fix a little bug in the example code

### DIFF
--- a/_overviews/scala-book/match-expressions.md
+++ b/_overviews/scala-book/match-expressions.md
@@ -226,8 +226,8 @@ Here are a few other examples of how you can use `if` expressions in `case` stat
 ```scala
 i match {
   case a if 0 to 9 contains a => println("0-9 range: " + a)
-  case b if 10 to 19 contains b => println("10-19 range: " + a)
-  case c if 20 to 29 contains c => println("20-29 range: " + a)
+  case b if 10 to 19 contains b => println("10-19 range: " + b)
+  case c if 20 to 29 contains c => println("20-29 range: " + c)
   case _ => println("Hmmm...")
 }
 ```


### PR DESCRIPTION
The variable (a, b, c) in each case should be matched the variable printed out.