### PR TITLE
Updated the comment for the return type

### DIFF
--- a/_tour/basics.md
+++ b/_tour/basics.md
@@ -145,7 +145,7 @@ println(add(1, 2)) // 3
 ```
 {% endscalafiddle %}
 
-Notice how the return type is declared _after_ the parameter list and the `: Int`.
+Notice how the return type `Int` is declared _after_ the parameter list and a `:`.
 
 A method can take multiple parameter lists:
 


### PR DESCRIPTION
The previous inline code highlighting of `: Int` together was confusing: the sentence as a whole seemed to imply that the return type could be found _after_ the colon *and* the `Int`, i.e. the sentence could be read to imply that `: Int` was a separate syntactic construct from the return type, even though the return type `Int` was already there in `: Int`.