### PR TITLE
Fixed annotations.md file error

### DIFF
--- a/_ru/tour/annotations.md
+++ b/_ru/tour/annotations.md
@@ -8,7 +8,7 @@ partof: scala-tour
 
 num: 32
 language: ru
-next-page: default-parameter-values
+next-page: packages-and-imports
 previous-page: by-name-parameters
 
 ---


### PR DESCRIPTION
The` /tour/annotations.html` next page is `/tour/packages-and-imports.html` - not `/tour/default-parameter-values.html` page!

