### PR TITLE
Update string interpolation docs with further information on escaping special chars

### DIFF
--- a/_overviews/core/string-interpolation.md
+++ b/_overviews/core/string-interpolation.md
@@ -42,11 +42,22 @@ String interpolators can also take arbitrary expressions.  For example:
 
 will print the string `1 + 1 = 2`.  Any arbitrary expression can be embedded in `${}`.
 
+For some special characters, it is necessary to escape them when embedded within a string.
 To represent an actual dollar sign you can double it `$$`, like here:
 
     println(s"New offers starting at $$14.99")
     
 which will print the string `New offers starting at $14.99`.
+
+Double quotes also need to be escaped. This can be done on an individual basis using a backslash before the double quote, as follows:
+
+    val person = "{\"name\":\"James\"}"
+
+On longer strings, this may be time intensive. To avoid the need to escape every individual quote, triple quotes can be used as shown:
+
+    val person = """{"name":"James"}"""
+
+Both of these strings, when printed, will produce the string `{"name":"James"}`.
 
 ### The `f` Interpolator
 

--- a/_overviews/core/string-interpolation.md
+++ b/_overviews/core/string-interpolation.md
@@ -49,15 +49,11 @@ To represent an actual dollar sign you can double it `$$`, like here:
     
 which will print the string `New offers starting at $14.99`.
 
-Double quotes also need to be escaped. This can be done on an individual basis using a backslash before the double quote, as follows:
-
-    val person = "{\"name\":\"James\"}"
-
-On longer strings, this may be time intensive. To avoid the need to escape every individual quote, triple quotes can be used as shown:
+Double quotes also need to be escaped. This can be done by using triple quotes as shown:
 
     val person = """{"name":"James"}"""
 
-Both of these strings, when printed, will produce the string `{"name":"James"}`.
+which will produce the string `{"name":"James"}` when printed.
 
 ### The `f` Interpolator
 


### PR DESCRIPTION
Resolves  #1314

Added ways in which Interpolation with double quotes can be achieved. Dollar signs are already documented.

Are there are further characters which would be necessary?