### PR TITLE
Two changes to Scala Book files (comments, break tags)

### DIFF
--- a/_overviews/scala-book/built-in-types.md
+++ b/_overviews/scala-book/built-in-types.md
@@ -49,13 +49,13 @@ Those data types and their ranges are:
 | Data Type     | Possible Values |
 | ------------- | --------------- |
 | Boolean       | `true` or `false` |
-| Byte          | 8-bit signed two’s complement integer (-2^7 to 2^7-1, inclusive)<br>-128 to 127   |
-| Short         | 16-bit signed two’s complement integer (-2^15 to 2^15-1, inclusive)<br>32,768 to 32,767 
-| Int           | 32-bit two’s complement integer (-2^31 to 2^31-1, inclusive)<br>2,147,483,648 to 2,147,483,647 | 
-| Long          | 64-bit two’s complement integer (-2^63 to 2^63-1, inclusive)<br>(-2^63 to 2^63-1, inclusive)   |
-| Float         | 32-bit IEEE 754 single-precision float<br>1.40129846432481707e-45 to 3.40282346638528860e+38 |
-| Double        | 64-bit IEEE 754 double-precision float<br>4.94065645841246544e-324d to 1.79769313486231570e+308d |
-| Char          | 16-bit unsigned Unicode character (0 to 2^16-1, inclusive)<br>0 to 65,535 |
+| Byte          | 8-bit signed two’s complement integer (-2^7 to 2^7-1, inclusive)<br/>-128 to 127   |
+| Short         | 16-bit signed two’s complement integer (-2^15 to 2^15-1, inclusive)<br/>32,768 to 32,767 
+| Int           | 32-bit two’s complement integer (-2^31 to 2^31-1, inclusive)<br/>2,147,483,648 to 2,147,483,647 | 
+| Long          | 64-bit two’s complement integer (-2^63 to 2^63-1, inclusive)<br/>(-2^63 to 2^63-1, inclusive)   |
+| Float         | 32-bit IEEE 754 single-precision float<br/>1.40129846432481707e-45 to 3.40282346638528860e+38 |
+| Double        | 64-bit IEEE 754 double-precision float<br/>4.94065645841246544e-324d to 1.79769313486231570e+308d |
+| Char          | 16-bit unsigned Unicode character (0 to 2^16-1, inclusive)<br/>0 to 65,535 |
 | String        | a sequence of `Char` |
 
 

--- a/_overviews/scala-book/case-classes.md
+++ b/_overviews/scala-book/case-classes.md
@@ -168,13 +168,6 @@ res1: Boolean = false
 
 These methods also let you easily use your objects in collections like sets and maps.
 
-<!-- 
-case class Person(name: String, relation: String)
-val christina = Person("Christina", "niece")
-val hannah = Person("Hannah", "niece")
-christina == hannah
--->
-
 
 
 ## `toString` methods

--- a/_overviews/scala-book/case-objects.md
+++ b/_overviews/scala-book/case-objects.md
@@ -49,13 +49,6 @@ A `case object` is like an `object`, but just like a case class has more feature
 - It has a default `hashCode` implementation
 - It has an improved `toString` implementation
 
