### PR TITLE
Link Tour of scala to Scala book

### DIFF
--- a/_tour/abstract-type-members.md
+++ b/_tour/abstract-type-members.md
@@ -2,7 +2,7 @@
 layout: tour
 title: Abstract Type Members
 partof: scala-tour
-num: 23
+num: 25
 next-page: compound-types
 previous-page: inner-classes
 topics: abstract type members

--- a/_tour/annotations.md
+++ b/_tour/annotations.md
@@ -3,9 +3,9 @@ layout: tour
 title: Annotations
 partof: scala-tour
 
-num: 33
+num: 34
 next-page: packages-and-imports
-previous-page: operators
+previous-page: by-name-parameters
 
 redirect_from: "/tutorials/tour/annotations.html"
 ---

--- a/_tour/annotations.md
+++ b/_tour/annotations.md
@@ -3,9 +3,9 @@ layout: tour
 title: Annotations
 partof: scala-tour
 
-num: 32
-next-page: default-parameter-values
-previous-page: by-name-parameters
+num: 33
+next-page: packages-and-imports
+previous-page: operators
 
 redirect_from: "/tutorials/tour/annotations.html"
 ---

--- a/_tour/basics.md
+++ b/_tour/basics.md
@@ -322,3 +322,7 @@ object Main {
     println("Hello, Scala developer!")
 }
 ```
+
+## More resources
+
+* [Scala book](/overviews/scala-book/prelude-taste-of-scala.html) overview

--- a/_tour/by-name-parameters.md
+++ b/_tour/by-name-parameters.md
@@ -3,7 +3,7 @@ layout: tour
 title: By-name Parameters
 partof: scala-tour
 
-num: 31
+num: 33
 next-page: annotations
 previous-page: operators
 

--- a/_tour/case-classes.md
+++ b/_tour/case-classes.md
@@ -57,4 +57,4 @@ The recipient of `message4` is used as the sender of `message5` but the `body` o
 
 ## More resources
 
-* Learn more about case classes in [Scala Book](/overviews/scala-book/case-classes.html)
+* Learn more about case classes in the [Scala Book](/overviews/scala-book/case-classes.html)

--- a/_tour/case-classes.md
+++ b/_tour/case-classes.md
@@ -3,7 +3,7 @@ layout: tour
 title: Case Classes
 partof: scala-tour
 
-num: 11
+num: 13
 next-page: pattern-matching
 previous-page: multiple-parameter-lists
 prerequisite-knowledge: classes, basics, mutability
@@ -54,3 +54,7 @@ message5.recipient // claire@bourgogne.fr
 message5.body  // "Me zo o komz gant ma amezeg"
 ```
 The recipient of `message4` is used as the sender of `message5` but the `body` of `message4` was copied directly.
+
+## More resources
+
+* Learn more about case classes in [Scala Book](/overviews/scala-book/case-classes.html)

--- a/_tour/classes.md
+++ b/_tour/classes.md
@@ -4,7 +4,7 @@ title: Classes
 partof: scala-tour
 
 num: 4
-next-page: traits
+next-page: default-parameter-values
 previous-page: unified-types
 topics: classes
 prerequisite-knowledge: no-return-keyword, type-declaration-syntax, string-interpolation, procedures
