### PR TITLE
Changed several relative URLs to absolute URLs

### DIFF
--- a/_overviews/scala-book/futures.md
+++ b/_overviews/scala-book/futures.md
@@ -324,7 +324,7 @@ Other useful and well-named methods include:
 - `fallbackTo`
 - `recoverWith`
 
-These methods and many more details are discussed on the [“Futures and Promises” page](/overviews/core/futures.html).
+These methods and many more details are discussed on the [“Futures and Promises” page]({{site.baseurl}}/overviews/core/futures.html).
 
 
 

--- a/_overviews/scala-book/scala-repl.md
+++ b/_overviews/scala-book/scala-repl.md
@@ -74,7 +74,7 @@ In addition to the REPL there are a couple of other, similar tools you can use:
 - The Scala IDE for Eclipse also has a Worksheet plugin
 - [scalafiddle.io](https://scalafiddle.io) lets you run similar experiments in a web browser
 
-For more information on the Scala REPL, see the [Scala REPL overview](/overviews/repl/overview.html)
+For more information on the Scala REPL, see the [Scala REPL overview]({{site.baseurl}}/overviews/repl/overview.html)
 
 
 

--- a/_overviews/scala-book/two-notes-about-strings.md
+++ b/_overviews/scala-book/two-notes-about-strings.md
@@ -62,7 +62,7 @@ A few other benefits of string interpolation are:
 - The `raw` interpolator performs no escaping of literals (such as `\n`) within the string
 - You can create your own string interpolators
 
-See the [string interpolation documentation](/overviews/core/string-interpolation.html) for more details.
+See the [string interpolation documentation]({{site.baseurl}}/overviews/core/string-interpolation.html) for more details.
 
 
 


### PR DESCRIPTION
Absolute URLs were being used in all but three places, and they are *required* for the ebook versions of Scala Book.