### PR TITLE
Added stripMargin to multiline string literal

### DIFF
--- a/_tour/singleton-objects.md
+++ b/_tour/singleton-objects.md
@@ -92,7 +92,7 @@ scalaCenterEmail match {
     s"""Registered an email
        |Username: ${email.username}
        |Domain name: ${email.domainName}
-     """)
+     """.stripMargin)
   case None => println("Error: could not parse email")
 }
 ```


### PR DESCRIPTION
Heads-up: I'm completely new to Scala so it's entirely plausible I'm overlooking something trivial, but reading through and locally reproducing the documentation examples it seemed as though this multiline string using a margin char lacked a call to `stripMargin`.