### PR TITLE
Link to implicit parameter page on first mention

### DIFF
--- a/_tour/multiple-parameter-lists.md
+++ b/_tour/multiple-parameter-lists.md
@@ -70,7 +70,7 @@ This definition doesn't need any type hints and can infer all of its type parame
 
 #### Implicit parameters
 
-To specify only certain parameters as `implicit`, they must be placed in their own `implicit` parameter list.
+To specify only certain parameters as [`implicit`](https://docs.scala-lang.org/tour/implicit-parameters.html), they must be placed in their own `implicit` parameter list.
 
 An example of this is:
 


### PR DESCRIPTION
When reading the tour I noticed that `implicit` is mentioned before it is defined.