### PR TITLE
add extra clarity to type description

### DIFF
--- a/_tour/upper-type-bounds.md
+++ b/_tour/upper-type-bounds.md
@@ -10,7 +10,7 @@ previous-page: variances
 redirect_from: "/tutorials/tour/upper-type-bounds.html"
 ---
 
-In Scala, [type parameters](generic-classes.html) and [abstract type members](abstract-type-members.html) may be constrained by a type bound. Such type bounds limit the concrete values of the type variables and possibly reveal more information about the members of such types. An _upper type bound_ `T <: A` declares that type variable `T` refers to a subtype of type `A`.
+In Scala, [type parameters](generic-classes.html) and [abstract type members](abstract-type-members.html) may be constrained by a type bound. Such type bounds limit the concrete values of the type variables and possibly reveal more information about the members of such types. An _upper type bound_ `T <: A` declares that type variable `T` refers to type `A` or a subtype of type `A`.
 Here is an example that demonstrates upper type bound for a type parameter of class `PetContainer`:
 
 ```tut


### PR DESCRIPTION
I don't know if this correction needs to be made.  If a type is always a subtype of itself then the way this statement exists in the documentation presently makes sense.  If a type cannot be considered to be a subtype of itself then this correction might be worth adding.  Thanks for reviewing:)