### PR TITLE
Upgrade migration guide to Scala 3.0.0 and 2.13.6

### DIFF
--- a/_overviews/scala3-migration/tooling-tour.md
+++ b/_overviews/scala3-migration/tooling-tour.md
@@ -82,7 +82,7 @@ Full-fledged support is being worked on by the team at JetBrains.
 
 ### Scalafmt
 
-[Scalafmt](https://scalameta.org/scalafmt/) v3.0.0-RC1 supports both Scala 2.13 and Scala 3.
+[Scalafmt](https://scalameta.org/scalafmt/) v3.0.0-RC3 supports both Scala 2.13 and Scala 3.
 
 To enable Scala 3 formatting you must set the `runner.dialect = scala3` in your `.scalafmt.conf` file.
 

--- a/_overviews/scala3-migration/tutorial-macro-cross-building.md
+++ b/_overviews/scala3-migration/tutorial-macro-cross-building.md
@@ -24,7 +24,7 @@ In order to exemplify this tutorial, we will consider the minimal macro library 
 lazy val example = project
   .in(file("example"))
   .settings(
-    scalaVersion := "2.13.5",
+    scalaVersion := "2.13.6",
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     )
@@ -69,7 +69,7 @@ The main idea is to build the artifact twice and to publish two releases:
 You can add Scala 3 to the list of `crossScalaVersions` of your project:
 
 ```scala
-crossScalaVersions := Seq("2.13.5", "3.0.0-RC3")
+crossScalaVersions := Seq("2.13.6", "3.0.0")
 ```
 
 The `scala-reflect` dependency won't be useful in Scala 3.
@@ -87,15 +87,15 @@ libraryDependencies ++= {
 }
 ```
 
-After reloading sbt, you can switch to the Scala 3 context by running `++3.0.0-RC3`.
-At any point you can go back to the Scala 2.13 context by running `++2.13.5`.
+After reloading sbt, you can switch to the Scala 3 context by running `++3.0.0`.
+At any point you can go back to the Scala 2.13 context by running `++2.13.6`.
 
 ## 2. Rearrange the code in version-specific source directories
 
 If you try to compile with Scala 3 you should see some errors of the same kind as:
 
 {% highlight text %}
-sbt:example> ++3.0.0-RC3
+sbt:example> ++3.0.0
 sbt:example> example / compile
 [error] -- Error: /example/src/main/scala/location/Location.scala:15:35 
 [error] 15 |    val location = typeOf[Location]
@@ -198,13 +198,13 @@ class MacrosSpec extends munit.FunSuite {
 You should now be able to run the tests in both versions.
 
 {% highlight text %}
-sbt:example> ++2.13.5
+sbt:example> ++2.13.6
 sbt:example> example / test
 location.MacrosSpec:
   + location
 [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
 [success]
-sbt:example> ++3.0.0-RC3
+sbt:example> ++3.0.0
 sbt:example> example / test
 location.MacrosSpec:
   + location

--- a/_overviews/scala3-migration/tutorial-macro-mixing.md
+++ b/_overviews/scala3-migration/tutorial-macro-mixing.md
@@ -87,13 +87,13 @@ However, in many cases you will have to move the Scala 2.13 macro implementation
 
 lazy val example = project.in(file("example"))
   .settings(
-    scalaVersion := "3.0.0-RC1"
+    scalaVersion := "3.0.0"
   )
   .dependsOn(`example-compat`)
 
 lazy val `example-compat` = project.in(file("example-compat"))
   .settings(
-    scalaVersion := "2.13.5",
+    scalaVersion := "2.13.6",
     libraryDependency += "org.scala-lang" % "scala-reflect" % scalaVersion.value
   )
 ```
@@ -133,15 +133,15 @@ Since we want to execute the tests in Scala 2.13 and Scala 3, we create a cross-
 // build.sbt
 lazy val `example-test` = project.in(file("example-test"))
   .settings(
-    scalaVersion := "3.0.0-RC1",
-    crossScalaVersions := Seq("3.0.0-RC1", "2.13.5"),
+    scalaVersion := "3.0.0",
+    crossScalaVersions := Seq("3.0.0", "2.13.6"),
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 13)) => Seq("-Ytasty-reader")
         case _ => Seq.empty
       }
     },
-    libraryDependencies += "org.scalameta" %% "munit" % "0.7.23" % Test
+    libraryDependencies += "org.scalameta" %% "munit" % "0.7.26" % Test
   )
   .dependsOn(example)
 ```
@@ -163,13 +163,13 @@ class MacrosSpec extends munit.FunSuite {
 You should now be able to run the tests in both versions.
 
 {% highlight text %}
-sbt:example> ++2.13.5
+sbt:example> ++2.13.6
 sbt:example> example-test / test
 location.MacrosSpec:
   + location
 [info] Passed: Total 1, Failed 0, Errors 0, Passed 1
 [success]
-sbt:example> ++3.0.0-RC1
+sbt:example> ++3.0.0
 sbt:example> example-test / test
 location.MacrosSpec:
   + location
@@ -191,7 +191,7 @@ You are now ready to publish your library.
 It can be used in Scala 3 projects, or in Scala 2.13 projects with these settings:
 
 ```scala
