### PR TITLE
Terminology fix: case class instances

### DIFF
--- a/_tour/basics.md
+++ b/_tour/basics.md
@@ -202,7 +202,7 @@ We will cover classes in depth [later](classes.html).
 
 ## Case Classes
 
-Scala has a special type of class called a "case" class. By default, case classes are immutable, and they are compared by value (unlike classes, which are compared by reference). This makes them additionally useful for [pattern matching](https://docs.scala-lang.org/tour/pattern-matching.html#matching-on-case-classes).
+Scala has a special type of class called a "case" class. By default, instances of case classes are immutable, and they are compared by value (unlike classes, whose instances are compared by reference). This makes them additionally useful for [pattern matching](https://docs.scala-lang.org/tour/pattern-matching.html#matching-on-case-classes).
 
 You can define case classes with the `case class` keywords:
 
@@ -218,7 +218,7 @@ val anotherPoint = Point(1, 2)
 val yetAnotherPoint = Point(2, 2)
 ```
 
-Case classes are compared by value, not by reference:
+Instances of case classes are compared by value, not by reference:
 
 ```tut
 if (point == anotherPoint) {

--- a/_tour/case-classes.md
+++ b/_tour/case-classes.md
@@ -33,7 +33,7 @@ message1.sender = "travis@washington.us"  // this line does not compile
 You can't reassign `message1.sender` because it is a `val` (i.e. immutable). It is possible to use `var`s in case classes but this is discouraged.
 
 ## Comparison
-Case classes are compared by structure and not by reference:
+Instances of case classes are compared by structure and not by reference:
 ```tut
 case class Message(sender: String, recipient: String, body: String)
 


### PR DESCRIPTION
Before this patch, the text said things like "case classes are compared by value". This caused me some confusion: is it the classes themselves that are compared, or is it the instances of those classes?