-<!--
-These features make a case object useful when you don’t know how it will be used by other developers, such as if it will be sent across a network, or even referenced in a different JVM (such as with the [Akka](https://akka.io/) actors platform, where you can send messages between JVM instances).
-
-https://doc.akka.io/docs/akka/new-docs-quickstart-snapshot/define-actors.html
-“Case classes and case objects make excellent messages since they are immutable and have support for pattern matching.”
--->
-
 Because of these features, case objects are primarily used in two places (instead of regular objects):
 
 - When creating enumerations
@@ -95,21 +88,6 @@ case class Pizza (
     toppings: Seq[Topping]
 )
 ```
-
-<!--
-// this works, implying that 'case' isn't needed for pattern-matching
-sealed trait CrustSize
-object SmallCrustSize extends CrustSize
-object MediumCrustSize extends CrustSize
-object LargeCrustSize extends CrustSize
-
-def poop(cs: CrustSize): Unit = cs match {
-    case SmallCrustSize  => println("small")
-    case MediumCrustSize => println("medium")
-    case LargeCrustSize  => println("large")
-}
--->
-
 
 
 

--- a/_overviews/scala-book/classes.md
+++ b/_overviews/scala-book/classes.md
@@ -85,10 +85,6 @@ public class Person {
 }
 ```
 
-{::comment}
-That Java code hasn’t been tested
-{:/comment}
-
 
 
 ## `val` makes fields read-only

--- a/_overviews/scala-book/collections-101.md
+++ b/_overviews/scala-book/collections-101.md
@@ -20,16 +20,6 @@ If you’re coming to Scala from Java, the best thing you can do is forget about
 
 The main Scala collections classes you’ll use on a regular basis are:
 
-{::comment}
-- `ArrayBuffer` - an indexed, mutable sequence
-- `List` - a linear, immutable sequence
-- `Vector` - an indexed, immutable sequence
-- `Map` - the base `Map` class
-    - there are many variations for special needs
-- `Set` - the base `Set` class
-    - other variations for special needs
-{:/comment}
-
 | Class         | Description   |
 | ------------- | ------------- |
 | `ArrayBuffer` | an indexed, mutable sequence |
@@ -43,14 +33,6 @@ The main Scala collections classes you’ll use on a regular basis are:
 We’ll demonstrate the basics of these classes in the following lessons.
 
 >In the following lessons on Scala collections classes, whenever we use the word *immutable*, it’s safe to assume that the class is intended for use in a *functional programming* (FP) style. With these classes you don’t modify the collection; you apply functional methods to the collection to create a new result. You’ll see what this means in the examples that follow.
-
-
-<!--
-TODO: mention IndexedSeq and LinearSeq, and show an image of the class hierarchy
--->
-
-
-
 
 
 

--- a/_overviews/scala-book/collections-maps.md
+++ b/_overviews/scala-book/collections-maps.md
@@ -64,17 +64,6 @@ firstTwoElements: scala.collection.immutable.Map[Int,String] = Map(1 -> a, 2 -> 
 
 >Note that the last example probably only makes sense for a sorted Map.
 
-{::comment}
-for ((k,v) <- m) printf("key: %s, value: %s\n", k, v)
-val keys = m.keys
-val values = m.values
-val contains3 = m.contains(3)
-val ucMap = m.transform((k,v) => v.toUpperCase)
-val twoAndThree = m.filterKeys(Set(2,3))
-val firstTwoElements = m.take(2) 
-{:/comment}
-
-
 
 
 ## Mutable Map examples

--- a/_overviews/scala-book/collections-methods.md
+++ b/_overviews/scala-book/collections-methods.md
@@ -92,13 +92,6 @@ lessThanFive: List[Boolean] = List(true, true, true, true, false, false, false, 
 
 As that last example shows, it’s perfectly legal (and very common) to use map to return a list with a different type (`List[Boolean]`) from the original type (`List[Int]`).
 
-{::comment}
-val doubles = nums.map(_ * 2)
-val lessThanFive = nums.map(_ < 5)
-val capNames = names.map(_.capitalize)
-{:/comment}
-
-
 
 
 ## `filter`
@@ -115,13 +108,6 @@ evens: List[Int] = List(2, 4, 6, 8, 10)
 scala> val shortNames = names.filter(_.length <= 4)
 shortNames: List[String] = List(joel, ed)
 ```
-
-{::comment}
-val lessThanFive = nums.filter(_ < 5)
-val evens = nums.filter(_ % 2 == 0)
-val shortNames = names.filter(_.length <= 4)
-{:/comment}
-
 
 
 

--- a/_overviews/scala-book/concurrency-signpost.md
+++ b/_overviews/scala-book/concurrency-signpost.md
@@ -14,6 +14,3 @@ next-page: futures
 
 In the next lesson you’ll see a primary tool for writing parallel and concurrent applications, the Scala `Future`.
 
-{::comment}
-This page used to be referred to as a “Concurrency Signpost,” because it introduced Akka actors and Scala futures. The actors’ lessons have been removed, but it still seems like the book needs a little transition to this new section, which is why this page is still here.
-{:/comment}

--- a/_overviews/scala-book/for-loops.md
+++ b/_overviews/scala-book/for-loops.md
@@ -108,20 +108,5 @@ ratings.foreach {
 ```
 
 
-{::comment}
-TODO: discuss side effects and the `foreach` signature
-
-def foreach(f: (A) => Unit): Unit
-
-When i first started working with Scala i used `foreach` quite a bit, but once i learned about functional programming i quit using `foreach`. (Mainly because it’s only used for *side effects*.) Therefore, i’m not going to discuss the `case` syntax in this example. (i will discuss `case` clauses later in this book.)
-{:/comment}
-
-
-
-
-
-
-
-
 
 

--- a/_overviews/scala-book/futures.md
+++ b/_overviews/scala-book/futures.md
@@ -92,10 +92,6 @@ res1: scala.concurrent.Future[Int] = Future(Success(84))
 
 Notice that the `84` you expected is wrapped in a `Success`, which is further wrapped in a `Future`. This is a key point to know: The value in a `Future` is always an instance of one of the `Try` types: `Success` or `Failure`. Therefore, when working with the result of a future, use the usual `Try`-handling techniques, or one of the other `Future` callback methods.
 
-{::comment}
-NOTE: i couldn’t find a better Partial Function link on docs.scala-lang.org, so i kept the following link for now
-{:/comment}
-
 One commonly used callback method is `onComplete`, which takes a [partial function](https://alvinalexander.com/scala/how-to-define-use-partial-functions-in-scala-syntax-examples) in which you should handle the `Success` and `Failure` cases, like this:
 
 ```scala

--- a/_overviews/scala-book/hello-world-1.md
+++ b/_overviews/scala-book/hello-world-1.md
@@ -89,40 +89,4 @@ As that output shows, the `javap` command reads that *.class* file just as if it
 
 
 
-<!--
-### Peaking behind the curtain
-
-To be more precise, what happens is that Scala source code is initially compiled to Java source code, and then that source code is turned into bytecode that works with the JVM.
-
-TODO: Add some more details here, such as what i have at this link.
-
-If you’re interested in more details on this process right now, see the “Using scalac print options” section of [How to disassemble and decompile Scala code](alvinalexander.com/scala/how-to-disassemble-decompile-scala-source-code-javap-scalac-jad) tutorial.
--->
-
-
-<!--
-This is what the output looks like when you run `javap` on the `Hello$.class` file:
-
-````
-$ javap Hello\$.class
-Compiled from "Hello.scala"
-public final class Hello$ {
-  public static Hello$ MODULE$;
-  public static {};
-  public void main(java.lang.String[]);
-}
-````
--->
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/_overviews/scala-book/no-null-values.md
+++ b/_overviews/scala-book/no-null-values.md
@@ -88,10 +88,6 @@ There are two main answers, depending on your needs:
 
 >There are other approaches, but these are the two main approaches, especially from an FP standpoint.
 
-{::comment}
-TODO: discuss combinator function approaches
-{:/comment}
-
 
 
 ### Using a match expression
@@ -281,11 +277,6 @@ val santa = new Address(
 
 Once you have an optional field like this, you work with it as shown in the previous examples: With `match` expressions, `for` expressions, and other built-in methods like `foreach`.
 
-{::comment}
-TODO: again, mention combinators
-{:/comment}
-
-
 
 
 ## Option isn’t the only solution
@@ -309,10 +300,6 @@ This lesson was a little longer than the others, so here’s a quick review of t
 ## See also
 
 - Tony Hoare invented the null reference in 1965, and refers to it as his “[billion dollar mistake](https://en.wikipedia.org/wiki/Tony_Hoare#Apologies_and_retractions).”
-
-{::comment}
-TODO: link to functional-error-handling.md
-{:/comment}
 
 
 

--- a/_overviews/scala-book/oop-pizza-example.md
+++ b/_overviews/scala-book/oop-pizza-example.md
@@ -37,11 +37,6 @@ case object ThickCrustType extends CrustType
 
 A nice thing about Scala is that even though we haven’t discussed sealed traits or case objects, you can probably still figure out how this code works.
 
-{::comment}
-TODO: explain that code here or elsewhere
-{:/comment}
-
-
 
 
 ## A few classes
@@ -221,11 +216,6 @@ To experiment with this on your own, please see the *PizzaOopExample* project in
 - [github.com/alvinj/HelloScalaExamples](https://github.com/alvinj/HelloScalaExamples)
 
 To compile this project it will help to either (a) use IntelliJ IDEA or Eclipse, or (b) know how to use the [Scala Build Tool](http://www.scala-sbt.org).
-
-{::comment}
-TODO: link to the sbt lessons in this book
-For information on getting started with SBT, see my tutorial, [How to compile, run, and package a Scala project with SBT](alvinalexander.com/scala/sbt-how-to-compile-run-package-scala-project).
-{:/comment}
 
 
 

--- a/_overviews/scala-book/passing-functions-around.md
+++ b/_overviews/scala-book/passing-functions-around.md
@@ -42,10 +42,6 @@ As those examples show, Scala clearly lets you pass anonymous functions and regu
 
 ## Function or method?
 
-{::comment}
-i left this link here because it’s a pretty detailed discussion
-{:/comment}
-
 Scala has [a special “function” syntax](https://alvinalexander.com/scala/fp-book-diffs-val-def-scala-functions), but as a practical matter the `def` syntax seems to be preferred. This may be because of two reasons:
 
 - The `def` syntax is more familiar to people coming from a C/Java/C# background
@@ -107,15 +103,6 @@ Those examples that use a “regular” function are equivalent to these anonymo
 List("foo", "bar").map(s => s.toUpperCase)
 List("foo", "bar").map(_.toUpperCase)
 ```
-
-
-
-{::comment}
-TODO: add this topic as a new lesson
-## How to write functions that takes functions as parameters
-
-In both the *Scala Cookbook* and *Functional Programming, Simplified* i demonstrate how to *write* methods like `map` and `filter` that take other functions as input parameters. i won’t do that in this book, but when you get to the point where you want to write functions like this, it’s a technique you’ll want to learn.
-{:/comment}
 
 
 

--- a/_overviews/scala-book/prelude-taste-of-scala.md
+++ b/_overviews/scala-book/prelude-taste-of-scala.md
@@ -11,8 +11,6 @@ previous-page: introduction
 next-page: preliminaries
 ---
 
-<!-- note: the character after the word “Prelude” above is not a colon, it’s a U+A789 -->
-
 Our hope in this book is to demonstrate that [Scala](http://scala-lang.org) is a beautiful, modern, expressive programming language. To help demonstrate that, in this first chapter we’ll jump right in and provide a whirlwind tour of Scala’s main features. After this tour, the book begins with a more traditional “Getting Started” chapter.
 
 >In this book we assume that you’ve used a language like Java before, and are ready to see a series of Scala examples to get a feel for what the language looks like. Although it’s not 100% necessary, it will also help if you’ve already [downloaded and installed Scala](https://www.scala-lang.org/download) so you can test the examples as you go along. You can also test these examples online with [ScalaFiddle.io](https://scalafiddle.io).
@@ -32,10 +30,6 @@ Before we jump into the examples, here are a few important things to know about 
 - Scala code results in *.class* files that run on the Java Virtual Machine (JVM)
 - It’s easy to use Java libraries in Scala
 
-<!--
-TODO: see https://github.com/scala/docs.scala-lang/pull/1469#discussion_r310903284
-- It has traits, which are a combination of interfaces and abstract classes that can be used as mixins, and support a modular programming style
--->
 
 
 ## Hello, world

--- a/_overviews/scala-book/scala-features.md
+++ b/_overviews/scala-book/scala-features.md
@@ -29,21 +29,4 @@ Here are a few more nuggets about Scala:
 - A great Scala benefit is that it lets you write concise, readable code. The time a programmer spends reading code compared to the time spent writing code is said to be at least a 10:1 ratio, so writing code that’s *concise and readable* is a big deal. Because Scala has these attributes, programmers say that it’s *expressive*.
 
 
-{::comment}
-## Scala levels
-
-Another way to describe the audience for this book involves looking at different levels of software developers. In the article at http://www.scala-lang.org/node/8610, Martin Odersky defines the following levels of computer programmers:
-
-- Level A1: Beginning application programmer
-- Level A2: Intermediate application programmer
-- Level A3: Expert application programmer
-- Level L1: Junior library designer
-- Level L2: Senior library designer
-- Level L3: Expert library designer
-
-This book is primarily aimed at the application developers in the A1, A2, A3, and L1 categories.
-{:/comment}
-
-
-
 

--- a/_overviews/scala-book/two-notes-about-strings.md
+++ b/_overviews/scala-book/two-notes-about-strings.md
@@ -112,14 +112,3 @@ Because this is what you generally want, this is a common way to create multilin
 
 
 
-{::comment}
-There are many more cool things you can do with strings. See my [collection of over 100 Scala string examples](alvinalexander.com/scala/scala-string-examples-collection-cheat-sheet) for more details and examples.
-{:/comment}
-
-
-
-
-
-
-
-


### PR DESCRIPTION
As the commit message shows, I removed all comments from the Scala Book files, because they end up being visible in the ePub and Kindle ebooks.

I also changed the break tags in the table in the *built-in-types.md* file from `<br>` to `<br/>` because they were causing a problem in the ePub build process.