### PR TITLE
[FIX] next-page link of tour/annotations.md in several language versions

### DIFF
--- a/_ba/tour/annotations.md
+++ b/_ba/tour/annotations.md
@@ -5,7 +5,7 @@ language: ba
 partof: scala-tour
 
 num: 32
-next-page: default-parameter-values
+next-page: packages-and-imports
 previous-page: by-name-parameters
 
 ---

--- a/_es/tour/annotations.md
+++ b/_es/tour/annotations.md
@@ -6,7 +6,7 @@ partof: scala-tour
 num: 3
 language: es
 
-next-page: classes
+next-page: packages-and-imports
 previous-page: abstract-type-members
 ---
 

--- a/_ja/tour/annotations.md
+++ b/_ja/tour/annotations.md
@@ -8,7 +8,7 @@ discourse: true
 partof: scala-tour
 
 num: 32
-next-page: default-parameter-values
+next-page: packages-and-imports
 previous-page: by-name-parameters
 
 ---

--- a/_ko/tour/annotations.md
+++ b/_ko/tour/annotations.md
@@ -6,7 +6,7 @@ partof: scala-tour
 num: 31
 language: ko
 
-next-page: default-parameter-values
+next-page: packages-and-imports
 previous-page: automatic-closures
 ---
 

--- a/_pt-br/tour/annotations.md
+++ b/_pt-br/tour/annotations.md
@@ -4,7 +4,7 @@ title: Anotações
 partof: scala-tour
 
 num: 31
-next-page: default-parameter-values
+next-page: packages-and-imports
 previous-page: automatic-closures
 language: pt-br
 ---

--- a/_th/tour/annotations.md
+++ b/_th/tour/annotations.md
@@ -7,6 +7,6 @@ num: 30
 
 language: th
 
-next-page: default-parameter-values
+next-page: packages-and-imports
 previous-page: by-name-parameters
 ---

--- a/_zh-cn/tour/annotations.md
+++ b/_zh-cn/tour/annotations.md
@@ -7,7 +7,7 @@ num: 30
 
 language: zh-cn
 
-next-page: default-parameter-values
+next-page: packages-and-imports
 previous-page: by-name-parameters
 ---
 


### PR DESCRIPTION
The Next-page link is not correct of tour/annotations.md of several languages.