### PR TITLE
Replace old FunSuite with newer AnyFunSuite

### DIFF
--- a/_getting-started/sbt-track/testing-scala-with-sbt-on-the-command-line.md
+++ b/_getting-started/sbt-track/testing-scala-with-sbt-on-the-command-line.md
@@ -71,10 +71,8 @@ indeed 27. The `===` is part of ScalaTest and provides clean error messages.
 ## Adding another test case
 1. Add another test block with its own `assert` statement that checks for the cube of `0`.
 
-    ```
-      import org.scalatest.FunSuite
-    
-      class CubeCalculatorTest extends FunSuite {
+    ```    
+      class CubeCalculatorTest extends org.scalatest.funsuite.AnyFunSuite {
           test("CubeCalculator.cube 3 should be 27") {
               assert(CubeCalculator.cube(3) === 27)
           }


### PR DESCRIPTION
The change is reflecting the newer tutorial example: When running: `sbt new scala/scalatest-example.g8`
the build.sbt file inside  contains the newer "scalatest" % "3.2.2" but the example above was written using the old "scalatest" % "3.0.8" in which the FunSuite was replaced by the newer AnyFunSuite which has a different path in the scalatest library.