### PR TITLE
Fix outdated sample code for querying types in Symbols doc

### DIFF
--- a/_overviews/reflection/annotations-names-scopes.md
+++ b/_overviews/reflection/annotations-names-scopes.md
@@ -200,7 +200,8 @@ Constant expressions are used to represent
 
 Example:
 
-    Literal(Constant(5))
+    scala> Literal(Constant(5))
+    val res6: reflect.runtime.universe.Literal = 5
 
 The above expression creates an AST representing the integer literal `5` in
 Scala source code.
@@ -420,7 +421,7 @@ Positions can refer either to only a single character in a source file, or to
 a *range*. In the latter case, a *range position* is used (positions that are
 not range positions are also called *offset positions*). Range positions have
 in addition `start` and `end` offsets. The `start` and `end` offsets can be
-"focussed" on using the `focusStart` and `focusEnd` methods which return
+"focused" on using the `focusStart` and `focusEnd` methods which return
 positions (when called on a position which is not a range position, they just
 return `this`).
 

--- a/_overviews/reflection/annotations-names-scopes.md
+++ b/_overviews/reflection/annotations-names-scopes.md
@@ -119,11 +119,11 @@ Additional functionality is exposed in *member scopes* that are returned by
 [scala.reflect.api.Scopes#MemberScope](https://www.scala-lang.org/api/current/scala-reflect/scala/reflect/api/Scopes$MemberScope.html)
 supports the `sorted` method, which sorts members *in declaration order*.
 
-The following example returns a list of the symbols of all overridden members
+The following example returns a list of the symbols of all final members
 of the `List` class, in declaration order:
 
-    scala> val overridden = listTpe.decls.sorted.filter(_.isOverride)
-    overridden: List[scala.reflect.runtime.universe.Symbol] = List(method companion, method ++, method +:, method toList, method take, method drop, method slice, method takeRight, method splitAt, method takeWhile, method dropWhile, method span, method reverse, method stringPrefix, method toStream, method foreach)
+    scala> val overridden = listTpe.decls.sorted.filter(_.isFinal)
+    overridden: List(method isEmpty, method map, method collect, method flatMap, method takeWhile, method span, method foreach, method reverse, method foldRight, method length, method lengthCompare, method forall, method exists, method contains, method find, method mapConserve, method toList)
 
 ## Exprs
 

--- a/_overviews/reflection/annotations-names-scopes.md
+++ b/_overviews/reflection/annotations-names-scopes.md
@@ -86,11 +86,7 @@ the `map` method (which is a term) declared in the `List` class, one can do:
     res1: scala.reflect.runtime.universe.Symbol = method map
 
 To search for a type member, one can follow the same procedure, using
-`TypeName` instead. It is also possible to rely on implicit conversions to
-convert between strings and term or type names:
-
-    scala> listTpe.member("map": TermName)
-    res2: scala.reflect.runtime.universe.Symbol = method map
+`TypeName` instead.
 
 ### Standard Names
 

--- a/_overviews/reflection/symbols-trees-types.md
+++ b/_overviews/reflection/symbols-trees-types.md
@@ -350,14 +350,14 @@ For example, to look up the `map` method of `List`, one can do:
     scala> import scala.reflect.runtime.universe._
     import scala.reflect.runtime.universe._
 
-    scala> typeOf[List[_]].member("map": TermName)
+    scala> typeOf[List[_]].member(TermName("map"))
     res0: scala.reflect.runtime.universe.Symbol = method map
 
 Note that we pass method `member` a `TermName`, since we're looking up a
 method. If we were to look up a type member, such as `List`'s self type, `Self`, we
 would pass a `TypeName`:
 
-    scala> typeOf[List[_]].member("Self": TypeName)
+    scala> typeOf[List[_]].member(TypeName("Self"))
     res1: scala.reflect.runtime.universe.Symbol = type Self
 
 We can also query all members or declarations on a type in interesting ways.

--- a/_overviews/reflection/symbols-trees-types.md
+++ b/_overviews/reflection/symbols-trees-types.md
@@ -707,7 +707,7 @@ there’s already a `parse` method built into the macro context. For example:
     scala> def impl(c: scala.reflect.macros.Context) = c.Expr[Unit](c.parse("println(2)"))
     impl: (c: scala.reflect.macros.Context)c.Expr[Unit]
 
-    scala> def test = macro impl
+    scala> def test: Unit = macro impl
     test: Unit
 
     scala> test


### PR DESCRIPTION
Other parts of this have the updated `___Name()` syntax. These examples were probably just missed.