### PR TITLE
Fix markdown table layout on Japanese cheatsheets

### DIFF
--- a/_ja/cheatsheets/index.md
+++ b/_ja/cheatsheets/index.md
@@ -15,6 +15,7 @@ language: ja
 
 
 |  <span id="variables" class="h2">変数</span>                                                             |                 |
+|----------------------------------------------------------------------------------------------------------|-----------------|
 |  `var x = 5`                                                                                             |  変数           |
 |  <span class="label success">Good</span> `val x = 5`<br> <span class="label important">Bad</span> `x=6`  |  定数           |
 |  `var x: Double = 5`                                                                                     |  明示的な型     |


### PR DESCRIPTION
I fixed the broken table layout on Japanese cheetsheets.

### before
![スクリーンショット 2020-02-15 16 30 29](https://user-images.githubusercontent.com/30188755/74583967-81774e80-5010-11ea-9780-522701a3ed80.png)

### after
![スクリーンショット 2020-02-15 16 31 52](https://user-images.githubusercontent.com/30188755/74583985-b1265680-5010-11ea-9857-f49640e631fb.png)

