### PR TITLE
Change style of h4 to pop less out

### DIFF
--- a/_sass/layout/type-md.scss
+++ b/_sass/layout/type-md.scss
@@ -43,10 +43,10 @@
 
     h4,
     h5 {
-        font-size: 1.063rem;
+        font-size: 1.0rem;
         font-family: $base-font-family;
         text-transform: uppercase;
-        font-weight: $font-bold;
+        font-weight: $font-regular;
     }
 }
 
@@ -74,19 +74,22 @@
 .text-step {
     h2 {
         margin-bottom: 24px;
-
+    }
+    h3 {
+        margin-bottom: 0.5rem;
     }
 
     blockquote,
-    h3,
-    h4,
-    h5,
     img,
     p,
     pre,
     table,
     ul {
         margin-bottom: 18px;
+    }
+
+    h4, h5 {
+        margin-bottom: 0.5rem;
     }
 
     ol,


### PR DESCRIPTION
The h4 style dominated h3 which was problematic for larger bodies of text. This PR proposes a slightly smaller font-size and not using bold-face. It also adjusts the margins slightly to be closer to the textbody.

The style is only rarely used and the effect can be observed on the following page:

   `/overviews/core/actors.html`