### PR TITLE
Delete a parenthesis which was causing build a build error.

### DIFF
--- a/_overviews/scala-book/sbt-scalatest-tdd.md
+++ b/_overviews/scala-book/sbt-scalatest-tdd.md
@@ -40,7 +40,7 @@ scalaVersion := "{{site.scala-version}}"
 
 libraryDependencies +=
     "org.scalatest" %% "scalatest" % "3.0.8" % Test
-)
+
 ```
 
 The first three lines of this file are essentially the same as the first example, and the `libraryDependencies` lines tell sbt to include the dependencies (jar files) that are needed to run ScalaTest:


### PR DESCRIPTION
The error was:
  [info] loading project definition from /HelloScalaTest/project
  [error] [/HelloScalaTest/build.sbt]:7: ';' expected but ')' found.
  Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? q

With this fix (without the parenthesis) the new message shown is:
  [info] Fetched artifacts of
  [info] Compiling 1 Scala source to /HelloScalaTest/target/scala-2.13/classes ...
  [info] Non-compiled module 'compiler-bridge_2.13' for Scala 2.13.3. Compiling...
  [info]   Compilation completed in 12.276s.
  [info] running simpletest.Hello
  Hello Alvin Alexander
  [success] Total time: 24 s, completed 14-jul-2020 9:53:06