@@ -108,3 +108,8 @@ class Point(x: Int, y: Int)
 val point = new Point(1, 2)
 point.x  // <-- does not compile
 ```
+
+## More resources
+
+* Learn more about Classes in scala in [Scala Book](/overviews/scala-book/classes.html)
+* How to use [Auxiliary Class Constructors](/overviews/scala-book/classes-aux-constructors.html)

--- a/_tour/classes.md
+++ b/_tour/classes.md
@@ -111,5 +111,5 @@ point.x  // <-- does not compile
 
 ## More resources
 
-* Learn more about Classes in scala in [Scala Book](/overviews/scala-book/classes.html)
+* Learn more about Classes in the [Scala Book](/overviews/scala-book/classes.html)
 * How to use [Auxiliary Class Constructors](/overviews/scala-book/classes-aux-constructors.html)

--- a/_tour/compound-types.md
+++ b/_tour/compound-types.md
@@ -3,7 +3,7 @@ layout: tour
 title: Compound Types
 partof: scala-tour
 
-num: 24
+num: 26
 next-page: self-types
 previous-page: abstract-type-members
 

--- a/_tour/default-parameter-values.md
+++ b/_tour/default-parameter-values.md
@@ -3,9 +3,9 @@ layout: tour
 title: Default Parameter Values
 partof: scala-tour
 
-num: 33
+num: 6
 next-page: named-arguments
-previous-page: annotations
+previous-page: classes
 prerequisite-knowledge: named-arguments, function syntax
 
 redirect_from: "/tutorials/tour/default-parameter-values.html"

--- a/_tour/extractor-objects.md
+++ b/_tour/extractor-objects.md
@@ -3,7 +3,7 @@ layout: tour
 title: Extractor Objects
 partof: scala-tour
 
-num: 16
+num: 18
 next-page: for-comprehensions
 previous-page: regular-expression-patterns
 

--- a/_tour/for-comprehensions.md
+++ b/_tour/for-comprehensions.md
@@ -65,4 +65,4 @@ foo(10, 10)
 
 ## More resources
 
-* Other examples of "For comprehension" in [Scala Book](/overviews/scala-book/for-expressions.html)
+* Other examples of "For comprehension" in the [Scala Book](/overviews/scala-book/for-expressions.html)

--- a/_tour/for-comprehensions.md
+++ b/_tour/for-comprehensions.md
@@ -3,7 +3,7 @@ layout: tour
 title: For Comprehensions
 partof: scala-tour
 
-num: 17
+num: 19
 next-page: generic-classes
 previous-page: extractor-objects
 
@@ -62,3 +62,7 @@ def foo(n: Int, v: Int) =
 
 foo(10, 10)
 ```
+
+## More resources
+
+* Other examples of "For comprehension" in [Scala Book](/overviews/scala-book/for-expressions.html)

--- a/_tour/generic-classes.md
+++ b/_tour/generic-classes.md
@@ -3,7 +3,7 @@ layout: tour
 title: Generic Classes
 partof: scala-tour
 
-num: 18
+num: 20
 next-page: variances
 previous-page: for-comprehensions
 assumed-knowledge: classes unified-types

--- a/_tour/higher-order-functions.md
+++ b/_tour/higher-order-functions.md
@@ -35,7 +35,7 @@ val salaries = Seq(20000, 70000, 40000)
 val newSalaries = salaries.map(x => x * 2) // List(40000, 140000, 80000)
 ```
 Notice how `x` is not declared as an Int in the above example. That's because the
-compiler can infer the type based on the type of function map expects (see [Currying]{/tour/multiple-parameter-lists.html}). An even more idiomatic way to write the same piece of code would be:
+compiler can infer the type based on the type of function map expects (see [Currying](/tour/multiple-parameter-lists.html). An even more idiomatic way to write the same piece of code would be:
 
 ```tut
 val salaries = Seq(20000, 70000, 40000)

--- a/_tour/higher-order-functions.md
+++ b/_tour/higher-order-functions.md
@@ -3,7 +3,7 @@ layout: tour
 title: Higher-order Functions
 partof: scala-tour
 
-num: 8
+num: 10
 next-page: nested-functions
 previous-page: mixin-class-composition
 
@@ -35,7 +35,7 @@ val salaries = Seq(20000, 70000, 40000)
 val newSalaries = salaries.map(x => x * 2) // List(40000, 140000, 80000)
 ```
 Notice how `x` is not declared as an Int in the above example. That's because the
-compiler can infer the type based on the type of function map expects. An even more idiomatic way to write the same piece of code would be:
+compiler can infer the type based on the type of function map expects (see [Currying]{/tour/multiple-parameter-lists.html}). An even more idiomatic way to write the same piece of code would be:
 
 ```tut
 val salaries = Seq(20000, 70000, 40000)

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -3,7 +3,7 @@ layout: tour
 title: Implicit Conversions
 partof: scala-tour
 
-num: 27
+num: 29
 next-page: polymorphic-methods
 previous-page: implicit-parameters
 

--- a/_tour/implicit-parameters.md
+++ b/_tour/implicit-parameters.md
@@ -3,7 +3,7 @@ layout: tour
 title: Implicit Parameters
 partof: scala-tour
 
