### PR TITLE
Remove note about overloading in package objects

### DIFF
--- a/_tour/package-objects.md
+++ b/_tour/package-objects.md
@@ -70,5 +70,3 @@ package object fruits extends FruitAliases with FruitHelpers {
   // helpers and variables follows here
 }
 ```
-
-Note that method overloading doesn't work in package objects.


### PR DESCRIPTION
This advice appears to come from [this old SO comment](https://stackoverflow.com/questions/3400734/package-objects#comment3539969_3401031). But I guess that this was some 2.8 limitation, which I can't even test because I don't know a low-effort way to fire up a Scala 2.8 compiler in 2020. Anyway I see no such limitation when compiling with any >= 2.10 version.

If there in fact still is a limitation then we should at least explain _what exactly_ doesn't work.