### PR TITLE
Batch of updates for SIPs

### DIFF
--- a/_sass/layout/sips.scss
+++ b/_sass/layout/sips.scss
@@ -105,6 +105,7 @@
 
   .pending,
   .completed,
+  .dormant,
   .rejected {
     .date {
       display: block;
@@ -169,6 +170,7 @@
     @include justify-content(space-between);
 
     .completed,
+    .dormant,
     .rejected {
       display: flex;
       flex-direction: column;

--- a/_sips/all.md
+++ b/_sips/all.md
@@ -13,7 +13,7 @@ redirect_from: "/sips/pending/index.html"
   <ul>
   {% assign sips = site.sips | sort: date | reverse %}
   {% for sip in sips %}
-   {% if sip.vote-status == "under-review" or sip.vote-status == "pending" or sip.vote-status == "dormant" or sip.vote-status == "under-revision" %}
+   {% if sip.vote-status == "under-review" or sip.vote-status == "pending" or sip.vote-status == "under-revision" %}
      <li>
       <strong><a href="{{ sip.url }}">{{ sip.title }}</a></strong>
       <div class="date">{{ sip.date | date: '%B %Y' }}</div>
@@ -37,6 +37,20 @@ redirect_from: "/sips/pending/index.html"
        </li>
      {% endif %}
     {% endfor %}    
+    </ul>
+  </div>
+  <div class="dormant">
+    <h2>Dormant</h2>
+    <ul>
+    {% for sip in sips %}
+     {% if sip.vote-status == "dormant" %}
+       <li>
+        <strong><a href="{{ sip.url }}">{{ sip.title }}</a></strong>
+        <div class="date">{{ sip.date | date: '%B %Y' }}</div>
+        <div class="tag" style="background-color: {{ site.data.sip-data[sip.vote-status].color }}">{{ site.data.sip-data[sip.vote-status].text }}</div>
+       </li>
+     {% endif %}
+    {% endfor %}
     </ul>
   </div>
   <div class="rejected">

--- a/_sips/index.md
+++ b/_sips/index.md
@@ -40,12 +40,3 @@ Please read [Submitting a SIP](./sip-submission.html) and our
 > Historical note: The SIP replaces the older SID (Scala Improvement Document) process.
 > Completed SID documents remain available in the
 > [completed section of the SIP list](all.html).
-
-## Scala Platform Process (SPP)
-
-The Scala Platform aims to be a stable collection of libraries with widespread
-use and a low barrier to entry for beginners and intermediate users. The
-Platform consists of several independent modules that solve specific problems.
-The Scala community sets the overall direction of the Platform.
-
-<a class="button" href="https://platform.scala-lang.org">Learn more about the Scala Platform</a>

--- a/_sips/sips/2013-06-10-spores.md
+++ b/_sips/sips/2013-06-10-spores.md
@@ -1,8 +1,8 @@
 ---
 layout: sip
 title: SIP-21 - Spores
-vote-status: "under-review"
-vote-text: Next iteration takes place in January/February 2017 by request of the authors.
+vote-status: "dormant"
+vote-text: There is an implementation for Scala 2.11. A new owner is needed to champion this proposal for the current Scala version. The proposal needs to be updated to explain how to handle transitive spores.
 permalink: /sips/:title.html
 redirect_from: /sips/pending/spores.html
 ---

--- a/_sips/sips/2015-6-18-trait-parameters.md
+++ b/_sips/sips/2015-6-18-trait-parameters.md
@@ -1,8 +1,8 @@
 ---
 layout: sip
 title: SIP-25 - Trait Parameters
-vote-status: "under-review"
-vote-text: The board agreed to schedule the next iteration of the evaluation process in 6 months, since there’s no implementation yet and the authors need time to produce one.
+vote-status: accepted
+vote-text: Trait parameters are implemented in Scala 3.0.
 permalink: /sips/:title.html
 redirect_from: /sips/pending/trait-parameters.html
 ---

--- a/_sips/sips/2016-09-09-inline-meta.md
+++ b/_sips/sips/2016-09-09-inline-meta.md
@@ -1,8 +1,8 @@
 ---
 layout: sip
 title: SIP-28 and SIP-29 - Inline meta
-vote-status: "under-revision"
-vote-text: The following proposal has been split and numbered as SIP-28 (Inline) and SIP-29 (Meta). For more information on this decision, check the <a href="https://docs.scala-lang.org/sips/minutes/sip-20th-september-minutes.html">minutes</a>. The authors need to split the proposal and update it.
+vote-status: dormant
+vote-text: This proposal needs an owner.
 permalink: /sips/:title.html
 redirect_from: /sips/pending/inline-meta.html
 ---

--- a/_sips/sips/2017-01-11-refer-other-arguments-in-args.md
+++ b/_sips/sips/2017-01-11-refer-other-arguments-in-args.md
@@ -1,6 +1,6 @@
 ---
 layout: sip
-title: SIP-NN - Allow referring to other arguments in default parameters
+title: SIP-32 - Allow referring to other arguments in default parameters
 vote-status: pending
 permalink: /sips/:title.html
 redirect_from: /sips/pending/refer-other-arguments-in-args.html

--- a/_sips/sips/2017-01-13-binary-compatibility.md
+++ b/_sips/sips/2017-01-13-binary-compatibility.md
@@ -1,7 +1,8 @@
 ---
 layout: sip
-title: SIP-NN - Improving binary compatibility with @stableABI
-vote-status: pending
+title: SIP-34 - Improving binary compatibility with @stableABI
+vote-status: dormant
+vote-text: When the author of this proposal figures out which features should be binary compatible and has more information on the future implementation, the SIP Committee will start the review period.
 permalink: /sips/:title.html
 redirect_from: /sips/pending/binary-compatibility.html
 ---

--- a/_sips/sips/2017-09-20-opaque-types.md
+++ b/_sips/sips/2017-09-20-opaque-types.md
@@ -2,7 +2,7 @@
 layout: sip
 title: SIP-35 - Opaque types
 
-vote-status: pending
+vote-status: accepted
 permalink: /sips/:title.html
 redirect_from: /sips/pending/opaque-types.html
 ---


### PR DESCRIPTION
Update old proposals based on minutes content. More recent proposals will be updated in a separate PR when the minutes will be available.

Also, move the “dormant” proposal in a separate list than the “pending” list.

I’ve taken the liberty to change the status of some proposals. Please let me know if I did something wrong (I @mentioned people related to the changed proposals in each commit).