### PR TITLE
Remove old Reflection name

### DIFF
--- a/_ja/scala3/new-in-scala3.md
+++ b/_ja/scala3/new-in-scala3.md
@@ -77,7 +77,7 @@ Scala 2 のマクロはあくまで実験的な機能という位置づけだが
 - **Inline**. [inline][meta-inline] を使うことで値やメソッドをコンパイル時に評価できる。 このシンプルな機能はさまざまなユースケースに対応している。また同時に`inline`はより高度な機能のエントリーポイントとしても使える。
 - **Compile-time operations**. [`scala.compiletime`][meta-compiletime] パッケージには inline method を実装するのに役立つ追加的な機能が含まれている。
 - **Quoted code blocks**. Scala 3 には [quasi-quotation][meta-quotes]という新機能がある。この機能を使えば扱いやすい高レベルなインターフェースを介してコードを組み立てたり分析したりすることができる。  `'{ 1 + 1 }` と書くだけで1 と 1 を足すASTを組み立てられる。
-- **Reflection API**. もっと高度なユースケースでは [TASTy reflect][meta-reflection]を使ってより細かくプログラムツリーを操作したり生成したりすることができる。
+- **Reflection API**. もっと高度なユースケースでは [quotes.reflect][meta-reflection]を使ってより細かくプログラムツリーを操作したり生成したりすることができる。
 
 
 Scala 3 のメタプログラミングについてもっと知りたいかたは、 こちらの[tutorial][meta-tutorial]を参照。

--- a/_overviews/scala3-macros/best-practices.md
+++ b/_overviews/scala3-macros/best-practices.md
@@ -57,5 +57,5 @@ val y: Expr[Int] = ...
 
 
 
-## TASTy reflection
+## Quotes Reflect
 **Coming soon**

--- a/scala3/guides/tasty-overview.md
+++ b/scala3/guides/tasty-overview.md
@@ -138,11 +138,11 @@ These articles provide more information about Scala 3 macros:
 
 - [Scala Macro Libraries](https://scalacenter.github.io/scala-3-migration-guide/docs/macros/macro-libraries.html)
 - [Macros: The Plan for Scala 3](https://www.scala-lang.org/blog/2018/04/30/in-a-nutshell.html)
-- [The reference documentation on TASTy Reflect][tasty-reflect]
+- [The reference documentation on Quotes Reflect][quotes-reflect]
 - [The reference documentation on macros](macros)
 
 [benefits]: https://www.scala-lang.org/blog/2018/04/30/in-a-nutshell.html
 [erasure]: https://www.scala-lang.org/files/archive/spec/2.13/03-types.html#type-erasure
 [binary]: {% link _overviews/tutorials/binary-compatibility-for-library-authors.md %}
-[tasty-reflect]: {{ site.scala3ref }}/metaprogramming/reflection.html
+[quotes-reflect]: {{ site.scala3ref }}/metaprogramming/reflection.html
 [macros]: {{ site.scala3ref }}/metaprogramming/macros.html

--- a/scala3/new-in-scala3.md
+++ b/scala3/new-in-scala3.md
@@ -89,7 +89,7 @@ The [macro tutorial]({% link _overviews/scala3-macros/index.md %}) contains deta
 - **Inline**. As the basic starting point, the [inline feature][meta-inline] allows values and methods to be reduced at compile time. This simple feature already covers many use-cases and at the same time provides the entry point for more advanced features.
 - **Compile-time operations**. The package [`scala.compiletime`][meta-compiletime] contains additional functionality that can be used to implement inline methods.
 - **Quoted code blocks**. Scala 3 adds the new feature of [quasi-quotation][meta-quotes] for code, providing a convenient high-level interface to construct and analyse code. Constructing code for adding one and one is as easy as `'{ 1 + 1 }`.
-- **Reflection API**. For more advanced use cases [TASTy reflect][meta-reflection] provides more detailed control to inspect and generate program trees.
+- **Reflection API**. For more advanced use cases [quotes.reflect][meta-reflection] provides more detailed control to inspect and generate program trees.
 
 If you want to learn more about meta programming in Scala 3, we invite you to take our [tutorial][meta-tutorial].
 


### PR DESCRIPTION
We have stopped using the name TASTy reflect since 2019 to avoid confusion with TASTy files.
We usually only refer to it as reflection or quotes reflection following the import `quotes.reflect`.