### PR TITLE
WIP Fix SIP-23 (Literal Types)

### DIFF
--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -113,7 +113,7 @@ Lightbend Scala compiler.
   added yielding the unique value of types with a single inhabitant.
   ```
   def foo[T](implicit v: ValueOf[T]): T = v.value
-  foo[13]                            // result is 13: 13
+  foo[13]                            // result is Int = 13
   ```
 
 

--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -89,9 +89,10 @@ Lightbend Scala compiler.
   ```
 
 + The `.type` singleton type forming operator can be applied to values of all subtypes of `Any`.
+  To prevent the compiler from widening our return type we assign to a final val.
   ```
   def foo[T](t: T): t.type = t
-  foo(23)                            // result is 23: 23
+  final val bar = foo(23)            // result is bar: 23 = 23
   ```
 
 + The presence of an upper bound of `Singleton` on a formal type parameter indicates that
@@ -386,7 +387,7 @@ applications which work with large datasets.
   Example,
   ```
   def foo[T](t: T): t.type = t
-  foo(23)                            // result is 23: 23
+  final val bar = foo(23)            // result is bar: 23 = 23
   ```
 
 + The presence of an upper bound of `Singleton` on a formal type parameter indicates that

--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -88,6 +88,12 @@ Lightbend Scala compiler.
   foo(1: 1)                          // type ascription
   ```
 
++ The `.type` singleton type forming operator can be applied to values of all subtypes of `Any`.
+  ```
+  def foo[T](t: T): t.type = t
+  foo(23)                            // result is 23: 23
+  ```
+
 + The presence of an upper bound of `Singleton` on a formal type parameter indicates that
   singleton types should be inferred for type parameters at call sites. To help see this
   we introduce type constructor `Id` to prevent the compiler from widening our return type.

--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -504,7 +504,7 @@ applications which work with large datasets.
   Example,
   ```
   def foo[T](implicit v: ValueOf[T]): T = v.value
-  foo[13]                            // result is 13: 13
+  foo[13]                            // result is Int = 13
   ```
 
   A method `valueOf` is also added to `scala.Predef` analogously to existing operators such as
@@ -517,9 +517,9 @@ applications which work with large datasets.
   Example,
   ```
   object Foo
-  valueOf[Foo.type]       // result is Foo: Foo.type
+  valueOf[Foo.type]       // result is Foo = Foo.type
 
-  valueOf[23]             // result is 23: 23
+  valueOf[23]             // result is Int = 23
   ```
 
 + Pattern matching against literal types and `isInstanceOf` tests are

--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -92,7 +92,7 @@ Lightbend Scala compiler.
   To prevent the compiler from widening our return type we assign to a final val.
   ```
   def foo[T](t: T): t.type = t
-  final val bar = foo(23)            // result is bar: 23 = 23
+  final val bar = foo(23)            // result is bar: 23
   ```
 
 + The presence of an upper bound of `Singleton` on a formal type parameter indicates that
@@ -101,9 +101,9 @@ Lightbend Scala compiler.
   ```
   type Id[A] = A
   def wide[T](t: T): Id[T] = t
-  wide(23)                           // result is Id[Int] = 23
+  wide(23)                           // result is 23: Id[Int]
   def narrow[T <: Singleton](t: T): Id[T] = t
-  narrow(23)                         // result is Id[23] = 23
+  narrow(23)                         // result is 23: Id[23]
   ```
 
 + Pattern matching against literal types and `isInstanceOf` tests are
@@ -112,15 +112,15 @@ Lightbend Scala compiler.
   (1: Any) match {
     case one: 1 => true
     case _ => false
-  }                                  // result is true
-  (1: Any).isInstanceOf[1]           // result is true
+  }                                  // result is true: Boolean
+  (1: Any).isInstanceOf[1]           // result is true: Boolean
   ```
 
 + A `scala.ValueOf[T]` type class and corresponding `scala.Predef.valueOf[T]` operator has been
   added yielding the unique value of types with a single inhabitant.
   ```
   def foo[T](implicit v: ValueOf[T]): T = v.value
-  foo[13]                            // result is Int = 13
+  foo[13]                            // result is 13: Int
   ```
 
 
@@ -141,7 +141,7 @@ val one: wOne.T = wOne.value  // wOne.T is the type 1
                               // wOne.value is 1: 1
 
 def foo[T](implicit w: Witness[T]): w.T = w.value
-foo[wOne.T]                   // result is 1 = 1
+foo[wOne.T]                   // result is 1: 1
 
 "foo" ->> 23      // shapeless record field constructor
                   // result type is FieldType["foo", Int]
@@ -387,7 +387,7 @@ applications which work with large datasets.
   Example,
   ```
   def foo[T](t: T): t.type = t
-  final val bar = foo(23)            // result is bar: 23 = 23
+  final val bar = foo(23)            // result is bar: 23
   ```
 
 + The presence of an upper bound of `Singleton` on a formal type parameter indicates that
@@ -451,7 +451,7 @@ applications which work with large datasets.
   class Widen
   object Narrow extends Wide
   def id[T](t: T): T = t
-  id(Narrow)                 // result is Narrow = Narrow.type
+  id(Narrow)                 // result is Narrow: Narrow.type
   ```
 
   This SIP updates the specification to match the current implementation and then adds the further
@@ -473,10 +473,10 @@ applications which work with large datasets.
   Example,
   ```
   def wide[T](t: T): T = t
-  wide(13)                           // result is Int = 13
+  wide(13)                           // result is 13: Int
   type Id[A] = A
   def narrow[T <: Singleton](t: T): Id[T] = t
-  narrow(23)                         // result is Id[23] = 23
+  narrow(23)                         // result is 23: Id[23]
   ```
 
   Note that we introduce the type constructor `Id` simply to avoid widening of the return type.
