### PR TITLE
Fix missing language selection on landing page

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -25,12 +25,39 @@
    </div>
  </section>
 
-  <section class="table-of-content content-primary">
+  <section class="table-of-content">
     <div class="wrap scala2">
       <div class="language-header">
         <h1>Scala 2</h1>
       </div>
-       <div class="inner-box">
+      <div class="inner-box">
+        <div class="language-dropdown inverted">
+          <div id="dd" class="wrapper-dropdown" tabindex="1">
+            <span>Language</span>
+            <ul class="dropdown"></ul>
+          </div>
+        </div>
+
+        <ul id="available-languages" style="display: none;">
+          {% if page.languages %}
+            <li><a href="{{ site.baseurl }}{{ page.url }}">English</a></li>
+            {% for l in page.languages %}
+              {% capture intermediate %}{{ page.url }}{% endcapture %}
+              {% capture rootTutorialURL %}{{ intermediate | remove_first: '/' }}{% endcapture %}
+              {% assign lang = site.data.languages[l] %}
+              <li><a href="{{ site.baseurl }}/{{ l }}/{{ rootTutorialURL }}" class="lang">{{ lang.name }}</a></li>
+            {% endfor %}
+          {% elsif page.language %}
+            {% assign engPath = page.url | remove_first: "/" | remove_first: page.language | remove_first: "index.html" %}
+            {% assign engPg = site.pages | where: 'partof', page.partof | first %}
+            <li><a href="{{ site.baseurl }}{{ engPath }}">English</a></li>
+            {% for l in engPg.languages %}
+              {% assign lang = site.data.languages[l] %}
+              <li><a href="{{ site.baseurl }}/{{ l }}{{ engPath }}" class="lang">{{ lang.name }}</a></li>
+            {% endfor %}
+          {% endif %}
+        </ul>
+
         {% include documentation-sections.html sections=page.scala2-sections %}
       </div>
     </div>
@@ -39,7 +66,7 @@
       <div class="language-header">
         <h1>Scala 3 (Preview)</h1>
       </div>
- 		  <div class="inner-box">
+      <div class="inner-box">
         <blockquote>
           Scala 3 has not been released, yet. We are still in the process of writing the documentation for Scala 3.<br/>
           You can <a href="/scala3/contribute-to-docs.html">help us to improve the documentation</a>.

--- a/index.md
+++ b/index.md
@@ -1,7 +1,9 @@
 ---
 layout: documentation
+languages: [ja, zh-cn, ru]
 title: Documentation
 namespace: root
+discourse: true
 partof: documentation
 more-resources-label: More Resources
 


### PR DESCRIPTION
The new layout incorporating Scala 3 documentation accidentally removed the language selection. This PR adds it back it.