### PR TITLE
scala 3 doesnt use _ in imports

### DIFF
--- a/_overviews/scala3-book/packaging-imports.md
+++ b/_overviews/scala3-book/packaging-imports.md
@@ -83,7 +83,7 @@ Those are discussed at the end of this chapter.
 
 A note before moving on:
 
-- Import clauses are not required for accessing members of the same package.
+> Import clauses are not required for accessing members of the same package.
 
 ### Importing one or more members
 

--- a/_overviews/scala3-book/packaging-imports.md
+++ b/_overviews/scala3-book/packaging-imports.md
@@ -81,12 +81,9 @@ They’re explained more in the subsections that follow.
 Import statements are also used to import `given` instances into scope.
 Those are discussed at the end of this chapter.
 
-Two notes before moving on:
+A note before moving on:
 
 - Import clauses are not required for accessing members of the same package.
-- When the `_` character is used in Scala import statements, it’s similar to the `*` character in Java.
-  One reason for this difference is that in Scala, the `*` character can be used for method names.
-
 
 ### Importing one or more members
 


### PR DESCRIPTION
removed a part describing _ in imports, since Scala 3 uses * instead (https://dotty.epfl.ch/docs/reference/changed-features/imports.html)