### PR TITLE
Fixed default-parameter-values.md file error 

### DIFF
--- a/_ru/tour/default-parameter-values.md
+++ b/_ru/tour/default-parameter-values.md
@@ -9,7 +9,7 @@ partof: scala-tour
 num: 33
 language: ru
 next-page: named-arguments
-previous-page: annotations
+previous-page: classes
 prerequisite-knowledge: named-arguments, function syntax
 
 ---


### PR DESCRIPTION
The `/tour/default-parameter-values.html` previous page is `/tour/classes.html` - not `/tour/annotations.html` page!