### PR TITLE
Fixes a typo for Scala 2 extending code example

### DIFF
--- a/_overviews/scala3-book/methods-main-methods.md
+++ b/_overviews/scala3-book/methods-main-methods.md
@@ -114,7 +114,7 @@ They replace the previous approach in Scala 2, which was to create an `object` t
 
 ```scala
 // scala 2
-object happyBirthday extends App: {
+object happyBirthday extends App {
   // needs by-hand parsing of the command line arguments ...
 }
 ```


### PR DESCRIPTION
Removes an invalid colon `:` usage from an example given for Scala 2