### PR TITLE
Update generic-classes.md

### DIFF
--- a/_tour/generic-classes.md
+++ b/_tour/generic-classes.md
@@ -17,7 +17,8 @@ Generic classes take a type as a parameter within square brackets `[]`. One conv
 ```tut
 class Stack[A] {
   private var elements: List[A] = Nil
-  def push(x: A) { elements = x :: elements }
+  def push(x: A): Unit =
+    elements = x :: elements
   def peek: A = elements.head
   def pop(): A = {
     val currentTop = peek


### PR DESCRIPTION
replace `{ elements = x :: elements }` with `: Unit = \n elements = x :: elements` to remove `warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `push`'s return type`