### PR TITLE
Fixed what I believe to be typos

### DIFF
--- a/_overviews/scala3-book/fun-write-map-function.md
+++ b/_overviews/scala3-book/fun-write-map-function.md
@@ -20,13 +20,13 @@ Given that statement, you start to write the method signature.
 First, you know that you want to accept a function as a parameter, and that function should transform an `Int` into some generic type `A`, so you write:
 
 ```scala
-def map(f: (Int) => A
+def map(f: (Int) => A)
 ```
 
 The syntax for using a generic type requires declaring that type symbol before the parameter list, so you add that:
 
 ```scala
-def map[A](f: (Int) => A
+def map[A](f: (Int) => A)
 ```
 
 Next, you know that `map` should also accept a `List[Int]`:

--- a/_overviews/scala3-book/methods-most.md
+++ b/_overviews/scala3-book/methods-most.md
@@ -233,7 +233,7 @@ Here’s a method named `isTruthy` that implements the Perl definitions of `true
 
 ```scala
 def isTruthy(a: Any) =
-  if a == 0 || a == ""
+  if a == 0 || a == "" then
     false
   else
     true

--- a/_overviews/scala3-book/methods-most.md
+++ b/_overviews/scala3-book/methods-most.md
@@ -261,8 +261,9 @@ def isTruthy(a: Matchable) = a match
   case _ => true
 ```
 
-This method works just like the previous method that used an `if`/`else` expression.
+This method works just like the previous method that used an `if`/`else` expression. We use `Matchable` instead of `Any` as the parameter's type because it's a safer alternative that will still admit any concrete value or reference.
 
+For more details on the `Matchable` trait, see the [Reference documentation][reference_matchable].
 
 
 ## Controlling visibility in classes
@@ -401,3 +402,4 @@ See the [Reference documentation][reference] for more details on these features.
 [extension]: {% link _overviews/scala3-book/ca-extension-methods.md %}
 [reference_extension_methods]: {{ site.scala3ref }}/contextual/extension-methods.html
 [reference]: {{ site.scala3ref }}/overview.html
+[reference_matchable]: {{ site.scala3ref }}/other-new-features/matchable.html

--- a/_overviews/scala3-book/methods-most.md
+++ b/_overviews/scala3-book/methods-most.md
@@ -261,7 +261,7 @@ def isTruthy(a: Matchable) = a match
   case _ => true
 ```
 
-This method works just like the previous method that used an `if`/`else` expression. We use `Matchable` instead of `Any` as the parameter's type because it's a safer alternative that will still admit any concrete value or reference.
+This method works just like the previous method that used an `if`/`else` expression. We use `Matchable` instead of `Any` as the parameter's type to accept any value that supports pattern matching.
 
 For more details on the `Matchable` trait, see the [Reference documentation][reference_matchable].
 

--- a/_overviews/scala3-book/methods-most.md
+++ b/_overviews/scala3-book/methods-most.md
@@ -256,7 +256,7 @@ A `match` expression can also be used as the entire method body, and often is.
 Here’s another version of `isTruthy`, written with a `match` expression :
 
 ```scala
-def isTruthy(a: Any) = a match
+def isTruthy(a: Matchable) = a match
   case 0 | "" => false
   case _ => true
 ```


### PR DESCRIPTION
I think this `if` expression is missing either a `then` or parenthesis.

I'm not so sure about the other change (replacing `Any` type for `Matchable`), since it seems to be valid Scala code, at least on worksheets. But maybe it would be better presented this way, to avoid conflicting with this quote from other section of the book:

> The top-type `Any` has a subtype Matchable, which is used to mark all types that we can perform pattern matching on. We will not go into details here, but in summary, it means that we cannot pattern match on values of type `Any`, but only on values that are a subtype of `Matchable`.