### PR TITLE
Add consistency to parameter lists formatting

### DIFF
--- a/_style/declarations.md
+++ b/_style/declarations.md
@@ -224,13 +224,20 @@ There are three main reasons you should do this:
         List("").foldLeft[Int](0, _ + _.length)
 
 For complex DSLs, or with type-names that are long, it can be difficult
-to fit the entire signature on one line. In those cases, align the
-open-paren of the parameter lists, one list per line (i.e. if you can't
-put them all on one line, put one each per line):
+to fit the entire signature on one line. In those cases, split the parameter
+lists, one parameter per line with
+[trailing commas](https://docs.scala-lang.org/sips/trailing-commas.html#motivation)
+and parentheses being on a separate lines adding to visual separation between
+lists:
 
-    protected def forResource(resourceInfo: Any)
-                             (f: (JsonNode) => Any)
-                             (implicit urlCreator: URLCreator, configurer: OAuthConfiguration): Any = {
+    protected def forResource(
+      resourceInfo: Any,
+    )(
+      f: (JsonNode) => Any,
+    )(implicit
+      urlCreator: URLCreator,
+      configurer: OAuthConfiguration,
+    ): Any = {
       ...
     }
 

--- a/_style/declarations.md
+++ b/_style/declarations.md
@@ -241,6 +241,15 @@ lists:
       ...
     }
 
+Other possibility is to align the open-paren of the parameter lists,
+one list per line:
+
+    protected def forResource(resourceInfo: Any)
+                             (f: (JsonNode) => Any)
+                             (implicit urlCreator: URLCreator, configurer: OAuthConfiguration): Any = {
+      ...
+    }
+
 #### Higher-Order Functions
 
 It's worth keeping in mind when declaring higher-order functions the

--- a/_style/declarations.md
+++ b/_style/declarations.md
@@ -224,31 +224,32 @@ There are three main reasons you should do this:
         List("").foldLeft[Int](0, _ + _.length)
 
 For complex DSLs, or with type-names that are long, it can be difficult
-to fit the entire signature on one line. In those cases, split the parameter
-lists, one parameter per line with
+to fit the entire signature on one line. For those cases there are several
+different styles in use:
+
+1. Split the parameter lists, one parameter per line with
 [trailing commas](https://docs.scala-lang.org/sips/trailing-commas.html#motivation)
-and parentheses being on a separate lines adding to visual separation between
-lists:
+and parentheses being on separate lines adding to visual separation between
+the lists:
 
-    protected def forResource(
-      resourceInfo: Any,
-    )(
-      f: (JsonNode) => Any,
-    )(implicit
-      urlCreator: URLCreator,
-      configurer: OAuthConfiguration,
-    ): Any = {
-      ...
-    }
+        protected def forResource(
+          resourceInfo: Any,
+        )(
+          f: (JsonNode) => Any,
+        )(implicit
+          urlCreator: URLCreator,
+          configurer: OAuthConfiguration,
+        ): Any = {
+          ...
+        }
 
-Other possibility is to align the open-paren of the parameter lists,
-one list per line:
+2. Or align the open-paren of the parameter lists, one list per line:
 
-    protected def forResource(resourceInfo: Any)
-                             (f: (JsonNode) => Any)
-                             (implicit urlCreator: URLCreator, configurer: OAuthConfiguration): Any = {
-      ...
-    }
+        protected def forResource(resourceInfo: Any)
+                                 (f: (JsonNode) => Any)
+                                 (implicit urlCreator: URLCreator, configurer: OAuthConfiguration): Any = {
+          ...
+        }
 
 #### Higher-Order Functions
 


### PR DESCRIPTION
To make it consistent with argument list formatting of [Classes](https://docs.scala-lang.org/style/declarations.html#classes).

Previously: #1805

Alternative offered, please review once again @SethTisue