### PR TITLE
Avoid text fragmentation with inline code

### DIFF
--- a/_sass/layout/type-md.scss
+++ b/_sass/layout/type-md.scss
@@ -156,8 +156,8 @@
             background: $gray-lighter;
             color: #667b83;
             // border: 1px solid #ced7d7;
-            padding: 0 6px;
-            margin: 0 4px;
+            padding: 1px 3px;
+            margin: 0 2px;
         }
     }
 


### PR DESCRIPTION
This change removes the extra padding around inline code snippets to make the text simpler to read. 

## New 

<img width="600" alt="Screenshot 2021-04-30 at 11 29 10" src="https://user-images.githubusercontent.com/3648029/116676621-7e634680-a9a7-11eb-9f97-7b4c9e5178b2.png">

<img width="601" alt="Screenshot 2021-04-30 at 11 30 11" src="https://user-images.githubusercontent.com/3648029/116676609-7acfbf80-a9a7-11eb-9bca-10b2657e4f3a.png">


## Old
<img width="598" alt="Screenshot 2021-04-30 at 11 22 40" src="https://user-images.githubusercontent.com/3648029/116675969-b6b65500-a9a6-11eb-875d-33f250fd6b9d.png">
<img width="601" alt="Screenshot 2021-04-30 at 11 16 08" src="https://user-images.githubusercontent.com/3648029/116675977-bae27280-a9a6-11eb-8e99-1836d4d50d82.png">

