### PR TITLE
Fix continuous integration by ignoring some more urls

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -16,6 +16,6 @@ bundle exec htmlproofer ./_site/\
   --http-status-ignore "400,401,429"\
   --empty-alt-ignore\
   --allow-hash-href\
-  --url-ignore '/https://github.com/scala/docs.scala-lang/blob/master/.*/,/www.oracle.com/,/http://dotty.epfl.ch/api/scala/tasty/Reflection/.*/'
+  --url-ignore '/https://github.com/scala/docs.scala-lang/blob/master/.*/,/www.oracle.com/,/.*dotty.epfl.ch\/api\/scala\/tasty\/Reflection.*/'
 
 exit 0

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,6 +10,6 @@ rm -r /tmp/mdoc-out/
 bundle exec jekyll build
 
 # Checking for docs.scala-lang/blob/master leads to a chicken and egg problem because of the edit links of new pages.
-bundle exec htmlproofer ./_site/ --only-4xx --http-status-ignore "401,429" --empty-alt-ignore --allow-hash-href --url-ignore '/https://github.com/scala/docs.scala-lang/blob/master/.*/,/www.oracle.com/'
+bundle exec htmlproofer ./_site/ --only-4xx --http-status-ignore "400,401,429" --empty-alt-ignore --allow-hash-href --url-ignore '/https://github.com/scala/docs.scala-lang/blob/master/.*/,/www.oracle.com/'
 
 exit 0

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,6 +10,12 @@ rm -r /tmp/mdoc-out/
 bundle exec jekyll build
 
 # Checking for docs.scala-lang/blob/master leads to a chicken and egg problem because of the edit links of new pages.
-bundle exec htmlproofer ./_site/ --only-4xx --http-status-ignore "400,401,429" --empty-alt-ignore --allow-hash-href --url-ignore '/https://github.com/scala/docs.scala-lang/blob/master/.*/,/www.oracle.com/'
+# The docs at http://dotty.epfl.ch/api/scala/tasty/ are temporarily not available.
+bundle exec htmlproofer ./_site/\
+  --only-4xx\
+  --http-status-ignore "400,401,429"\
+  --empty-alt-ignore\
+  --allow-hash-href\
+  --url-ignore '/https://github.com/scala/docs.scala-lang/blob/master/.*/,/www.oracle.com/,/http://dotty.epfl.ch/api/scala/tasty/Reflection/.*/'
 
 exit 0


### PR DESCRIPTION
Continuous integration is broken because of two reasons:

1) Twitter API responds with `400` which indicates missing permission
2) Some API links generated by the Scala 3 doctool are currently not available

This PR addresses both by ignoring `400` status errors and ignoring the missing doctool url (temporarily).