### PR TITLE
Highlight deprecation of early definitions for initialization order

### DIFF
--- a/_overviews/FAQ/initialization-order.md
+++ b/_overviews/FAQ/initialization-order.md
@@ -124,7 +124,7 @@ Note that using multiple lazy vals creates a new risk: cycles among lazy vals ca
 
 Early definitions are a bit unwieldy, there are limitations as to what can appear and what can be referenced in an early definitions block, and they don't compose as well as lazy vals: but if a lazy val is undesirable, they present another option.  They are specified in SLS 5.1.6.
 
-Note that early definitions are deprecated in Scala 2.13 and will be removed in 2.14; they will be replaced by trait parameters in 3.0. This option is not recommended if future compatibility is a concern.
+Note that early definitions are deprecated in Scala 2.13; they will be replaced by trait parameters in Scala 3. So, early definitions are not recommended for use if future compatibility is a concern.
 
 #### Use constant value definitions ####
     abstract class A {

--- a/_overviews/FAQ/initialization-order.md
+++ b/_overviews/FAQ/initialization-order.md
@@ -124,6 +124,8 @@ Note that using multiple lazy vals creates a new risk: cycles among lazy vals ca
 
 Early definitions are a bit unwieldy, there are limitations as to what can appear and what can be referenced in an early definitions block, and they don't compose as well as lazy vals: but if a lazy val is undesirable, they present another option.  They are specified in SLS 5.1.6.
 
+Note that early definitions are deprecated in Scala 2.13 and will be removed in 2.14; they will be replaced by trait parameters in 3.0. This option is not recommended if future compatibility is a concern.
+
 #### Use constant value definitions ####
     abstract class A {
       val x1: String


### PR DESCRIPTION
Document that early definitions are deprecated and going to be obsolete due to Tasty compatibly. See
https://github.com/scala/scala-dev/issues/513 for more details. I did wonder if removing the section on using early definitions entirely, but figured people will still be able to use it for a while and it is code that is seen out there in real code bases, so just a deprecation warning made sense.