### PR TITLE
add redirects for removed FAQ answer pages

### DIFF
--- a/_overviews/FAQ/index.md
+++ b/_overviews/FAQ/index.md
@@ -2,6 +2,14 @@
 layout: singlepage-overview
 title: Scala FAQs
 permalink: /tutorials/FAQ/index.html
+redirect_from: "/tutorials/FAQ/breakout.html"
+redirect_from: "/tutorials/FAQ/chaining-implicits.html"
+redirect_from: "/tutorials/FAQ/collections.html"
+redirect_from: "/tutorials/FAQ/context-bounds.html"
+redirect_from: "/tutorials/FAQ/finding-implicits.html"
+redirect_from: "/tutorials/FAQ/finding-symbols.html"
+redirect_from: "/tutorials/FAQ/stream-view.html"
+redirect_from: "/tutorials/FAQ/yield.html"
 ---
 
 Frequently asked questions, with _brief_ answers and/or links to


### PR DESCRIPTION
redirecting to the [main FAQ page](https://docs.scala-lang.org/tutorials/FAQ/index.html) is perhaps not the _ideal_ solution, perhaps we could have redirected to the SO answers the removed pages were based on, or redirected to the Wayback Machine, or I don't know what

...but personally I think this is good enough. merging on fast track since #1844 just got merged.