### PR TITLE
fix typo on features page

### DIFF
--- a/_overviews/scala3-book/scala-features.md
+++ b/_overviews/scala3-book/scala-features.md
@@ -57,8 +57,6 @@ def double(ints: List[Int]): List[Int] = {
       buffer += i * 2
   }
   buffer.toList
-  foo
-  bar
 }
 
 val newNumbers = double(oldNumbers)


### PR DESCRIPTION
Hello,

This removes what appears to be a typo in the `double` example -- it runs in https://scastie.scala-lang.org/JGjPOt5ESK6viRdTW0xtDA
