### PR TITLE
Improve the getting started page

### DIFF
--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -7,55 +7,121 @@ includeTOC: true
 
 redirect_from: "/getting-started.html"
 ---
+## Try Scala without installing anything 
+You can [try Scala in your browser](https://scastie.scala-lang.org/MHc7C9iiTbGfeSAvg8CKAA), with access to all Scala compilers and 
+all published libraries.
 
-There are __two__ main ways people prefer to work in Scala:
+##  Installing Scala
+### Using the Scala Installer (recommended way)
+The Scala installer is a tool named `cs` that ensures that a JVM and standard Scala tools are installed on your system.  
 
-* Using an IDE.
-* Using the command line.
+* Download the `cs` tool and execute the `setup` command
 
-The following tutorials will walk you through the setup process for whichever way
-you prefer.
-
-However, if you just want to jump directly into Scala without installing anything, skip the guides on this page and check out:
-
-* [Our interactive introduction to Scala on scala-exercises.com](https://www.scala-exercises.org/scala_tutorial/terms_and_types), or
-* [Scastie](https://scastie.scala-lang.org/), Scala in the browser, with access to all Scala compilers and all published libraries!
-
-## Setting up and getting started with Scala
-
-### If you prefer working in an IDE...
-
-IntelliJ is the most commonly-used IDE by Scala developers. In this tutorial,
-we'll walk you through downloading and setting up IntelliJ with the Scala
-plugin, and we'll get you started with your first Scala project, complete with
-unit tests!
-
-* [Getting Started with Scala in IntelliJ](/getting-started/intellij-track/getting-started-with-scala-in-intellij.html)
-* [Building a Scala Project with IntelliJ and sbt](/getting-started/intellij-track/building-a-scala-project-with-intellij-and-sbt.html)
-* [Testing Scala in IntelliJ with ScalaTest](/getting-started/intellij-track/testing-scala-in-intellij-with-scalatest.html)
+<div class="main-download">
+    <div id="download-step-one">
+        <p>Follow <a href="https://get-coursier.io/docs/cli-overview.html#install-native-launcher" target="_blank">the instructions to install the <code>cs</code> launcher</a> then run:</p>
+        <p><code>$ ./cs setup</code></p>
+    </div>
+</div>
 
 
-### If you prefer working on the command line...
+Along with managing JVMs, it also install useful command-line tools: 
+ammonite, coursier, scala, scalac, sbt-launcher, scalafmt.
 
-If you prefer using a text editor like emacs, Vim, Atom, or Sublime Text, then
-the best way to compile, test, and run Scala code is by using _sbt_, Scala's build
-tool.
+For more information, read [couriser-cli documentation](https://get-coursier.io/docs/cli-overview)
 
-* [Getting Started with Scala and sbt on the Command Line](/getting-started/sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.html)
-* [Testing Scala with sbt and ScalaTest on the Command Line](/getting-started/sbt-track/testing-scala-with-sbt-on-the-command-line.html)
+### ...Or manually
+1. if you don't have java 1.8 or 11 installed, download 
+Java from [Oracle Java 8](https://www.oracle.com/java/technologies/javase-jdk8-downloads.html), [
+Oracle Java 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html), 
+or [AdoptOpenJDK 8/11](https://adoptopenjdk.net/). Refer [JDK Compatibility](/overviews/jdk-compatibility/overview.html) for Scala/Java compatibility detail.
+1. Install [sbt](https://www.scala-sbt.org/download.html)
 
-<!-- sbt is the easiest way to ensure that your Scala project is reproducible;
-you specify a Scala version, any libraries you depend on, and sbt takes care of
-the rest, so it's as easy as possible for someone else to compile and run your
-Scala project. -->
+
+## Create a Hello-world project with sbt
+### Using command-line
+sbt is a build tool for Scala. sbt compiles, runs, 
+and tests your projects among other related tasks.
+
+1. `cd` to an empty folder.
+1. Run the following command `sbt new scala/hello-world.g8`.
+This pulls the 'hello-world' template from GitHub.
+It will also create a `target` folder, which you can ignore.
+1. When prompted, name the application `hello-world`. This will
+create a project called "hello-world".
+1. Let's take a look at what just got generated:
+
+```
+- hello-world
+    - project (sbt uses this to install and manage plugins and dependencies)
+        - build.properties
+    - src
+        - main
+            - scala (All of your scala code goes here)
+                - Main.scala (Entry point of program) <-- this is all we need for now
+    - build.sbt (sbt's build definition file)
+```
+
+More documentation about sbt can be found in the [Scala Book](/overviews/scala-book/scala-build-tool-sbt.html) 
+or in the official sbt [documentation](https://www.scala-sbt.org/1.x/docs/index.html)
+
+### Without using command-line
+You can skip the rest of this page and go directly to [Building a Scala Project with IntelliJ and sbt](/getting-started/intellij-track/building-a-scala-project-with-intellij-and-sbt.html#next-steps)
+
+
+## Open hello-world project
+### Using Intellij
+1. Download and install [IntelliJ Community Edition](https://www.jetbrains.com/idea/download/)
+1. Install Scala plugin by following [the instructions on how to install IntelliJ plugins](https://www.jetbrains.com/help/idea/managing-plugins.html)
+1. Open the `build.sbt` file then choose *Open as a project*
+
+### Using VSCode with metals 
+1. Download [VSCode](https://code.visualstudio.com/Download)
+1. Install the Metals extension from [the Marketplace](https://marketplace.visualstudio.com/items?itemName=scalameta.metals)
+1. Next, open the directory containing a `build.sbt` file. When prompted to do so, select *Import build*.
+
+## Run Hello World
+Open a terminal
+1. `cd` into `hello-world`.
+1. Run `sbt`. This will open up the sbt console.
+1. Type `~run`. The `~` is optional and causes sbt to re-run on every file save,
+allowing for a fast edit/run/debug cycle. sbt will also generate a `target` directory
+which you can ignore.
+
 
 ## Next Steps
 Once you've finished these tutorials, check out:
 
-* [The Tour of Scala](/tour/tour-of-scala.html) for bite-sized introductions to Scala's features.
 * [The Scala Book](/overviews/scala-book/introduction.html), which provides a set of short lessons introducing Scala’s main features.
+* [The Tour of Scala](/tour/tour-of-scala.html) for bite-sized introductions to Scala's features.
 * [Learning Resources](/learn.html), which includes online interactive tutorials and courses.
 * [Our list of some popular Scala books](/books.html).
 
 ## Getting Help
 There are a multitude of mailing lists and real-time chat channels in case you want to quickly connect with other Scala users. Check out our [community](https://scala-lang.org/community/) page for a list of these resources, and for where to reach out for help.
+
+<!-- Hidden elements whose content are used to provide OS-specific download instructions.
+ -- This is handled in `resources/js/functions.js`.
+ --> 
+<div style="display:none" id="stepOne-linux">
+       <code class="hljs">$ curl -Lo cs https://git.io/coursier-cli-linux && chmod +x cs && ./cs setup </code> <br>
+</div>
+ 
+<div style="display:none" id="stepOne-unix">
+    <p>Follow <a href="https://get-coursier.io/docs/cli-overview.html#install-native-launcher" target="_blank">the instructions to install the <code>cs</code> launcher</a> then run:</p>
+    <p><code>$ ./cs setup</code></p>
+</div>
+ 
+<div style="display:none" id="stepOne-osx">
+    <div class="highlight">
+        <code class="hljs">$ brew install coursier/formulas/coursier && cs setup </code> <br>
+    </div>
+    <p>Alternatively, if you don't use Homebrew</p>
+    <div class="highlight">
+        <code class="hljs">$ curl -Lo cs https://git.io/coursier-cli-macos && chmod +x cs &&  (xattr -d com.apple.quarantine cs || true) && ./cs  setup </code> <br>
+    </div>
+</div>
+  
+<div style="display:none" id="stepOne-windows">
+    <p>Download and execute <a href="https://git.io/coursier-cli-windows-exe">the Scala installer for Windows</a> based on coursier</p>
+</div>

--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -72,7 +72,7 @@ You can skip the rest of this page and go directly to [Building a Scala Project 
 ## Open hello-world project
 ### Using IntelliJ
 1. Download and install [IntelliJ Community Edition](https://www.jetbrains.com/idea/download/)
-1. Install Scala plugin by following [the instructions on how to install IntelliJ plugins](https://www.jetbrains.com/help/idea/managing-plugins.html)
+1. Install the Scala plugin by following [the instructions on how to install IntelliJ plugins](https://www.jetbrains.com/help/idea/managing-plugins.html)
 1. Open the `build.sbt` file then choose *Open as a project*
 
 ### Using VSCode with metals 

--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -28,7 +28,7 @@ The Scala installer is a tool named `cs` that ensures that a JVM and standard Sc
 Along with managing JVMs, it also installs useful command line tools: 
 ammonite, coursier, scala, scalac, sbt-launcher, scalafmt.
 
-For more information, read [couriser-cli documentation](https://get-coursier.io/docs/cli-overview)
+For more information, read [coursier-cli documentation](https://get-coursier.io/docs/cli-overview)
 
 ### ...Or manually
 1. if you don't have java 1.8 or 11 installed, download 

--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -31,7 +31,7 @@ ammonite, coursier, scala, scalac, sbt-launcher, scalafmt.
 For more information, read [coursier-cli documentation](https://get-coursier.io/docs/cli-overview)
 
 ### ...Or manually
-1. if you don't have java 1.8 or 11 installed, download 
+1. if you don't have Java 1.8 or 11 installed, download 
 Java from [Oracle Java 8](https://www.oracle.com/java/technologies/javase-jdk8-downloads.html), [
 Oracle Java 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html), 
 or [AdoptOpenJDK 8/11](https://adoptopenjdk.net/). Refer [JDK Compatibility](/overviews/jdk-compatibility/overview.html) for Scala/Java compatibility detail.

--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -11,7 +11,10 @@ redirect_from: "/getting-started.html"
 You can [try Scala in your browser](https://scastie.scala-lang.org/MHc7C9iiTbGfeSAvg8CKAA), with access to all Scala compilers and 
 all published libraries.
 
-##  Installing Scala
+##  Install Scala
+Installing scala means installing various command-line tools such as the Scala compiler and build tools.
+We recommend using the Scala installer tool that automatically installs all the requirements, but you can still manually install each tool.
+
 ### Using the Scala Installer (recommended way)
 The Scala installer is a tool named `cs` that ensures that a JVM and standard Scala tools are installed on your system.  
 
@@ -26,7 +29,11 @@ The Scala installer is a tool named `cs` that ensures that a JVM and standard Sc
 
 
 Along with managing JVMs, it also installs useful command line tools: 
-ammonite, coursier, scala, scalac, sbt-launcher, scalafmt.
+[Ammonite](https://ammonite.io/), 
+[coursier](https://get-coursier.io/), 
+scala, scalac (the Scala compiler), 
+[sbt](https://www.scala-sbt.org/), 
+[scalafmt](https://scalameta.org/scalafmt/).
 
 For more information, read [coursier-cli documentation](https://get-coursier.io/docs/cli-overview)
 
@@ -39,6 +46,9 @@ or [AdoptOpenJDK 8/11](https://adoptopenjdk.net/). Refer [JDK Compatibility](/ov
 
 
 ## Create a Hello-world project with sbt
+To create a project, you can either use a command-line tool or an IDE. 
+If you are familiar with command-lines, we recommend to use the first approach.
+
 ### Using command-line
 sbt is a build tool for Scala. sbt compiles, runs, 
 and tests your projects among other related tasks.
@@ -65,11 +75,13 @@ create a project called "hello-world".
 More documentation about sbt can be found in the [Scala Book](/overviews/scala-book/scala-build-tool-sbt.html) 
 or in the official sbt [documentation](https://www.scala-sbt.org/1.x/docs/index.html)
 
-### Without using the command line
+### With an IDE
 You can skip the rest of this page and go directly to [Building a Scala Project with IntelliJ and sbt](/getting-started/intellij-track/building-a-scala-project-with-intellij-and-sbt.html#next-steps)
 
 
 ## Open hello-world project
+Let's use an IDE to open the project. The most popular ones are IntelliJ and VSCode. 
+They both offer rich IDE features, but you can still use [many other editors.](https://scalameta.org/metals/docs/editors/overview.html)
 ### Using IntelliJ
 1. Download and install [IntelliJ Community Edition](https://www.jetbrains.com/idea/download/)
 1. Install the Scala plugin by following [the instructions on how to install IntelliJ plugins](https://www.jetbrains.com/help/idea/managing-plugins.html)

--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -12,7 +12,7 @@ You can [try Scala in your browser](https://scastie.scala-lang.org/MHc7C9iiTbGfe
 all published libraries.
 
 ##  Install Scala
-Installing scala means installing various command-line tools such as the Scala compiler and build tools.
+Installing Scala means installing various command-line tools such as the Scala compiler and build tools.
 We recommend using the Scala installer tool that automatically installs all the requirements, but you can still manually install each tool.
 
 ### Using the Scala Installer (recommended way)
@@ -31,27 +31,26 @@ The Scala installer is a tool named `cs` that ensures that a JVM and standard Sc
 Along with managing JVMs, it also installs useful command line tools: 
 [Ammonite](https://ammonite.io/), 
 [coursier](https://get-coursier.io/), 
-scala, scalac (the Scala compiler), 
-[sbt](https://www.scala-sbt.org/), 
+scala (the Scala REPL and script runner),
+scalac (the Scala compiler), 
+[sbt](https://www.scala-sbt.org/), and
 [scalafmt](https://scalameta.org/scalafmt/).
 
-For more information, read [coursier-cli documentation](https://get-coursier.io/docs/cli-overview)
+For more information, read [coursier-cli documentation](https://get-coursier.io/docs/cli-overview).
 
 ### ...Or manually
-1. if you don't have Java 1.8 or 11 installed, download 
-Java from [Oracle Java 8](https://www.oracle.com/java/technologies/javase-jdk8-downloads.html), [
-Oracle Java 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html), 
-or [AdoptOpenJDK 8/11](https://adoptopenjdk.net/). Refer [JDK Compatibility](/overviews/jdk-compatibility/overview.html) for Scala/Java compatibility detail.
+1. if you don't have Java 8 or 11 installed, download 
+Java from [Oracle Java 8](https://www.oracle.com/java/technologies/javase-jdk8-downloads.html), [Oracle Java 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html), 
+or [AdoptOpenJDK 8/11](https://adoptopenjdk.net/). Refer to [JDK Compatibility](/overviews/jdk-compatibility/overview.html) for Scala/Java compatibility detail.
 1. Install [sbt](https://www.scala-sbt.org/download.html)
-
 
 ## Create a Hello-world project with sbt
 To create a project, you can either use a command-line tool or an IDE. 
-If you are familiar with command-lines, we recommend to use the first approach.
+If you are familiar with the command line, we recommend that approach.
 
 ### Using command-line
 sbt is a build tool for Scala. sbt compiles, runs, 
-and tests your projects among other related tasks.
+and tests your Scala code. (It can also publish libraries and do many other tasks.)
 
 1. `cd` to an empty folder.
 1. Run the following command `sbt new scala/hello-world.g8`.
@@ -63,17 +62,17 @@ create a project called "hello-world".
 
 ```
 - hello-world
-    - project (sbt uses this to install and manage plugins and dependencies)
+    - project (sbt uses this for its own files)
         - build.properties
+    - build.sbt (sbt's build definition file)
     - src
         - main
-            - scala (All of your scala code goes here)
+            - scala (all of your Scala code goes here)
                 - Main.scala (Entry point of program) <-- this is all we need for now
-    - build.sbt (sbt's build definition file)
 ```
 
 More documentation about sbt can be found in the [Scala Book](/overviews/scala-book/scala-build-tool-sbt.html) 
-or in the official sbt [documentation](https://www.scala-sbt.org/1.x/docs/index.html)
+and in the official sbt [documentation](https://www.scala-sbt.org/1.x/docs/index.html)
 
 ### With an IDE
 You can skip the rest of this page and go directly to [Building a Scala Project with IntelliJ and sbt](/getting-started/intellij-track/building-a-scala-project-with-intellij-and-sbt.html#next-steps)
@@ -102,7 +101,7 @@ which you can ignore.
 
 
 ## Next Steps
-Once you've finished these tutorials, check out:
+Once you've finished the above tutorials, consider checking out:
 
 * [The Scala Book](/overviews/scala-book/introduction.html), which provides a set of short lessons introducing Scala’s main features.
 * [The Tour of Scala](/tour/tour-of-scala.html) for bite-sized introductions to Scala's features.
@@ -110,7 +109,7 @@ Once you've finished these tutorials, check out:
 * [Our list of some popular Scala books](/books.html).
 
 ## Getting Help
-There are a multitude of mailing lists and real-time chat channels in case you want to quickly connect with other Scala users. Check out our [community](https://scala-lang.org/community/) page for a list of these resources, and for where to reach out for help.
+There are a multitude of mailing lists and real-time chat rooms in case you want to quickly connect with other Scala users. Check out our [community](https://scala-lang.org/community/) page for a list of these resources, and for where to reach out for help.
 
 <!-- Hidden elements whose content are used to provide OS-specific download instructions.
  -- This is handled in `resources/js/functions.js`.

--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -65,7 +65,7 @@ create a project called "hello-world".
 More documentation about sbt can be found in the [Scala Book](/overviews/scala-book/scala-build-tool-sbt.html) 
 or in the official sbt [documentation](https://www.scala-sbt.org/1.x/docs/index.html)
 
-### Without using command-line
+### Without using the command line
 You can skip the rest of this page and go directly to [Building a Scala Project with IntelliJ and sbt](/getting-started/intellij-track/building-a-scala-project-with-intellij-and-sbt.html#next-steps)
 
 

--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -25,7 +25,7 @@ The Scala installer is a tool named `cs` that ensures that a JVM and standard Sc
 </div>
 
 
-Along with managing JVMs, it also install useful command-line tools: 
+Along with managing JVMs, it also installs useful command line tools: 
 ammonite, coursier, scala, scalac, sbt-launcher, scalafmt.
 
 For more information, read [couriser-cli documentation](https://get-coursier.io/docs/cli-overview)

--- a/_getting-started/index.md
+++ b/_getting-started/index.md
@@ -70,7 +70,7 @@ You can skip the rest of this page and go directly to [Building a Scala Project 
 
 
 ## Open hello-world project
-### Using Intellij
+### Using IntelliJ
 1. Download and install [IntelliJ Community Edition](https://www.jetbrains.com/idea/download/)
 1. Install Scala plugin by following [the instructions on how to install IntelliJ plugins](https://www.jetbrains.com/help/idea/managing-plugins.html)
 1. Open the `build.sbt` file then choose *Open as a project*

--- a/_getting-started/intellij-track/building-a-scala-project-with-intellij-and-sbt.md
+++ b/_getting-started/intellij-track/building-a-scala-project-with-intellij-and-sbt.md
@@ -105,6 +105,7 @@ Continue to the next tutorial in the _getting started with IntelliJ_ series, and
 
 **or**
 
+* [The Scala Book](/overviews/scala-book/introduction.html), which provides a set of short lessons introducing Scala’s main features.
+* [The Tour of Scala](/tour/tour-of-scala.html) for bite-sized introductions to Scala's features.
 - Continue learning Scala interactively online on
  [Scala Exercises](https://www.scala-exercises.org/scala_tutorial).
-- Learn about Scala's features in bite-sized pieces by stepping through our [Tour of Scala]({{ site.baseurl }}/tour/tour-of-scala.html).


### PR DESCRIPTION
* making the page self contained: users can have a working "hello-world"
without visiting other pages
* introducing couriser-cli a recommended way to install jvm requirements
* adding Vscode/metals as a possible IDE
* advertising only two ways of starting with Scala: interactive with Scastie or with and IDE + sbt

![image](https://user-images.githubusercontent.com/7843237/78141274-8ad74180-742b-11ea-8897-63b28b90b795.png)
