### PR TITLE
Update MOOCs links and descriptions

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -36,7 +36,7 @@ this course in the following video:
   <iframe width="560" height="315" src="https://www.youtube.com/embed/MSDJ7ehjrqo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-After taking this course, you might be interested in growing further your
+After taking this course, you might be interested in improving your
 skills in specific areas by taking the courses [Parallel Programming],
 [Big Data Analysis with Scala and Spark], or [Programming Reactive Systems].
 

--- a/learn.md
+++ b/learn.md
@@ -61,6 +61,16 @@ and Spark.
 teaches how to write responsive, scalable, and resilient systems with the
 library Akka.
 
+### Scala 2 Courses
+
+The above courses use Scala 3 (except the Spark courses). If needed, you can find
+the (legacy) Scala 2 version of our courses here:
+
+- [Functional Programming Principles in Scala (Scala 2 version)](https://www.coursera.org/learn/scala2-functional-programming)
+- [Functional Program Design (Scala 2 version)](https://www.coursera.org/learn/scala2-functional-program-design)
+- [Parallel Programming (Scala 2 version)](https://www.coursera.org/learn/scala2-parallel-programming)
+- [Programming Reactive Systems (Scala 2 version)](https://www.coursera.org/learn/scala2-akka-reactive)
+
 [Scala Specialization]: https://www.coursera.org/specializations/scala
 [Effective Programming in Scala]: https://www.coursera.org/learn/effective-scala
 [Functional Programming Principles in Scala]: https://www.coursera.org/learn/progfun1

--- a/learn.md
+++ b/learn.md
@@ -11,24 +11,64 @@ There are a handful of websites where you can interactively run Scala code in yo
 
 ## Online courses from the Scala Center
 
-The following courses are available for free. They teach you the main features of the Scala language and introduce you
-to functional programming. They are published either on [Coursera](https://www.coursera.org) or [edX](https://www.edx.org).
+The following online courses provide two main paths to learn Scala. The
+fast path consists of taking the course [Effective Programming in Scala],
+otherwise you can take the full [Scala Specialization], which is made of
+four courses and a capstone project.
 
- * [Functional Programming in Scala Specialization](https://www.coursera.org/specializations/scala).
-   The Specialization provides a hands-on introduction to functional programming using Scala. You can access the courses
-   material and exercises by either signing up for the specialization or auditing the courses individually. The
-   specialization has the following courses.
-    * [Functional Programming Principles in Scala](https://www.coursera.org/learn/progfun1),
-    * [Functional Program Design in Scala](https://www.coursera.org/learn/progfun2),
-    * [Parallel programming](https://www.coursera.org/learn/parprog1),
-    * [Big Data Analysis with Scala and Spark](https://www.coursera.org/learn/scala-spark-big-data),
-    * [Functional Programming in Scala Capstone](https://www.coursera.org/learn/scala-capstone),
- * [Programming Reactive Systems](https://www.coursera.org/learn/scala-reactive) (also available on [edX](https://www.edx.org/course/programming-reactive-systems)).
-
-Note : On Coursera and edX, there is a paid version available. The only difference with the free version is that
-the paid version delivers a certificate of completion. Learn more about
+All the courses are available for free. Optionally, a subscription gives
+you access to a certificate of completion that attests your accomplishments.
+Learn more about
 [Coursera certificates](https://learner.coursera.help/hc/en-us/articles/209819053-Get-a-Course-Certificate) or
 [edX certificates](https://support.edx.org/hc/en-us/categories/115002269627-Certificates).
+
+### Effective Programming in Scala
+
+[Effective Programming in Scala] teaches non-Scala programmers everything
+they need to be ready to work in Scala. At the end of this hands-on course,
+you will know how to achieve common programming tasks in Scala (e.g.,
+modeling business domains, implementing business logic, designing large
+systems made of components, handling errors, manipulating data, running 
+concurrent tasks in parallel, testing your code). You can learn more about
+this course in the following video:
+
+<div style="text-align: center">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/MSDJ7ehjrqo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+After taking this course, you might be interested in growing further your
+skills in specific areas by taking the courses [Parallel Programming],
+[Big Data Analysis with Scala and Spark], or [Programming Reactive Systems].
+
+### Scala Specialization
+
+The [Scala Specialization] provides a hands-on introduction to functional programming using Scala. You can access the courses
+material and exercises by either signing up for the specialization or auditing the courses individually. The
+   specialization has the following courses.
+* [Functional Programming Principles in Scala],
+* [Functional Program Design in Scala],
+* [Parallel programming],
+* [Big Data Analysis with Scala and Spark],
+* [Functional Programming in Scala Capstone].
+
+These courses provide a deep understanding of the Scala language itself,
+and they also dive into more specific topics such as parallel programming,
+and Spark.
+
+### Programming Reactive Systems
+
+[Programming Reactive Systems] (also available on [edX](https://www.edx.org/course/scala-akka-reactive))
+teaches how to write responsive, scalable, and resilient systems with the
+library Akka.
+
+[Scala Specialization]: https://www.coursera.org/specializations/scala
+[Effective Programming in Scala]: https://www.coursera.org/learn/effective-scala
+[Functional Programming Principles in Scala]: https://www.coursera.org/learn/progfun1
+[Functional Program Design in Scala]: https://www.coursera.org/learn/progfun2
+[Parallel programming]: https://www.coursera.org/learn/parprog1
+[Big Data Analysis with Scala and Spark]: https://www.coursera.org/learn/scala-spark-big-data
+[Functional Programming in Scala Capstone]: https://www.coursera.org/learn/scala-capstone
+[Programming Reactive Systems]: https://www.coursera.org/learn/scala-akka-reactive
 
 ## Scala Exercises
 


### PR DESCRIPTION
Vincenzo noticed that this page is still available through the Scala 2 banner, which is partially wrong because most of the courses have already been updated to Scala 3. I think we need to take a bit more time to overhaul the co-existence of the Scala 2 and Scala 3 documentation (most likely, we want to move most of the current content of https://docs.scala-lang.org/learn.html into a page https://docs.scala-lang.org/scala2/learn.html, so that we keep the URL https://docs.scala-lang.org/learn.html for documentation up to date with the latest stable release of Scala. But this is not the path that has been taken so far… e.g. https://docs.scala-lang.org/overviews/scala-book/introduction.html shows the Scala 2 book, not Scala 3’s). In the meantime, I would like to merge this as it is, at least for SEO reasons.