### PR TITLE
Update release and target options

### DIFF
--- a/_data/compiler-options.yml
+++ b/_data/compiler-options.yml
@@ -260,7 +260,7 @@
       type: "String"
       arg: "release"
       default:
-    description: "Compile for a specific version of the Java platform. Supported targets: 6, 7, 8, 9"
+    description: "Compile for a specific version of the Java platform. Supported targets: 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16"
     abbreviations:
     - "--release"
   - option: "-sourcepath"
@@ -282,6 +282,10 @@
       - choice: "10"
       - choice: "11"
       - choice: "12"
+      - choice: "13"
+      - choice: "14"
+      - choice: "15"
+      - choice: "16"
     description: "Target platform for object files. ([8],9,10,11,12)"
     abbreviations:
     - "--target"


### PR DESCRIPTION
I also noticed that `17` also works, but I guess it is still experimental according to [**JDK COMPATIBILITY**](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html). So, I am not sure if I should also add that; maybe with an _(experimental)_ flag.
Also, maybe we should drop everything below `8`?


----

BTW I also noticed that the `scalac` built-in help command shows:

> -release <release>           Compile for a specific version of the Java platform. Supported targets: 6, 7, 8, 9

Which AFAIK is wrong, where may I fix that?