### PR TITLE
Correct typo in built-in-types.md

### DIFF
--- a/_overviews/scala-book/built-in-types.md
+++ b/_overviews/scala-book/built-in-types.md
@@ -50,8 +50,8 @@ Those data types and their ranges are:
 | ------------- | --------------- |
 | Boolean       | `true` or `false` |
 | Byte          | 8-bit signed two’s complement integer (-2^7 to 2^7-1, inclusive)<br/>-128 to 127   |
-| Short         | 16-bit signed two’s complement integer (-2^15 to 2^15-1, inclusive)<br/>32,768 to 32,767 
-| Int           | 32-bit two’s complement integer (-2^31 to 2^31-1, inclusive)<br/>2,147,483,648 to 2,147,483,647 | 
+| Short         | 16-bit signed two’s complement integer (-2^15 to 2^15-1, inclusive)<br/>-32,768 to 32,767 
+| Int           | 32-bit two’s complement integer (-2^31 to 2^31-1, inclusive)<br/>-2,147,483,648 to 2,147,483,647 | 
 | Long          | 64-bit two’s complement integer (-2^63 to 2^63-1, inclusive)<br/>(-2^63 to 2^63-1, inclusive)   |
 | Float         | 32-bit IEEE 754 single-precision float<br/>1.40129846432481707e-45 to 3.40282346638528860e+38 |
 | Double        | 64-bit IEEE 754 double-precision float<br/>4.94065645841246544e-324d to 1.79769313486231570e+308d |


### PR DESCRIPTION
Leading minus symbol missing from negative end of `Short` and `Int` table descriptions