-num: 26
+num: 28
 next-page: implicit-conversions
 previous-page: self-types
 

--- a/_tour/inner-classes.md
+++ b/_tour/inner-classes.md
@@ -3,7 +3,7 @@ layout: tour
 title: Inner Classes
 partof: scala-tour
 
-num: 22
+num: 24
 next-page: abstract-type-members
 previous-page: lower-type-bounds
 

--- a/_tour/lower-type-bounds.md
+++ b/_tour/lower-type-bounds.md
@@ -3,7 +3,7 @@ layout: tour
 title: Lower Type Bounds
 partof: scala-tour
 
-num: 21
+num: 23
 next-page: inner-classes
 previous-page: upper-type-bounds
 prerequisite-knowledge: upper-type-bounds, generics, variance

--- a/_tour/mixin-class-composition.md
+++ b/_tour/mixin-class-composition.md
@@ -3,7 +3,7 @@ layout: tour
 title: Class Composition with Mixins
 partof: scala-tour
 
-num: 7
+num: 9
 next-page: higher-order-functions
 previous-page: tuples
 prerequisite-knowledge: inheritance, traits, abstract-classes, unified-types

--- a/_tour/multiple-parameter-lists.md
+++ b/_tour/multiple-parameter-lists.md
@@ -3,7 +3,7 @@ layout: tour
 title: Multiple Parameter Lists (Currying)
 partof: scala-tour
 
-num: 10
+num: 12
 next-page: case-classes
 previous-page: nested-functions
 

--- a/_tour/named-arguments.md
+++ b/_tour/named-arguments.md
@@ -3,8 +3,8 @@ layout: tour
 title: Named Arguments
 partof: scala-tour
 
-num: 34
-next-page: packages-and-imports
+num: 5
+next-page: traits
 previous-page: default-parameter-values
 prerequisite-knowledge: function-syntax
 

--- a/_tour/nested-functions.md
+++ b/_tour/nested-functions.md
@@ -3,7 +3,7 @@ layout: tour
 title: Nested Methods
 partof: scala-tour
 
-num: 9
+num: 11
 next-page: multiple-parameter-lists
 previous-page: higher-order-functions
 

--- a/_tour/operators.md
+++ b/_tour/operators.md
@@ -4,7 +4,7 @@ title: Operators
 partof: scala-tour
 
 num: 32
-next-page: annotations
+next-page: by-name-parameters
 previous-page: type-inference
 prerequisite-knowledge: case-classes
 

--- a/_tour/operators.md
+++ b/_tour/operators.md
@@ -3,8 +3,8 @@ layout: tour
 title: Operators
 partof: scala-tour
 
-num: 30
-next-page: by-name-parameters
+num: 32
+next-page: annotations
 previous-page: type-inference
 prerequisite-knowledge: case-classes
 

--- a/_tour/package-objects.md
+++ b/_tour/package-objects.md
@@ -3,7 +3,7 @@ layout: tour
 title: Package Objects
 partof: scala-tour
 
-num: 35
+num: 36
 previous-page: packages-and-imports
 ---
 

--- a/_tour/package-objects.md
+++ b/_tour/package-objects.md
@@ -3,7 +3,7 @@ layout: tour
 title: Package Objects
 partof: scala-tour
 
-num: 36
+num: 35
 previous-page: packages-and-imports
 ---
 

--- a/_tour/packages-and-imports.md
+++ b/_tour/packages-and-imports.md
@@ -3,7 +3,7 @@ layout: tour
 title: Packages and Imports
 partof: scala-tour
 
-num: 34
+num: 35
 next-page: package-objects
 previous-page: annotations
 ---

--- a/_tour/packages-and-imports.md
+++ b/_tour/packages-and-imports.md
@@ -3,9 +3,9 @@ layout: tour
 title: Packages and Imports
 partof: scala-tour
 
-num: 35
-previous-page: named-arguments
+num: 34
 next-page: package-objects
+previous-page: annotations
 ---
 
 # Packages and Imports

--- a/_tour/pattern-matching.md
+++ b/_tour/pattern-matching.md
@@ -3,8 +3,7 @@ layout: tour
 title: Pattern Matching
 partof: scala-tour
 
-num: 12
-
+num: 14
 next-page: singleton-objects
 previous-page: case-classes
 prerequisite-knowledge: case-classes, string-interpolation, subtyping
