### PR TITLE
scala 3 installation via cs

### DIFF
--- a/scala3/getting-started.md
+++ b/scala3/getting-started.md
@@ -27,7 +27,8 @@ Install it on your system with the following instructions.
 <div class="main-download">
   <div id="download-step-one">
     <p>Follow <a href="https://get-coursier.io/docs/cli-overview.html#install-native-launcher" target="_blank">the instructions to install the <code>cs</code> launcher</a> then run:</p>
-    <p><code>$ ./cs setup</code></p>
+    <p><code>$ cs install scala3-repl</code></p>
+    <p><code>$ cs install scala3-compiler</code></p>
   </div>
 </div>
 


### PR DESCRIPTION
original command have installed scala 2 (that was pretty misleading). Now `cs` install repl and compiler for Scala 3. Now it is consistent with http://dotty.epfl.ch/#getting-started, where the same 2 commands are used