### PR TITLE
Avoid deprecation warning

### DIFF
--- a/_overviews/scala-book/classes-aux-constructors.md
+++ b/_overviews/scala-book/classes-aux-constructors.md
@@ -28,17 +28,17 @@ val DefaultCrustType = "THIN"
 class Pizza (var crustSize: Int, var crustType: String) {
 
     // one-arg auxiliary constructor
-    def this(crustSize: Int) {
+    def this(crustSize: Int) = {
         this(crustSize, DefaultCrustType)
     }
 
     // one-arg auxiliary constructor
-    def this(crustType: String) {
+    def this(crustType: String) = {
         this(DefaultCrustSize, crustType)
     }
 
     // zero-arg auxiliary constructor
-    def this() {
+    def this() = {
         this(DefaultCrustSize, DefaultCrustType)
     }
 


### PR DESCRIPTION
This change fixes the following compiler warning:
  procedure syntax is deprecated for constructors: add `=`, as in method definition