### PR TITLE
Fix typo in self-types.md

### DIFF
--- a/_ja/tour/self-types.md
+++ b/_ja/tour/self-types.md
@@ -38,4 +38,4 @@ class VerifiedTweeter(val username_ : String) extends Tweeter with User {  // Tw
 val realBeyoncé = new VerifiedTweeter("Beyoncé")
 realBeyoncé.tweet("Just spilled my glass of lemonade")  // "real Beyoncé: Just spilled my glass of lemonade"と出力します。
 ```
-`trait Tweeter`の中で`this: User =>`と記述したので、今は変数`username`は`tweet`メソッドのスコープ内にあります。これはさらに、`VerifiedTweeter`が`Tweeter`を継承する際、(`with User`を使って)`User`もミックスインしなければならいことを意味します。
+`trait Tweeter`の中で`this: User =>`と記述したので、今は変数`username`は`tweet`メソッドのスコープ内にあります。これはさらに、`VerifiedTweeter`が`Tweeter`を継承する際、(`with User`を使って)`User`もミックスインしなければならないことを意味します。


### PR DESCRIPTION
Add 'な'

```
ミックスインしなければならいことを意味します
```
↓
```
ミックスインしなければならないことを意味します
```