### PR TITLE
Fixed packages-and-imports.md file error

### DIFF
--- a/_ru/tour/packages-and-imports.md
+++ b/_ru/tour/packages-and-imports.md
@@ -8,7 +8,7 @@ partof: scala-tour
 
 num: 35
 language: ru
-previous-page: named-arguments
+previous-page: annotations
 next-page: package-objects
 ---
 


### PR DESCRIPTION
The` /tour/packages-and-imports.html` previous page is `/tour/annotations.html` - not `/tour/named-arguments.html` page!
