### PR TITLE
Cleanup markdown and add a few fixes to Python examples

### DIFF
--- a/_overviews/scala3-book/scala-for-python-devs.md
+++ b/_overviews/scala3-book/scala-for-python-devs.md
@@ -4,7 +4,7 @@ type: chapter
 description: This page is for Python developers who are interested in learning about Scala 3.
 num: 73
 previous-page: scala-for-javascript-devs
-next-page: 
+next-page:
 ---
 
 {% include_relative scala4x.css %}
@@ -33,7 +33,7 @@ The two languages are first compared at a high level, and then at an everyday pr
 
 ### High level similarities
 
-At a high level, Scala shares these *similarities* with Python:  
+At a high level, Scala shares these *similarities* with Python:
 
 - Both are high-level programming languages, where you don’t have to concern yourself with low-level concepts like pointers and manual memory management
 - Both have a relatively simple, concise syntax
@@ -47,8 +47,8 @@ At a high level, Scala shares these *similarities* with Python:
 ### High level differences
 
 Also at a high level, the _differences_ between Python and Scala are:
-  
-- Python is dynamically typed, and Scala is statically typed  
+
+- Python is dynamically typed, and Scala is statically typed
   - Though it’s statically typed, Scala features like type inference make it feel like a dynamic language
 - Python is interpreted, and Scala code is compiled to _.class_ files, and runs on the Java Virtual Machine (JVM)
 - In addition to running on the JVM, the [Scala.js](https://www.scala-js.org) project lets you use Scala as a JavaScript replacement
@@ -59,7 +59,7 @@ Also at a high level, the _differences_ between Python and Scala are:
 
 ### Programming level similarities
 
-This section looks at the similarities you’ll see between Python and Scala when you write code on an everyday basis:  
+This section looks at the similarities you’ll see between Python and Scala when you write code on an everyday basis:
 
 - Scala’s type inference often makes it feel like a dynamically typed language
 - Neither language uses semicolons to end expressions
@@ -72,7 +72,7 @@ This section looks at the similarities you’ll see between Python and Scala whe
 
 ### Programming level differences
 
-Also at a programming level, these are some of the differences you’ll see every day when writing code:  
+Also at a programming level, these are some of the differences you’ll see every day when writing code:
 
 - Programming in Scala feels very consistent:
   - `val` and `var` fields are used consistently to define fields and parameters
@@ -83,7 +83,7 @@ Also at a programming level, these are some of the differences you’ll see ever
 - Scala variables and parameters are defined with the `val` (immutable) or `var` (mutable) keywords
 - Scala idioms prefer immutable data structures
 - Scala has terrific IDE support with IntelliJ IDEA and Microsoft VS Code
-- Comments: Python uses `#` for comments; Scala uses the C, C++, and Java style: `//`, `/*...*/`, and `/**...*/`  
+- Comments: Python uses `#` for comments; Scala uses the C, C++, and Java style: `//`, `/*...*/`, and `/**...*/`
 - Naming conventions: The Python standard is to use underscores like `my_list`; Scala uses `myList`
 - Scala is statically typed, so you declare types for method parameters, method return values, and in other places
 - Pattern matching and `match` expressions are used extensively in Scala  (and will change the way you write code)
@@ -631,7 +631,7 @@ Scala also has `match` expressions.
     </tr>
     <tr>
       <td class="scala-block">
-        <code>val x = 
+        <code>val x =
         <br>&nbsp; for
         <br>&nbsp;&nbsp;&nbsp; i &lt;- 1 to 3
         <br>&nbsp; yield
@@ -988,10 +988,10 @@ Python and Scala have several of the same common functional methods available to
 
 - `map`
 - `filter`
-- `reduce`  
+- `reduce`
 
 If you’re used to using these methods with lambda expressions in Python, you’ll see that Scala has a similar approach with methods on its collections classes.
-To demonstrate this functionality, here are two sample lists:  
+To demonstrate this functionality, here are two sample lists:
 
 ```scala
 numbers = (1,2,3)           // python
@@ -1131,7 +1131,7 @@ Some common grouping methods:
 | `c.span(p)`      | Returns a collection of two collections, the first created by `c.takeWhile(p)`, and the second created by `c.dropWhile(p)`. |
 | `c.splitAt(n)`   | Returns a collection of two collections by splitting the collection `c` at element `n`. |
 
-Some informational and mathematical methods:  
+Some informational and mathematical methods:
 
 | Method         | Description   |
 | -------------- | ------------- |
@@ -1274,7 +1274,7 @@ This section compares enums (enumerations) in Python and Scala 3.
 ## Concepts that are unique to Scala
 
 There are other concepts in Scala which currently don’t have equivalent functionality in Python.
-Follow the links below for more details: 
+Follow the links below for more details:
 
 - Most concepts related to [contextual abstractions][contextual], such as [extension methods][extension-methods], [type classes][type-classes], implicit values
 - Scala allows multiple parameter lists, which enables features like partially-applied functions, and the ability to create your own DSLs

--- a/_overviews/scala3-book/scala-for-python-devs.md
+++ b/_overviews/scala3-book/scala-for-python-devs.md
@@ -256,7 +256,7 @@ This section provides comparisons of features related to OOP-style classes and m
         <br>&nbsp;&nbsp;&nbsp; self.name = name
         <br>
         <br>&nbsp; def speak(self):
-        <br>&nbsp;&nbsp;&nbsp; print('Hello, my name is %s' % self.name)</code>
+        <br>&nbsp;&nbsp;&nbsp; print(f'Hello, my name is {self.name}')</code>
       </td>
     </tr>
     <tr>
@@ -543,8 +543,7 @@ Scala also has `match` expressions.
       <td class="python-block">
         <code>for i in ints:
         <br>&nbsp; x = i * 2
-        <br>&nbsp; s = "i = {}, x = {}"
-        <br>&nbsp; print(s.format(i,x))</code>
+        <br>&nbsp; print(f"i = {i}, x = {x}")</code>
       </td>
     </tr>
     <tr>
@@ -568,8 +567,7 @@ Scala also has `match` expressions.
         <code>for i in range(1,3):
         <br>&nbsp; for j in range(4,6):
         <br>&nbsp;&nbsp;&nbsp; for k in range(1,10,3):
-        <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; s= "i = {}, j = {}, k = {}"
-        <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; print(s.format(i,j,k))</code>
+        <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; print(f"i = {i}, j = {j}, k = {k}")</code>
       </td>
     </tr>
     <tr>

--- a/_overviews/scala3-book/scala-for-python-devs.md
+++ b/_overviews/scala3-book/scala-for-python-devs.md
@@ -8,10 +8,12 @@ next-page:
 ---
 
 {% include_relative scala4x.css %}
+
 <div markdown="1" class="scala3-comparison-page">
 
 {% comment %}
-NOTE: Hopefully someone with more Python experience can give this a thorough review 
+
+NOTE: Hopefully someone with more Python experience can give this a thorough review
 
 NOTE: On this page (https://contributors.scala-lang.org/t/feedback-sought-optional-braces/4702/10), Li Haoyi comments: “Python’s success also speaks for itself; beginners certainly don’t pick Python because of performance, ease of installation, packaging, IDE support, or simplicity of the language’s runtime semantics!” I’m not a Python expert, so these points are good to know, though I don’t want to go negative in any comparisons.
 It’s more like thinking, “Python developers will appreciate Scala’s performance, ease of installation, packaging, IDE support, etc.”
@@ -21,18 +23,15 @@ It’s more like thinking, “Python developers will appreciate Scala’s perfor
 TODO: We should probably go through this document and add links to our other detail pages, when time permits.
 {% endcomment %}
 
-
 This section provides a comparison between the Python and Scala programming languages.
 It’s intended for programmers who know Python and want to learn about Scala, specifically by seeing examples of how Python language features compare to Scala.
 
-
-
-## Introduction 
+## Introduction
 
 Before getting into the examples, this first section provides a relatively brief introduction and summary of the sections that follow.
 The two languages are first compared at a high level, and then at an everyday programming level.
 
-### High level similarities 
+### High level similarities
 
 At a high level, Scala shares these *similarities* with Python:  
 
@@ -45,7 +44,7 @@ At a high level, Scala shares these *similarities* with Python:
 - Both can be used with [Apache Spark](https://spark.apache.org) for big data processing
 - Both have a wealth of terrific libraries
 
-### High level differences 
+### High level differences
 
 Also at a high level, the _differences_ between Python and Scala are:
   
@@ -97,7 +96,6 @@ Also at a programming level, these are some of the differences you’ll see ever
 - Scala code can run in the JVM and even be compiled to native images (using [Scala Native](https://github.com/scala-native/scala-native) and [GraalVM](https://www.graalvm.org)) for high performance
 - Many other goodies: case classes, companion classes and objects, macros, [union][union-types] and [intersection][intersection-types] types, [toplevel definitions][toplevel], numeric literals, multiple parameter lists, and more
 
-
 ### Features compared with examples
 
 Given that introduction, the following sections provide side-by-side comparisons of Python and Scala programming language features.
@@ -105,8 +103,6 @@ Given that introduction, the following sections provide side-by-side comparisons
 {% comment %}
 TODO: Update the Python examples to use four spaces. I started to do this, but then thought it would be better to do that in a separate PR.
 {% endcomment %}
-
-
 
 ## Comments
 
@@ -128,8 +124,6 @@ Python uses `#` for comments, while the Scala comment syntax is the same as lang
     </tr>
   </tbody>
 </table>
-
-  
 
 ## Variable assignment
 
@@ -239,8 +233,6 @@ x += 1
 
 However, the rule of thumb in Scala is to always use `val` unless the variable specifically needs to be mutated.
 
-  
-
 ## OOP style classes and methods
 
 This section provides comparisons of features related to OOP-style classes and methods.
@@ -331,8 +323,6 @@ This section provides comparisons of features related to OOP-style classes and m
   </tbody>
 </table>
 
-
-
 ## Interfaces, traits, and inheritance
 
 If you’re familiar with Java 8 and newer, Scala traits are similar to those Java interfaces.
@@ -354,8 +344,6 @@ sm.multiply(2,2)   // 4
 ```
 
 There are [many other ways to use traits with classes and objects][modeling-intro], but this gives you a little idea of how they can be used to organize concepts into logical groups of behavior, and then merge them as needed to create a complete solution.
-
-  
 
 ## Control structures
 
@@ -717,7 +705,7 @@ Scala also has `match` expressions.
         <br>catch
         <br>&nbsp; case ioe: IOException =&gt;
         <br>&nbsp;&nbsp;&nbsp; println(ioe.getMessage)
-        <br>&nbsp; case fnf: FileNotFoundException =&gt; 
+        <br>&nbsp; case fnf: FileNotFoundException =&gt;
         <br>&nbsp;&nbsp;&nbsp; println(fnf.getMessage)
         <br>finally
         <br>&nbsp; println("Finally")</code>
@@ -728,13 +716,11 @@ Scala also has `match` expressions.
 
 Match expressions and pattern matching are a big part of the Scala programming experience, but only a few `match` expression features are shown here. See the [Control Structures][control-structures] page for many more examples.
 
-
-
 ## Collections classes
 
 This section compares the [collections classes][collections-classes] that are available in Python and Scala, including lists, dictionaries/maps, sets, and tuples.
 
-### Lists 
+### Lists
 
 Where Python has its list, Scala has several different specialized mutable and immutable sequence classes, depending on your needs.
 Because the Python list is mutable, it most directly compares to Scala’s `ArrayBuffer`.
@@ -956,7 +942,7 @@ The Python set is similar to the _mutable_ Scala `Set` class.
 
 Scala has other specialized `Set` classes for different needs.
 
-### Tuples 
+### Tuples
 
 Python and Scala tuples are also similar.
 
@@ -995,8 +981,6 @@ Python and Scala tuples are also similar.
     </tr>
   </tbody>
 </table>
-
-
 
 ## Methods on collections classes
 
@@ -1190,8 +1174,6 @@ None of these methods mutate the initial list `a`; instead, they all return the 
 
 There are many more methods available, but hopefully these descriptions and examples give you a taste of the power that’s available in the pre-built collections methods.
 
-
-
 ## Enums
 
 This section compares enums (enumerations) in Python and Scala 3.
@@ -1289,8 +1271,6 @@ This section compares enums (enumerations) in Python and Scala 3.
   </tbody>
 </table>
 
-
-
 ## Concepts that are unique to Scala
 
 There are other concepts in Scala which currently don’t have equivalent functionality in Python.
@@ -1304,7 +1284,6 @@ Follow the links below for more details:
 - [Multiversal equality][multiversal]: the ability to control at compile time what equality comparisons make sense
 - Infix methods
 - Macros and metaprogramming
-
 
 [collections-classes]: {% link _overviews/scala3-book/collections-classes.md %}
 [concurrency]: {% link _overviews/scala3-book/concurrency.md %}
@@ -1320,7 +1299,4 @@ Follow the links below for more details:
 [toplevel]: {% link _overviews/scala3-book/taste-toplevel-definitions.md %}
 [type-classes]: {% link _overviews/scala3-book/types-type-classes.md %}
 [union-types]: {% link _overviews/scala3-book/types-union.md %}
-
-
 </div>
-

--- a/_overviews/scala3-book/scala-for-python-devs.md
+++ b/_overviews/scala3-book/scala-for-python-devs.md
@@ -719,7 +719,7 @@ Scala also has `match` expressions.
         <br>catch
         <br>&nbsp; case ioe: IOException =&gt;
         <br>&nbsp;&nbsp;&nbsp; println(ioe.getMessage)
-        <br>&nbsp; case nfe: FileNotFoundException =&gt; 
+        <br>&nbsp; case fnf: FileNotFoundException =&gt; 
         <br>&nbsp;&nbsp;&nbsp; println(fnf.getMessage)
         <br>finally
         <br>&nbsp; println("Finally")</code>

--- a/_overviews/scala3-book/scala-for-python-devs.md
+++ b/_overviews/scala3-book/scala-for-python-devs.md
@@ -13,7 +13,7 @@ next-page:
 
 {% comment %}
 
-NOTE: Hopefully someone with more Python experience can give this a thorough review
+NOTE: Hopefully someone with more Python experience can give this a thorough review.
 
 NOTE: On this page (https://contributors.scala-lang.org/t/feedback-sought-optional-braces/4702/10), Li Haoyi comments: “Python’s success also speaks for itself; beginners certainly don’t pick Python because of performance, ease of installation, packaging, IDE support, or simplicity of the language’s runtime semantics!” I’m not a Python expert, so these points are good to know, though I don’t want to go negative in any comparisons.
 It’s more like thinking, “Python developers will appreciate Scala’s performance, ease of installation, packaging, IDE support, etc.”


### PR DESCRIPTION
Removed a lot of redundant whitespace in markdown.
Also translated various Python string formatting examples to use f-strings to better match the Scala equivalent.
Fixed a misnamed Scala variable in case statement.