### PR TITLE
Fix names of View's sub classes

### DIFF
--- a/_overviews/core/custom-collections.md
+++ b/_overviews/core/custom-collections.md
@@ -596,11 +596,11 @@ this is why we always get a `Vector` as a result.
       // symbolic alias for `concat`
       @inline final def ++ (suffix: IterableOnce[Base]): RNA2 = concat(suffix)
       def appended(base: Base): RNA2 =
-        fromSpecific(new View.Append(this, base))
+        fromSpecific(new View.Appended(this, base))
       def appendedAll(suffix: IterableOnce[Base]): RNA2 =
         concat(suffix)
       def prepended(base: Base): RNA2 = 
-        fromSpecific(new View.Prepend(base, this))
+        fromSpecific(new View.Prepended(base, this))
       def prependedAll(prefix: IterableOnce[Base]): RNA2 =
         fromSpecific(prefix.iterator ++ iterator)
       def map(f: Base => Base): RNA2 =


### PR DESCRIPTION
There are no `View.Append` or `View.Prepend` classes.
Instead, `View.Appended` and `View.Prepend` exist.

Refer

* https://github.com/scala/scala/blob/1851c5d637e55c8af786f428bddc9758a44c583c/src/library/scala/collection/View.scala#L366
* https://github.com/scala/scala/blob/1851c5d637e55c8af786f428bddc9758a44c583c/src/library/scala/collection/View.scala#L377