### PR TITLE
Do not use coll which is a protected member

### DIFF
--- a/_overviews/collections-2.13/views.md
+++ b/_overviews/collections-2.13/views.md
@@ -18,8 +18,8 @@ There are two principal ways to implement transformers. One is _strict_, that is
 
 As an example of a non-strict transformer consider the following implementation of a lazy map operation:
 
-    def lazyMap[T, U](coll: Iterable[T], f: T => U) = new Iterable[U] {
-      def iterator = coll.iterator map f
+    def lazyMap[T, U](iter: Iterable[T], f: T => U) = new Iterable[U] {
+      def iterator = iter.iterator map f
     }
 
 Note that `lazyMap` constructs a new `Iterable` without stepping through all elements of the given collection `coll`. The given function `f` is instead applied to the elements of the new collection's `iterator` as they are demanded.


### PR DESCRIPTION
In Scala 2.13.0 and 2.13.4,

The below will not compile
```scala
  def lazyMap[T, U](coll: Iterable[T], f: T => U): Iterable[U] = new Iterable[U] {
    def iterator: Iterator[U] = coll.iterator map f
  }
```

The argument `coll` is shadowed by the protected member of `Iterable` trait.
Ref. https://github.com/scala/scala/blob/1851c5d637e55c8af786f428bddc9758a44c583c/src/library/scala/collection/Iterable.scala#L34
