### PR TITLE
Update generic-classes.md

### DIFF
--- a/_ba/tour/generic-classes.md
+++ b/_ba/tour/generic-classes.md
@@ -22,7 +22,8 @@ Konvencija je da se koristi slovo `A` kao identifikator tipa, mada se može kori
 ```tut
 class Stack[A] {
   private var elements: List[A] = Nil
-  def push(x: A) { elements = x :: elements }
+  def push(x: A): Unit =
+    elements = x :: elements
   def peek: A = elements.head
   def pop(): A = {
     val currentTop = peek

--- a/_es/tour/generic-classes.md
+++ b/_es/tour/generic-classes.md
@@ -16,7 +16,8 @@ A continuación se muestra un ejemplo:
 
     class Stack[T] {
       var elems: List[T] = Nil
-      def push(x: T) { elems = x :: elems }
+      def push(x: T): Unit =
+    	elems = x :: elems
       def top: T = elems.head
       def pop() { elems = elems.tail }
     }

--- a/_ja/tour/generic-classes.md
+++ b/_ja/tour/generic-classes.md
@@ -21,7 +21,8 @@ assumed-knowledge: classes unified-types
 ```tut
 class Stack[A] {
   private var elements: List[A] = Nil
-  def push(x: A) { elements = x :: elements }
+  def push(x: A): Unit =
+    elements = x :: elements
   def peek: A = elements.head
   def pop(): A = {
     val currentTop = peek

--- a/_ko/tour/generic-classes.md
+++ b/_ko/tour/generic-classes.md
@@ -14,7 +14,8 @@ previous-page: extractor-objects
 
     class Stack[T] {
       var elems: List[T] = Nil
-      def push(x: T) { elems = x :: elems }
+      def push(x: T): Unit =
+        elems = x :: elems
       def top: T = elems.head
       def pop() { elems = elems.tail }
     }

--- a/_pl/tour/generic-classes.md
+++ b/_pl/tour/generic-classes.md
@@ -16,7 +16,8 @@ Poniższy przykład demonstruje zastosowanie parametrów generycznych:
 ```tut
 class Stack[T] {
   var elems: List[T] = Nil
-  def push(x: T) { elems = x :: elems }
+  def push(x: T): Unit =
+    elems = x :: elems 
   def top: T = elems.head
   def pop() { elems = elems.tail }
 }

--- a/_pt-br/tour/generic-classes.md
+++ b/_pt-br/tour/generic-classes.md
@@ -15,7 +15,8 @@ Aqui temos um exemplo que demonstra isso:
 ```tut
 class Stack[T] {
   var elems: List[T] = Nil
-  def push(x: T) { elems = x :: elems }
+  def push(x: T): Unit =
+    elems = x :: elems
   def top: T = elems.head
   def pop() { elems = elems.tail }
 }

--- a/_ru/tour/generic-classes.md
+++ b/_ru/tour/generic-classes.md
@@ -20,7 +20,8 @@ assumed-knowledge: classes unified-types
 ```tut
 class Stack[A] {
   private var elements: List[A] = Nil
-  def push(x: A) { elements = x :: elements }
+  def push(x: A): Unit =
+    elements = x :: elements
   def peek: A = elements.head
   def pop(): A = {
     val currentTop = peek

--- a/_zh-cn/tour/generic-classes.md
+++ b/_zh-cn/tour/generic-classes.md
@@ -17,7 +17,8 @@ previous-page: extractor-objects
 ```tut
 class Stack[A] {
   private var elements: List[A] = Nil
-  def push(x: A) { elements = x :: elements }
+  def push(x: A): Unit =
+    elements = x :: elements 
   def peek: A = elements.head
   def pop(): A = {
     val currentTop = peek


### PR DESCRIPTION
replace `{ elements = x :: elements }` with `: Unit =
elements = x :: elements` to remove
`warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `push`'s return type`
for various languages