@@ -504,7 +504,7 @@ applications which work with large datasets.
   Example,
   ```
   def foo[T](implicit v: ValueOf[T]): T = v.value
-  foo[13]                            // result is Int = 13
+  foo[13]                            // result is 13: Int
   ```
 
   A method `valueOf` is also added to `scala.Predef` analogously to existing operators such as
@@ -517,9 +517,9 @@ applications which work with large datasets.
   Example,
   ```
   object Foo
-  valueOf[Foo.type]       // result is Foo = Foo.type
+  valueOf[Foo.type]       // result is Foo: Foo.type
 
-  valueOf[23]             // result is Int = 23
+  valueOf[23]             // result is 23: Int
   ```
 
 + Pattern matching against literal types and `isInstanceOf` tests are
@@ -539,8 +539,8 @@ applications which work with large datasets.
   (1: Any) match {
     case one: 1 => true
     case _ => false
-  }                                  // result is true
-  (1: Any).isInstanceOf[1]           // result is true
+  }                                  // result is true: Boolean
+  (1: Any).isInstanceOf[1]           // result is true: Boolean
   ```
 
   Importantly, that doesn't include `asInstanceOf` as that is a user assertion to the compiler, with

--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -141,7 +141,7 @@ val one: wOne.T = wOne.value  // wOne.T is the type 1
                               // wOne.value is 1: 1
 
 def foo[T](implicit w: Witness[T]): w.T = w.value
-foo[wOne.T]                   // result is 1: 1
+foo[wOne.T]                   // result is 1 = 1
 
 "foo" ->> 23      // shapeless record field constructor
                   // result type is FieldType["foo", Int]
@@ -451,7 +451,7 @@ applications which work with large datasets.
   class Widen
   object Narrow extends Wide
   def id[T](t: T): T = t
-  id(Narrow)                 // result is Narrow: Narrow.type
+  id(Narrow)                 // result is Narrow = Narrow.type
   ```
 
   This SIP updates the specification to match the current implementation and then adds the further

--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -89,12 +89,14 @@ Lightbend Scala compiler.
   ```
 
 + The presence of an upper bound of `Singleton` on a formal type parameter indicates that
-  singleton types should be inferred for type parameters at call sites.
+  singleton types should be inferred for type parameters at call sites. To help see this
+  we introduce type constructor `Id` to prevent the compiler from widening our return type.
   ```
-  def wide[T](t: T): T = t
-  wide(13)                           // result is 13: Int
-  def narrow[T <: Singleton](t: T): T = t
-  narrow(23)                         // result is 23: 23
+  type Id[A] = A
+  def wide[T](t: T): Id[T] = t
+  wide(23)                           // result is Id[Int] = 23
+  def narrow[T <: Singleton](t: T): Id[T] = t
+  narrow(23)                         // result is Id[23] = 23
   ```
 
 + Pattern matching against literal types and `isInstanceOf` tests are

--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -88,12 +88,6 @@ Lightbend Scala compiler.
   foo(1: 1)                          // type ascription
   ```
 
-+ The `.type` singleton type forming operator can be applied to values of all subtypes of `Any`.
-  ```
-  def foo[T](t: T): t.type = t
-  foo(23)                            // result is 23: 23
-  ```
-
 + The presence of an upper bound of `Singleton` on a formal type parameter indicates that
   singleton types should be inferred for type parameters at call sites.
   ```

--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -473,10 +473,13 @@ applications which work with large datasets.
   Example,
   ```
   def wide[T](t: T): T = t
-  wide(13)                           // result is 13: Int
-  def narrow[T <: Singleton](t: T): T = t
-  narrow(23)                         // result is 23: 23
+  wide(13)                           // result is Int = 13
+  type Id[A] = A
+  def narrow[T <: Singleton](t: T): Id[T] = t
+  narrow(23)                         // result is Id[23] = 23
   ```
+
+  Note that we introduce the type constructor `Id` simply to avoid widening of the return type.
 
 + A `scala.ValueOf[T]` type class and corresponding `scala.Predef.valueOf[T]` operator has been
   added yielding the unique value of types with a single inhabitant.

--- a/_sips/sips/2014-06-27-42.type.md
+++ b/_sips/sips/2014-06-27-42.type.md
@@ -472,9 +472,9 @@ applications which work with large datasets.
 
   Example,
   ```
-  def wide[T](t: T): T = t
-  wide(13)                           // result is 13: Int
   type Id[A] = A
+  def wide[T](t: T): Id[T] = t
+  wide(23)                           // result is 23: Id[Int]
   def narrow[T <: Singleton](t: T): Id[T] = t
   narrow(23)                         // result is 23: Id[23]
   ```


### PR DESCRIPTION
This PR cleans up some incorrect code examples in the SIP-23 document.

> a PR bringing the SIP in line with the implementation would be welcome; so would a PR merging the whole SIP into the spec - @SethTisue (via [gitter](https://gitter.im/scala/contributors?at=5dee8b9832df1245cb112b45))

- [x] update comments showing return types to match repl session
- [x] confirm all examples in proposal details section
- [ ] figure out if we need to update the history section to reflect these changes

## Additional commentary
This PR better addresses the issues discussed in https://github.com/scala/docs.scala-lang/pull/1570
I do not think this addresses all the confusion one could run into when playing with literal types.
I think we need to improve the spec and write some documentation elsewhere, perhaps an overview or section in the tour.
However, hopefully this PR serves as an incremental improvement over the current state.