### PR TITLE
reginald instead of not-defined p

### DIFF
--- a/_overviews/scala3-book/fp-immutable-values.md
+++ b/_overviews/scala3-book/fp-immutable-values.md
@@ -59,7 +59,7 @@ val reginald = Person("Reginald", "Dwight")
 Then, when you need to make a change to the data, you use the `copy` method that comes with a `case` class to “update the data as you make a copy,” like this:
 
 ```scala
-val elton = p.copy(
+val elton = reginald.copy(
   firstName = "Elton",   // update the first name
   lastName = "John"      // update the last name
 )


### PR DESCRIPTION
`p` is not defined within the article. I suggest to replace `p` with properly defined `reginald` 