### PR TITLE
Removed mention of String in FAQ about Context Bounds

### DIFF
--- a/_overviews/FAQ/context-bounds.md
+++ b/_overviews/FAQ/context-bounds.md
@@ -16,8 +16,7 @@ so-called _type class pattern_, a pattern of code that emulates the
 functionality provided by Haskell type classes, though in a more verbose
 manner.
 
-A context bound requires a _parameterized type_, such as `Ordered[A]`,
-but unlike `String`.
+A context bound requires a _parameterized type_, such as `Ordered[A]`.
 
 A context bound describes an implicit _value_. It is used to declare that for
 some type `A`, there is an


### PR DESCRIPTION
Mention of String doesn't make sense without [View Bound example](https://stackoverflow.com/questions/4465948/what-are-scala-context-and-view-bounds) which is no longer here.