### PR TITLE
Updates Library Author Guide regarding Nexus

### DIFF
--- a/_overviews/contributors/index.md
+++ b/_overviews/contributors/index.md
@@ -215,7 +215,7 @@ $ sbt publishSigned
 
 `sbt-sonatype` will package your project and ask your PGP passphrase to sign the files with your PGP key.
 It will then upload the files to Sonatype using your account credentials. When the task is finished, you can
-check the artifacts in the [Nexus Repository Manager](https://oss.sonatype.org) (under “Staging Repositories”).
+check the artifacts in the [Nexus Repository Manager](https://oss.sonatype.org) (in “Repositories”, select “Nexus Managed Repositories“ and look for your group name with all dots removed).
 
 Finally, perform the release with the `sonatypeRelease` sbt task:
 

--- a/_overviews/contributors/index.md
+++ b/_overviews/contributors/index.md
@@ -215,7 +215,7 @@ $ sbt publishSigned
 
 `sbt-sonatype` will package your project and ask your PGP passphrase to sign the files with your PGP key.
 It will then upload the files to Sonatype using your account credentials. When the task is finished, you can
-check the artifacts in the [Nexus Repository Manager](https://oss.sonatype.org) (in “Repositories”, select “Nexus Managed Repositories“ and look for your group name with all dots removed).
+check the artifacts in the [Nexus Repository Manager](https://oss.sonatype.org) (under “Staging Repositories” in the side menu − if you do not see it, make sure you are logged in).
 
 Finally, perform the release with the `sonatypeRelease` sbt task:
 


### PR DESCRIPTION
As far as I can tell, the current description does not correspond to the correct place to look anymore. There is still a Staging repository in "User Managed Repository" (the type selected by default), but it does not contain a library waiting to be released.
Since it was a head-scratcher for me when publishing my first lib, I assume it might help others.