### PR TITLE
Add consistency to parameter lists formatting

### DIFF
--- a/_style/declarations.md
+++ b/_style/declarations.md
@@ -224,13 +224,20 @@ There are three main reasons you should do this:
         List("").foldLeft[Int](0, _ + _.length)
 
 For complex DSLs, or with type-names that are long, it can be difficult
-to fit the entire signature on one line. In those cases, align the
-open-paren of the parameter lists, one list per line (i.e. if you can't
-put them all on one line, put one each per line):
+to fit the entire signature on one line. In those cases, split the parameter
+lists, one parameter per line with
+[trailing commas](https://docs.scala-lang.org/sips/trailing-commas.html#motivation)
+and parentheses being on a separate lines adding to visual separation between
+lists:
 
-    protected def forResource(resourceInfo: Any)
-                             (f: (JsonNode) => Any)
-                             (implicit urlCreator: URLCreator, configurer: OAuthConfiguration): Any = {
+    protected def forResource(
+      resourceInfo: Any,
+    )(
+      f: (JsonNode) => Any,
+    )(implicit
+      urlCreator: URLCreator,
+      configurer: OAuthConfiguration,
+    ): Any = {
       ...
     }
 


### PR DESCRIPTION
To make it more in line with argument list formatting of #classes