### PR TITLE
traits->classes

### DIFF
--- a/_overviews/scala3-book/domain-modeling-oop.md
+++ b/_overviews/scala3-book/domain-modeling-oop.md
@@ -123,7 +123,7 @@ class Person(name: String)
 class SoftwareDeveloper(name: String, favoriteLang: String)
   extends Person(name)
 ```
-However, since _traits_ are designed as the primary means of decomposition,
+However, since _classes_ are designed as the primary means of decomposition,
 a class that is defined in one file _cannot_ be extended in another file.
 In order to allow this, the base class needs to be [marked as `open`][open]:
 ```scala


### PR DESCRIPTION
the whole section `Planning for Extension` is about classes (not traits). 

It also might be that I just didnt get the sentence:
*However, since traits are designed as the primary means of decomposition, a class that is defined in one file cannot be extended in another file. In order to allow this, the base class needs to be marked as `open`*