### PR TITLE
Fix typo on line 131 of domain-modeling-oop.md

### DIFF
--- a/_overviews/scala3-book/domain-modeling-oop.md
+++ b/_overviews/scala3-book/domain-modeling-oop.md
@@ -128,7 +128,7 @@ In order to allow this, the base class needs to be marked as `open`:
 ```scala
 open class Person(name: String)
 ```
-Marking classes with [`open`][open] is a new feature of Sala 3. Having to explicitly mark classes as open avoids many common pitfalls in OO design.
+Marking classes with [`open`][open] is a new feature of Scala 3. Having to explicitly mark classes as open avoids many common pitfalls in OO design.
 In particular, it requires library designers to explicitly plan for extension and for instance document the classes that are marked as open with additional extension contracts.
 
 {% comment %}


### PR DESCRIPTION
Very simple typo. Was: "Sala 3", should be: "Scala 3".
I've never actually submitted a PR before so hopefully I did it the correct way.