### PR TITLE
Update getting-started-with-scala-in-intellij.md

### DIFF
--- a/_getting-started/intellij-track/getting-started-with-scala-in-intellij.md
+++ b/_getting-started/intellij-track/getting-started-with-scala-in-intellij.md
@@ -40,7 +40,7 @@ take a few minutes but subsequent projects can use the same SDK.
 ## Writing code
 
 1. On the **Project** pane on the left, right-click `src` and select
-**New** => **Scala class**. If you don't see **Scala class**, right-click on **HelloWorld** and click on **Add Framework Support...**, select **Scala** and proceed. If you see **Error: library is not specified**, you can either click download button, or select the library path manually.
+**New** => **Scala class**. If you don't see **Scala class**, right-click on **HelloWorld** and click on **Add Framework Support...**, select **Scala** and proceed. If you see **Error: library is not specified**, you can either click download button, or select the library path manually. If you only see **Scala Worksheet** try expanding the `src` folder and its `main` subfolder, and right-click on the `scala` folder.
 1. Name the class `Hello` and change the **Kind** to `object`.
 1. Change the code in the class to the following:
 


### PR DESCRIPTION
The instructions as written did not work for me today, so I edited them so they would have. Presumably IntelliJ has changed its behavior since they were written. Note also, they are still off: "To the right of the Scala SDK field, click the **Create** button." There is no such field or button at that point, I assume there was in older versions of IntelliJ. I don't know how best to fix that issue.