### PR TITLE
Fixed translation into Japanese

### DIFF
--- a/_ja/overviews/collections/overview.md
+++ b/_ja/overviews/collections/overview.md
@@ -60,7 +60,7 @@ Scala のコレクションは、体系的に可変および不変コレクシ�
 
 [![Mutable collection hierarchy][3]][3]
 
-図の伝説:
+図の凡例:
 
 [![Graph legend][4]][4]
 


### PR DESCRIPTION
Hi, I found mistranslation, so I've fixed it.
In before docs, "[legend](https://github.com/scala/docs.scala-lang/blob/9191e0b6f1e082ee920bd3dd395a909d79b55149/_overviews/collections/overview.md#L111)" is transted into "伝説". But "伝説" means a story from ancient times or a famous person. So I change translation from "伝説" to "凡例". "凡例" means explanation of diagram. 
Please check it.😃 
