### PR TITLE
alter wording in SIP process about flags

### DIFF
--- a/_sips/sip-submission.md
+++ b/_sips/sip-submission.md
@@ -150,10 +150,11 @@ the formal evaluation phase.
 
 ### Merging the proposal
 
-If the SIP is accepted, the committee will propose a release date to the
-compiler maintainers, where the role of the committee ends. Accepted SIPs will
-then be merged under a flag. When SIPs introduce intricate changes and they
-cannot be merged under a flag, the compiler maintainers will merge it directly.
+If the SIP is accepted, the committee will propose a release date to
+the compiler maintainers, where the role of the committee ends.
+(Compiler maintainers may choose to merge changes under a flag
+initially, for testing, or directly, as they deem appropriate,
+taking committee and community feedback into consideration.)
 
 ## Structure of the process
 


### PR DESCRIPTION
I don't think either the Scala 2 or 3 teams were aware this wording existed; I suggest we bring the wording in line with de facto reality.

This is just a draft for now because I may want to adjust the wording again once https://github.com/lampepfl/dotty/issues/11774 has been addressed.