### PR TITLE
remove postfix ops from style guide

### DIFF
--- a/_style/index.md
+++ b/_style/index.md
@@ -55,7 +55,6 @@ This document is intended to outline some basic Scala stylistic guidelines which
   - [Trivial Conditionals](control-structures.html#trivial-conditionals)
 - [Method Invocation](method-invocation.html)
   - [Arity-0](method-invocation.html#arity-0)
-    - [Postfix Notation](method-invocation.html#postfix-notation)
   - [Arity-1 (Infix Notation)](method-invocation.html#arity-1-infix-notation)
     - [Symbolic Methods/Operators](method-invocation.html#symbolic-methodsoperators)
     - [Higher-Order Functions](method-invocation.html#higher-order-functions)

--- a/_style/method-invocation.md
+++ b/_style/method-invocation.md
@@ -56,30 +56,6 @@ readability and will make it much easier to understand at a glance the
 most basic operation of any given method. Resist the urge to omit
 parentheses simply to save two characters!
 
-### Postfix Notation
-
-Scala allows methods that take no arguments to be invoked using postfix notation:
-
-    // recommended
-    names.toList
-
-    // discourage
-    names toList
-
-This style is unsafe, and should not be used. Since semicolons are
-optional, the compiler will attempt to treat it as an infix method
-if it can, potentially taking a term from the next line.
-
-    names toList
-    val answer = 42        // will not compile!
-
-This may result in unexpected compile errors at best, and happily
-compiled faulty code at worst. Although the syntax is used by some
-DSLs, it should be considered deprecated, and avoided.
-
-Since Scala 2.10, using postfix operator notation will result in a
-compiler warning.
-
 ## Arity-1 (Infix Notation)
 
 Scala has a special punctuation-free syntax for invoking methods of arity-1


### PR DESCRIPTION
Scala 2.13 errors by default, so I don't think the style guide
needs to cover this any more