### PR TITLE
Copying description is unclear

### DIFF
--- a/_tour/case-classes.md
+++ b/_tour/case-classes.md
@@ -44,7 +44,7 @@ val messagesAreTheSame = message2 == message3  // true
 Even though `message2` and `message3` refer to different objects, the value of each object is equal.
 
 ## Copying
-You can create a (shallow) copy of an instance of a case class simply by using the `copy` method. You can optionally change the constructor arguments.
+You can create a (deep) copy of an instance of a case class simply by using the `copy` method. You can optionally change the constructor arguments.
 ```tut
 case class Message(sender: String, recipient: String, body: String)
 val message4 = Message("julien@bretagne.fr", "travis@washington.us", "Me zo o komz gant ma amezeg")


### PR DESCRIPTION
It looks like `message4.copy` creates a deep copy instead of a shallow copy. I wasn't really sure so I tested this using some sample code, as well and it pretty much looks like a deep copy. (Please be kind, I am a newbie!)
```
case class Message(sender: String, var recipient: String, body: String)
val message4 = Message("julien@bretagne.fr", "travis@washington.us", "Me zo o komz gant ma amezeg")
val message5 = message4.copy(sender = message4.recipient, recipient = "claire@bourgogne.fr")
message5.sender  // travis@washington.us
message5.recipient // claire@bourgogne.fr
message5.body  // "Me zo o komz gant ma amezeg"
message4.recipient = "abc@new.ny"
message5.sender // travis@washington.us
```