-scalaVersion := "2.13.5"
+scalaVersion := "2.13.6"
 libraryDependencies += ("org" %% "example" % "x.y.z").cross(CrossVersion.for2_13Use3)
 scalacOptions += "-Ytasty-reader"
 ```

--- a/_overviews/scala3-migration/tutorial-prerequisites.md
+++ b/_overviews/scala3-migration/tutorial-prerequisites.md
@@ -69,8 +69,8 @@ You can find all configured compiler plugins by looking at the compiler options 
 
 {% highlight text %}
 sbt:example> show example / Compile / scalacOptions
-[info] * -Xplugin:target/compiler_plugins/wartremover_2.13.5-2.4.12.jar
-[info] * -Xplugin:target/compiler_plugins/semanticdb-scalac_2.13.5-4.3.20.jar
+[info] * -Xplugin:target/compiler_plugins/wartremover_2.13.6-2.4.15.jar
+[info] * -Xplugin:target/compiler_plugins/semanticdb-scalac_2.13.6-4.4.18.jar
 [info] * -Yrangepos
 [info] * -P:semanticdb:targetroot:/example/target/scala-2.13/meta
 {% endhighlight %}

--- a/_overviews/scala3-migration/tutorial-sbt.md
+++ b/_overviews/scala3-migration/tutorial-sbt.md
@@ -43,16 +43,16 @@ This is crucial to avoid bugs that could happen when fixing the incompatibilitie
 Configuring cross-building ins sbt is as short as:
 
 ```scala
-scalaVersion := "3.0.0-RC3"
-crossScalaVersions ++= Seq("2.13.5", "3.0.0-RC3")
+scalaVersion := "3.0.0"
+crossScalaVersions ++= Seq("2.13.6", "3.0.0")
 ```
 
 This configuration means:
-- The default version is `3.0.0-RC3`.
-- 2.13.5 can be loaded by running the `++2.13.5` command.
-- 3.0.0-RC3 can be loaded by running the `++3.0.0-RC3` command.
+- The default version is `3.0.0`.
+- 2.13.6 can be loaded by running the `++2.13.6` command.
+- 3.0.0 can be loaded by running the `++3.0.0` command.
 
-Beware that the `reload` command will always load the default version---here it is 3.0.0-RC3.
+Beware that the `reload` command will always load the default version---here it is 3.0.0.
 
 ## 4. Prepare the dependencies
 
@@ -77,20 +77,20 @@ Make sure the one you choose does not bring any breaking change.
 You can use the Scala 2.13 version of the library. The syntax is:
 
 ```scala
-("com.lihaoyi" %% "os-lib" % "0.7.3").cross(CrossVersion.for3Use2_13)
+("com.lihaoyi" %% "os-lib" % "0.7.7").cross(CrossVersion.for3Use2_13)
 ```
 
 Or for a Scala.js dependencies:
 
 ```scala
-("com.lihaoyi" %%% "os-lib" % "0.7.3").cross(CrossVersion.for3Use2_13)
+("com.lihaoyi" %%% "os-lib" % "0.7.7").cross(CrossVersion.for3Use2_13)
 ```
 
 Once you have fixed all the unresolved dependencies, you can check that the tests are still passing in Scala 2.13:
 
 {% highlight text %}
-sbt:example> ++2.13.5
-[info] Setting Scala version to 2.13.5 on 1 project.
+sbt:example> ++2.13.6
+[info] Setting Scala version to 2.13.6 on 1 project.
 ...
 sbt:example> example / test
 ...
@@ -138,8 +138,8 @@ Also you should disable `-Xfatal-warnings` to take full advantage of the migrati
 It is now time to try compiling in Scala 3:
 
 {% highlight text %}
-sbt:example> ++3.0.0-RC3
-[info] Setting Scala version to 3.0.0-RC3 on 1 project.
+sbt:example> ++3.0.0
+[info] Setting Scala version to 3.0.0 on 1 project.
 ...
 sbt:example> example / compile
 ...
@@ -171,8 +171,8 @@ This is particularly crucial if your project is a published library.
 After fixing an incompatibility, you can validate the solution by running the tests in Scala 2.13.
 
 {% highlight text %}
-sbt:example> ++2.13.5
-[info] Setting Scala version to 2.13.5 on 1 project.
+sbt:example> ++2.13.6
+[info] Setting Scala version to 2.13.6 on 1 project.
 ...
 sbt:example> example / test
 ...
@@ -186,7 +186,7 @@ Only the migration warnings are remaining.
 You can patch them automatically by compiling with the `-source:3.0-migration -rewrite` options.
 
 {% highlight text %}
-sbt:example> ++3.0.0-RC3
+sbt:example> ++3.0.0
 sbt:example> set example / scalacOptions += "-rewrite"
 sbt:example> example / compile
 ...
@@ -206,11 +206,11 @@ Good tests are the only guarantee to prevent such bugs from going unnoticed.
 Make sure that the tests are passing in both Scala 2.13 and Scala 3.
 
 {% highlight text %}
-sbt:example> ++2.13.5
+sbt:example> ++2.13.6
 sbt:example> example / test
 ...
 [success]
-sbt:example> ++3.0.0-RC3
+sbt:example> ++3.0.0
 sbt:example> example / test
 ...
 [success]


### PR DESCRIPTION
In the migration guide:
- upgrade to Scala 3.0.0 final
- upgrade to 2.13.6 which is TASTy compatible with 3.0.0
- update all library versions accordingly