@@ -143,7 +142,33 @@ def findPlaceToSit(piece: Furniture): String = piece match {
 ```
 This is useful for pattern matching because we don't need a "catch all" case.
 
+## Summary of pattern matching syntax
+
+```tut
+case class Point(x: Int, y: Int)
+
+val value: Any = "test"
+
+val res: String = value match {
+  case "a" => "exact match"
+  case v @ "b" => "exact match: " + v
+  case 5 => "exact match"
+  case (2, true) => "exact match"
+  case i: String => "type match: " + i
+  case _: Boolean => "type match"
+  case (false, s) => "extract tuple: " + s
+  case Point(0, y) => "extract case class: " + y
+  case x: Int if x > 1 => "condition"
+  case (true, Point(x, 3)) if x < 0 => "complex"
+  case _ => "default"
+}
+```
+
 ## Notes
 
 Scala's pattern matching statement is most useful for matching on algebraic types expressed via [case classes](case-classes.html).
 Scala also allows the definition of patterns independently of case classes, using `unapply` methods in [extractor objects](extractor-objects.html).
+
+## More resources
+
+* More details on match expressions in [Scala Book](/overviews/scala-book/match-expressions.html)

--- a/_tour/pattern-matching.md
+++ b/_tour/pattern-matching.md
@@ -142,28 +142,6 @@ def findPlaceToSit(piece: Furniture): String = piece match {
 ```
 This is useful for pattern matching because we don't need a "catch all" case.
 
-## Summary of pattern matching syntax
-
-```tut
-case class Point(x: Int, y: Int)
-
-val value: Any = "test"
-
-val res: String = value match {
-  case "a" => "exact match"
-  case v @ "b" => "exact match: " + v
-  case 5 => "exact match"
-  case (2, true) => "exact match"
-  case i: String => "type match: " + i
-  case _: Boolean => "type match"
-  case (false, s) => "extract tuple: " + s
-  case Point(0, y) => "extract case class: " + y
-  case x: Int if x > 1 => "condition"
-  case (true, Point(x, 3)) if x < 0 => "complex"
-  case _ => "default"
-}
-```
-
 ## Notes
 
 Scala's pattern matching statement is most useful for matching on algebraic types expressed via [case classes](case-classes.html).
@@ -171,4 +149,4 @@ Scala also allows the definition of patterns independently of case classes, usin
 
 ## More resources
 
-* More details on match expressions in [Scala Book](/overviews/scala-book/match-expressions.html)
+* More details on match expressions in the [Scala Book](/overviews/scala-book/match-expressions.html)

--- a/_tour/polymorphic-methods.md
+++ b/_tour/polymorphic-methods.md
@@ -3,7 +3,7 @@ layout: tour
 title: Polymorphic Methods
 partof: scala-tour
 
-num: 28
+num: 30
 
 next-page: type-inference
 previous-page: implicit-conversions

--- a/_tour/regular-expression-patterns.md
+++ b/_tour/regular-expression-patterns.md
@@ -3,7 +3,7 @@ layout: tour
 title: Regular Expression Patterns
 partof: scala-tour
 
-num: 15
+num: 17
 
 next-page: extractor-objects
 previous-page: singleton-objects

--- a/_tour/self-types.md
+++ b/_tour/self-types.md
@@ -3,7 +3,7 @@ layout: tour
 title: Self-type
 partof: scala-tour
 
-num: 25
+num: 27
 next-page: implicit-parameters
 previous-page: compound-types
 topics: self-types

--- a/_tour/singleton-objects.md
+++ b/_tour/singleton-objects.md
@@ -107,4 +107,4 @@ When using a companion object from Java code, the members will be defined in a c
 
 ## More resources
 
-* Learn more about Companion objects in [Scala Book](/overviews/scala-book/companion-objects.html)
+* Learn more about Companion objects in the [Scala Book](/overviews/scala-book/companion-objects.html)

--- a/_tour/singleton-objects.md
+++ b/_tour/singleton-objects.md
@@ -3,8 +3,7 @@ layout: tour
 title: Singleton Objects
 partof: scala-tour
 
-num: 13
-
+num: 15
 next-page: regular-expression-patterns
 previous-page: pattern-matching
 redirect_from: "/tutorials/tour/singleton-objects.html"
@@ -105,3 +104,7 @@ Note: If a class or object has a companion, both must be defined in the same fil
 `static` members in Java are modeled as ordinary members of a companion object in Scala.
 
 When using a companion object from Java code, the members will be defined in a companion class with a `static` modifier. This is called _static forwarding_. It occurs even if you haven't defined a companion class yourself.
+
+## More resources
+
+* Learn more about Companion objects in [Scala Book](/overviews/scala-book/companion-objects.html)

--- a/_tour/traits.md
+++ b/_tour/traits.md
@@ -83,5 +83,5 @@ The `trait Pet` has an abstract field `name` that gets implemented by Cat and Do
 
 ## More resources
 
-* Learn more about traits in [Scala Book](/overviews/scala-book/traits-intro.html) in Scala book
+* Learn more about traits in the [Scala Book](/overviews/scala-book/traits-intro.html)
 * Use traits to define [Enum](/overviews/scala-book/enumerations-pizza-class.html)

--- a/_tour/traits.md
+++ b/_tour/traits.md
@@ -3,9 +3,9 @@ layout: tour
 title: Traits
 partof: scala-tour
 
-num: 5
+num: 7
 next-page: tuples
-previous-page: classes
+previous-page: named-arguments
 topics: traits
 prerequisite-knowledge: expressions, classes, generics, objects, companion-objects
 
@@ -79,3 +79,9 @@ animals.append(cat)
 animals.foreach(pet => println(pet.name))  // Prints Harry Sally
 ```
 The `trait Pet` has an abstract field `name` that gets implemented by Cat and Dog in their constructors. On the last line, we call `pet.name`, which must be implemented in any subtype of the trait `Pet`.
+
+
+## More resources
+
+* Learn more about traits in [Scala Book](/overviews/scala-book/traits-intro.html) in Scala book
+* Use traits to define [Enum](/overviews/scala-book/enumerations-pizza-class.html)

--- a/_tour/tuples.md
+++ b/_tour/tuples.md
@@ -82,4 +82,4 @@ Users may sometimes find it hard to choose between tuples and case classes. Case
 
 ## More resources
 
-* Learn more about tuples in [Scala Book](/overviews/scala-book/tuples.html) in Scala book
+* Learn more about tuples in the [Scala Book](/overviews/scala-book/tuples.html)

--- a/_tour/tuples.md
+++ b/_tour/tuples.md
@@ -3,7 +3,7 @@ layout: tour
 title: Tuples
 partof: scala-tour
 
-num: 6
+num: 8
 next-page: mixin-class-composition
 previous-page: traits
 topics: tuples
@@ -79,3 +79,7 @@ for ((a, b) <- numPairs) {
 
 Users may sometimes find it hard to choose between tuples and case classes. Case classes have named elements. The names can improve the readability of some kinds of code. In the planet example above, we might define `case class Planet(name: String, distance: Double)` rather than using tuples.
 
+
+## More resources
+
+* Learn more about tuples in [Scala Book](/overviews/scala-book/tuples.html) in Scala book

--- a/_tour/type-inference.md
+++ b/_tour/type-inference.md
@@ -3,7 +3,7 @@ layout: tour
 title: Type Inference
 partof: scala-tour
 
-num: 29
+num: 31
 next-page: operators
 previous-page: polymorphic-methods
 ---

--- a/_tour/upper-type-bounds.md
+++ b/_tour/upper-type-bounds.md
@@ -3,7 +3,7 @@ layout: tour
 title: Upper Type Bounds
 partof: scala-tour
 categories: tour
-num: 20
+num: 22
 next-page: lower-type-bounds
 previous-page: variances
 

--- a/_tour/variances.md
+++ b/_tour/variances.md
@@ -3,7 +3,7 @@ layout: tour
 title: Variances
 partof: scala-tour
 
-num: 19
+num: 21
 next-page: upper-type-bounds
 previous-page: generic-classes
 


### PR DESCRIPTION
Some articles in scala book give additional information/examples to some tour of scala articles.
I added some links to Tour of scala
+ Moved Named arguments and default parameter values next to Classes articles
+ Added an example to pattern matching article to summarise pattern matching syntax