### PR TITLE
add additional information about for-comprehention desugaring

### DIFF
--- a/_overviews/FAQ/yield.md
+++ b/_overviews/FAQ/yield.md
@@ -76,12 +76,12 @@ That it because, for example, the following statement
 
 is translated into
 
-    c.withFiler{
+    c.withFilter{
         case (a, b) => true
         case _ => false
     }.map{case (a, b) => {...}
 
-where the `withFiler` ensures that the pattern in the subsequent function is
+where the `withFilter` ensures that the pattern in the subsequent function is
 always satisfied
 
 Clarity

--- a/_overviews/FAQ/yield.md
+++ b/_overviews/FAQ/yield.md
@@ -63,8 +63,31 @@ is translated into
 
     c.map(x => (x, ...)).map((x,y) => {...})
 
+#### Example 5
 
-When you look at very simple for comprehensions, the map/foreach alternatives
+When pattern matching is used in for comprehensions on objects which do not
+implement `filter` or `withFilter` compilation fails with the following error
+
+    value withFilter is not a member of ...
+
+That it because, for example, the following statement
+
+    for((a, b) <- c) yield {...}
+
+is translated into
+
+    c.withFiler{
+        case (a, b) => true
+        case _ => false
+    }.map{case (a, b) => {...}
+
+where the `withFiler` ensures that the pattern in the subsequent function is
+always satisfied
+
+Clarity
+----------------------------------
+
+When you look at very simple for comprehensions, the `map`/`foreach` alternatives
 look, indeed, better. Once you start composing them, though, you can easily get
 lost in parenthesis and nesting levels. When that happens, for comprehensions
 are usually much clearer.


### PR DESCRIPTION
Once in a while I encounter this feature of for comprehentions. Today I was trying to figure out what exactly is going on and how the functions passed to `withFilter` looks like. Since it is not exaplained in the docs I decided to create a PR.

Plus adding few missing ``` ` ``` at the begininig of the next paragraph.