### PR TITLE
Coding example of "Variances" corrected

### DIFF
--- a/_pl/tour/multiple-parameter-lists.md
+++ b/_pl/tour/multiple-parameter-lists.md
@@ -73,7 +73,4 @@ numbers.foldRight(0)((sum, item) => sum + item) // postać ogólna
 
 numbers.foldLeft(0)(_+_) // postać rozwijana (curried)
 numbers.foldRight(0)(_+_) // postać rozwijana (curried)
-
-(0 /: numbers)(_+_) // Alternatywy sposób wywołania foldLeft
-(numbers :\ 0)(_+_) // Alternatywy sposób wywołania foldRight
 ```

--- a/_ru/tour/multiple-parameter-lists.md
+++ b/_ru/tour/multiple-parameter-lists.md
@@ -78,10 +78,7 @@ numbers.foldRight(0)((sum, item) => sum + item) // Общая Форма
 
 numbers.foldLeft(0)(_+_) // Форма с каррированием
 numbers.foldRight(0)(_+_) // Форма с каррированием
-
-(0 /: numbers)(_+_) // Используется вместо foldLeft
-(numbers :\ 0)(_+_) // Используется вместо foldRight
-```   
+```
 
    
 #### Неявные параметры

--- a/_tour/variances.md
+++ b/_tour/variances.md
@@ -40,18 +40,17 @@ In the following example, the method `printAnimalNames` will accept a list of an
 object CovarianceTest extends App {
   def printAnimalNames(animals: List[Animal]): Unit =
     animals.foreach {
-      animal => println(animal.name) }
+      animal => println(animal.name)
+    }
 }
 val cats: List[Cat] = List(Cat("Whiskers"), Cat("Tom"))
 val dogs: List[Dog] = List(Dog("Fido"), Dog("Rex"))
 
+// prints: Whiskers, Tom
 CovarianceTest.printAnimalNames(cats)
-// Whiskers
-// Tom
 
+// prints: Fido, Rex
 CovarianceTest.printAnimalNames(dogs)
-// Fido
-// Rex
 ```
 
 ### Contravariance

--- a/_tour/variances.md
+++ b/_tour/variances.md
@@ -37,20 +37,19 @@ Both `Cat` and `Dog` are subtypes of `Animal`. The Scala standard library has a 
 In the following example, the method `printAnimalNames` will accept a list of animals as an argument and print their names each on a new line. If `List[A]` were not covariant, the last two method calls would not compile, which would severely limit the usefulness of the `printAnimalNames` method.
 
 ```tut
-object CovarianceTest extends App {
-  def printAnimalNames(animals: List[Animal]): Unit =
-    animals.foreach {
-      animal => println(animal.name)
-    }
-}
+def printAnimalNames(animals: List[Animal]): Unit =
+  animals.foreach {
+    animal => println(animal.name)
+  }
+
 val cats: List[Cat] = List(Cat("Whiskers"), Cat("Tom"))
 val dogs: List[Dog] = List(Dog("Fido"), Dog("Rex"))
 
 // prints: Whiskers, Tom
-CovarianceTest.printAnimalNames(cats)
+printAnimalNames(cats)
 
 // prints: Fido, Rex
-CovarianceTest.printAnimalNames(dogs)
+printAnimalNames(dogs)
 ```
 
 ### Contravariance
