### PR TITLE
Fix typo in macro tutorial

### DIFF
--- a/_overviews/scala3-macros/tutorial/quotes.md
+++ b/_overviews/scala3-macros/tutorial/quotes.md
@@ -14,7 +14,7 @@ Intuitively, the code directly within the quote is not executed now, while the c
 
 ```scala
 val msg = Expr("Hello")
-val printHello = '{ print($hello) }
+val printHello = '{ print($msg) }
 println(printHello.show) // print("Hello")
 ```
 


### PR DESCRIPTION
Nearly tripped me up 😉  