### PR TITLE
fix up FAQ

### DIFF
--- a/_overviews/FAQ/index.md
+++ b/_overviews/FAQ/index.md
@@ -65,6 +65,16 @@ get poor results, try surrounding the symbol with double quotes.
 
 ## Specific technical questions
 
+### Why is my (abstract or overridden) `val` null?
+
+<!-- this is left over from a previous version of the FAQ.
+so, grandfathering this in, but I suggest we not host any further FAQ
+answers here, I think it's better to provide only short answers and
+links. if something needs more space to explain, there should be
+official documentation that addresses it, not just an FAQ answer -->
+
+[answer]({{ site.baseurl }}/tutorials/FAQ/initialization-order.html)
+
 ### Which type of collection should I choose?
 
 see the [Scala 2.13 Collections Guide](https://docs.scala-lang.org/overviews/collections-2.13/introduction.html)
@@ -81,7 +91,7 @@ see the [Scala 2.13 Collections Guide](https://docs.scala-lang.org/overviews/col
 
 [answer on Stack Overflow](https://stackoverflow.com/a/5159356)
 
-### How can I chain/nest implicit conversions?
+### Can I chain or nest implicit conversions?
 
 [answer on Stack Overflow](https://stackoverflow.com/a/5332804)
 
@@ -99,14 +109,3 @@ equivalents, such as `List[java.lang.Integer]`?
 One would hope so, but doing it that way was tried and it proved
 impossible.  [This SO question](https://stackoverflow.com/questions/11167430/why-are-primitive-types-such-as-int-erased-to-object-in-scala)
 sadly lacks a concise explanation, but it does link to past discussions.
-
-## More questions
-
-{% assign overviews = site.overviews | sort: 'num' %}
-<ul>
-{% for overview in overviews %}
-  {% if overview.partof == "FAQ" %}
-    <li><a href="{{ site.baseurl }}{{ overview.url }}">{{ overview.title }}</a></li>
-  {% endif %}
-{% endfor %}
-</ul>

--- a/_overviews/FAQ/initialization-order.md
+++ b/_overviews/FAQ/initialization-order.md
@@ -2,13 +2,11 @@
 layout: multipage-overview
 title: Why is my abstract or overridden val null?
 overview-name: FAQ
-partof: FAQ
-
-num: 9
 permalink: /tutorials/FAQ/:title.html
 ---
 
 ## Example
+
 To understand the problem, let's pick the following concrete example.
 
     abstract class A {

--- a/index.md
+++ b/index.md
@@ -47,8 +47,8 @@ sections:
         description: "A handy cheatsheet covering the basics of Scala's syntax."
         icon: "fa fa-list"
         link: /cheatsheets/index.html
-      - title: "Scala FAQs"
-        description: "A list of frequently-asked questions about Scala language features and their answers."
+      - title: "Scala FAQ"
+        description: "Answers to frequently-asked questions about Scala."
         icon: "fa fa-question-circle"
         link: /tutorials/FAQ/index.html
       - title: "Language Spec"


### PR DESCRIPTION
followup to #1844

There was some question about what to do with the one FAQ answer that wasn't just a copy of something from Stack Overflow. I've handled it by leaving the answer page in place but fixing the look of the questions page so this question is formatted like the others.

I hope the historically conscious will be amused by my retaining the old "one-question FAQ" as the first question in the technical-question section :-)

I think it's fine to grandfather in this one page, but I don't think we should add any more pages like this in the future.