@@ -82,16 +81,14 @@ class CatPrinter extends Printer[Cat] {
 If a `Printer[Cat]` knows how to print any `Cat` to the console, and a `Printer[Animal]` knows how to print any `Animal` to the console, it makes sense that a `Printer[Animal]` would also know how to print any `Cat`. The inverse relationship does not apply, because a `Printer[Cat]` does not know how to print any `Animal` to the console. Therefore, we should be able to substitute a `Printer[Animal]` for a `Printer[Cat]`, if we wish, and making `Printer[A]` contravariant allows us to do exactly that.
 
 ```tut
-object ContravarianceTest extends App {
-  def printMyCat(printer: Printer[Cat], cat: Cat): Unit = {
-    printer.print(cat)
-  }
-}
+def printMyCat(printer: Printer[Cat], cat: Cat): Unit =
+  printer.print(cat)
+
 val catPrinter: Printer[Cat] = new CatPrinter
 val animalPrinter: Printer[Animal] = new AnimalPrinter
 
-ContravarianceTest.printMyCat(catPrinter, Cat("Boots"))
-ContravarianceTest.printMyCat(animalPrinter, Cat("Boots"))
+printMyCat(catPrinter, Cat("Boots"))
+printMyCat(animalPrinter, Cat("Boots"))
 ```
 
 The output of this program will be:

--- a/_tour/variances.md
+++ b/_tour/variances.md
@@ -38,23 +38,20 @@ In the following example, the method `printAnimalNames` will accept a list of an
 
 ```tut
 object CovarianceTest extends App {
-  def printAnimalNames(animals: List[Animal]): Unit = {
-    animals.foreach { animal =>
-      println(animal.name)
-    }
-  }
-
-  val cats: List[Cat] = List(Cat("Whiskers"), Cat("Tom"))
-  val dogs: List[Dog] = List(Dog("Fido"), Dog("Rex"))
-
-  printAnimalNames(cats)
-  // Whiskers
-  // Tom
-
-  printAnimalNames(dogs)
-  // Fido
-  // Rex
+  def printAnimalNames(animals: List[Animal]): Unit =
+    animals.foreach {
+      animal => println(animal.name) }
 }
+val cats: List[Cat] = List(Cat("Whiskers"), Cat("Tom"))
+val dogs: List[Dog] = List(Dog("Fido"), Dog("Rex"))
+
+CovarianceTest.printAnimalNames(cats)
+// Whiskers
+// Tom
+
+CovarianceTest.printAnimalNames(dogs)
+// Fido
+// Rex
 ```
 
 ### Contravariance
@@ -87,18 +84,15 @@ If a `Printer[Cat]` knows how to print any `Cat` to the console, and a `Printer[
 
 ```tut
 object ContravarianceTest extends App {
-  val myCat: Cat = Cat("Boots")
-
-  def printMyCat(printer: Printer[Cat]): Unit = {
-    printer.print(myCat)
+  def printMyCat(printer: Printer[Cat], cat: Cat): Unit = {
+    printer.print(cat)
   }
-
-  val catPrinter: Printer[Cat] = new CatPrinter
-  val animalPrinter: Printer[Animal] = new AnimalPrinter
-
-  printMyCat(catPrinter)
-  printMyCat(animalPrinter)
 }
+val catPrinter: Printer[Cat] = new CatPrinter
+val animalPrinter: Printer[Animal] = new AnimalPrinter
+
+ContravarianceTest.printMyCat(catPrinter, Cat("Boots"))
+ContravarianceTest.printMyCat(animalPrinter, Cat("Boots"))
 ```
 
 The output of this program will be:

--- a/_zh-cn/tour/multiple-parameter-lists.md
+++ b/_zh-cn/tour/multiple-parameter-lists.md
@@ -65,9 +65,6 @@ numbers.foldRight(0)((sum, item) => sum + item) // Generic Form
 
 numbers.foldLeft(0)(_+_) // Curried Form
 numbers.foldRight(0)(_+_) // Curried Form
-
-(0 /: numbers)(_+_) // Used in place of foldLeft
-(numbers :\ 0)(_+_) // Used in place of foldRight
 ```
 
 

--- a/scripts/run-tut.sh
+++ b/scripts/run-tut.sh
@@ -5,7 +5,7 @@ set -eux
 # black-list _overviews/contributors/index.md because it embeds a Markdown snippet which embeds Scala code that does not compile
 mv _overviews/contributors/index.md /tmp/_overviews_contributors_index.md
 
-coursier launch -r "https://dl.bintray.com/tpolecat/maven/" org.tpolecat:tut-core_2.12:0.6.7 -- . tut-tmp '.*\.md$' -classpath $(coursier fetch -p com.chuusai:shapeless_2.12:2.3.3) -Xfatal-warnings -feature
+coursier launch -r "https://dl.bintray.com/tpolecat/maven/" org.tpolecat:tut-core_2.12:0.6.13 -- . tut-tmp '.*\.md$' -classpath $(coursier fetch -p com.chuusai:shapeless_2.12:2.3.3) -Xfatal-warnings -feature
 
 # restore _overviews/contributors/index.md file
 mv /tmp/_overviews_contributors_index.md _overviews/contributors/index.md


### PR DESCRIPTION
The coding example inside the Variances (both in Covariance and Contravariance) wasn't completely working (as reported in #1533 ) , even if the proposed solution could be unelegant it should make possible for everyone to try it on their own platform.