### PR TITLE
Fixed traits.md file error

### DIFF
--- a/_ru/tour/traits.md
+++ b/_ru/tour/traits.md
@@ -9,7 +9,7 @@ partof: scala-tour
 num: 5
 language: ru
 next-page: tuples
-previous-page: classes
+previous-page: named-arguments
 topics: traits
 prerequisite-knowledge: expressions, classes, generics, objects, companion-objects
 


### PR DESCRIPTION
The `/tour/traits.html` previous page is `/tour/named-arguments.html` - not `/tour/classes.html` page!