### PR TITLE
Remove `fruits` from path to `planted`

### DIFF
--- a/_ja/tour/package-objects.md
+++ b/_ja/tour/package-objects.md
@@ -56,7 +56,7 @@ package object fruits {
 import gardening.fruits._
 object PrintPlanted {
   def main(args: Array[String]): Unit = {
-    for (fruit <- fruits.planted) {
+    for (fruit <- planted) {
       showFruit(fruit)
     }
   }

--- a/_ru/tour/package-objects.md
+++ b/_ru/tour/package-objects.md
@@ -54,7 +54,7 @@ package object fruits {
 import gardening.fruits._
 object PrintPlanted {
   def main(args: Array[String]): Unit = {
-    for (fruit <- fruits.planted) {
+    for (fruit <- planted) {
       showFruit(fruit)
     }
   }

--- a/_tour/package-objects.md
+++ b/_tour/package-objects.md
@@ -56,7 +56,7 @@ way it imports class `Fruit`, using a wildcard import on package gardening.fruit
 import gardening.fruits._
 object PrintPlanted {
   def main(args: Array[String]): Unit = {
-    for (fruit <- fruits.planted) {
+    for (fruit <- planted) {
       showFruit(fruit)
     }
   }

--- a/_zh-cn/tour/package-objects.md
+++ b/_zh-cn/tour/package-objects.md
@@ -51,7 +51,7 @@ package object fruits {
 import gardening.fruits._
 object PrintPlanted {
   def main(args: Array[String]): Unit = {
-    for (fruit <- fruits.planted) {
+    for (fruit <- planted) {
       showFruit(fruit)
     }
   }


### PR DESCRIPTION
Applying this PR will remove `fruits` from the path to `planted`, making the example work. Right now it will fail with:
```
PrintPlanted.scala:4: error: not found: value fruits
    for (fruit <- fruits.planted) {
                  ^
```