### PR TITLE
Change documentation paragraph line height (and fix haskellwiki link)

### DIFF
--- a/_overviews/quasiquotes/terminology.md
+++ b/_overviews/quasiquotes/terminology.md
@@ -10,7 +10,7 @@ permalink: /overviews/quasiquotes/:title.html
 ---
 <span class="tag" style="float: right;">EXPERIMENTAL</span>
 
-* **Quasiquote** (not quasi-quote) can refer to either the quasiquote library or any usage of one its [interpolators](intro.html#interpolators). The name is not hyphenated for the sake of consistency with implementations of the same concept in other languages (e.g. [Scheme and Racket](https://docs.racket-lang.org/reference/quasiquote.html), [Haskell](https://www.haskell.org/haskellwiki/Quasiquotation))
+* **Quasiquote** (not quasi-quote) can refer to either the quasiquote library or any usage of one its [interpolators](intro.html#interpolators). The name is not hyphenated for the sake of consistency with implementations of the same concept in other languages (e.g. [Scheme and Racket](https://docs.racket-lang.org/reference/quasiquote.html), [Haskell](https://wiki.haskell.org/Quasiquotation))
 * **Tree** or **AST** (Abstract Syntax Tree) is a representation of a Scala program or a part of it through means of the Scala reflection API's Tree type.
 * **Tree construction** refers to usages of quasiquotes as expressions to represent creation of new tree values.
 * **Tree deconstruction** refers to usages of quasiquotes as patterns to structurally tear apart trees.

--- a/_overviews/quasiquotes/terminology.md
+++ b/_overviews/quasiquotes/terminology.md
@@ -10,7 +10,7 @@ permalink: /overviews/quasiquotes/:title.html
 ---
 <span class="tag" style="float: right;">EXPERIMENTAL</span>
 
-* **Quasiquote** (not quasi-quote) can refer to either the quasiquote library or any usage of one its [interpolators](intro.html#interpolators). The name is not hyphenated for the sake of consistency with implementations of the same concept in other languages (e.g. [Scheme and Racket](https://docs.racket-lang.org/reference/quasiquote.html), [Haskell](https://wiki.haskell.org/Quasiquotation))
+* **Quasiquote** (not quasi-quote) can refer to either the quasiquote library or any usage of one of its [interpolators](intro.html#interpolators). The name is not hyphenated for the sake of consistency with implementations of the same concept in other languages (e.g. [Scheme and Racket](https://docs.racket-lang.org/reference/quasiquote.html), [Haskell](https://wiki.haskell.org/Quasiquotation))
 * **Tree** or **AST** (Abstract Syntax Tree) is a representation of a Scala program or a part of it through means of the Scala reflection API's Tree type.
 * **Tree construction** refers to usages of quasiquotes as expressions to represent creation of new tree values.
 * **Tree deconstruction** refers to usages of quasiquotes as patterns to structurally tear apart trees.

--- a/_sass/layout/documentation.scss
+++ b/_sass/layout/documentation.scss
@@ -44,6 +44,10 @@
 .content-primary.documentation {
   line-height: 1.3;
 
+  p {
+    line-height: 1.5;
+  }
+
   ol {
     margin-bottom: 18px;
   }


### PR DESCRIPTION
Improve the readability of paragraphs in the documentation by adding some extra space between the lines.

**New**

<img width="607" alt="Screenshot 2021-05-05 at 13 06 45" src="https://user-images.githubusercontent.com/3648029/117132674-73435880-ada3-11eb-837e-23fd0c9e9ebd.png">

**Old**

<img width="604" alt="Screenshot 2021-05-05 at 13 07 00" src="https://user-images.githubusercontent.com/3648029/117132698-7a6a6680-ada3-11eb-92e0-53fc20b06f0c.png">
