### PR TITLE
Replace the deprecated code

### DIFF
--- a/_overviews/scala-book/abstract-classes.md
+++ b/_overviews/scala-book/abstract-classes.md
@@ -96,7 +96,7 @@ Therefore, this example shows how to pass the constructor parameter from the `Do
 
 ```scala
 abstract class Pet (name: String) {
-    def speak { println(s"My name is $name") }
+    def speak: Unit = println(s"My name is $name")
 }
 
 class Dog(name: String) extends Pet(name)


### PR DESCRIPTION
There was one deprecation warning as procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `speak`'s return type or implicitly using `=`.