### PR TITLE
Update naming-conventions.md: remove duplications

### DIFF
--- a/_style/index.md
+++ b/_style/index.md
@@ -20,7 +20,7 @@ This document is intended to outline some basic Scala stylistic guidelines which
     - [Accessors/Mutators](naming-conventions.html#accessorsmutators)
     - [Parentheses](naming-conventions.html#parentheses)
     - [Symbolic Method Names](naming-conventions.html#symbolic-method-names)
-  - [Constants, Values, Variable and Methods](naming-conventions.html#constants-values-variable-and-methods)
+  - [Constants, Values and Variables](naming-conventions.html#constants-values-and-variables)
   - [Type Parameters (generics)](naming-conventions.html#type-parameters-generics)
     - [Higher-Kinds and Parameterized Type parameters](naming-conventions.html#higher-kinds-and-parameterized-type-parameters)
   - [Annotations](naming-conventions.html#annotations)

--- a/_style/naming-conventions.md
+++ b/_style/naming-conventions.md
@@ -266,7 +266,7 @@ advanced feature in Scala, to be used only by those most well-versed in
 its pitfalls. Without care, excessive use of symbolic method names can
 easily transform even the simplest code into symbolic soup.
 
-## Constants, Values and Variable
+## Constants, Values and Variables
 
 Constant names should be in upper camel case. Similar to Java's `static final`
 members, if the member is final, immutable and it belongs to a package

--- a/_style/naming-conventions.md
+++ b/_style/naming-conventions.md
@@ -266,7 +266,7 @@ advanced feature in Scala, to be used only by those most well-versed in
 its pitfalls. Without care, excessive use of symbolic method names can
 easily transform even the simplest code into symbolic soup.
 
-## Constants, Values, Variable and Methods
+## Constants, Values and Variable
 
 Constant names should be in upper camel case. Similar to Java's `static final`
 members, if the member is final, immutable and it belongs to a package
@@ -278,10 +278,9 @@ object or an object, it may be considered a constant:
 
 The value: `Pi` in `scala.math` package is another example of such a constant.
 
-Method, Value and variable names should be in lower camel case:
+Value and variable names should be in lower camel case:
 
     val myValue = ...
-    def myMethod = ...
     var myVariable
 
 ## Type Parameters (generics)


### PR DESCRIPTION
I found duplications of naming conventions,  so I just removed them.
It seems naming conventions of "Methods" are already written in the above section.