### PR TITLE
Old style Scala 2 If-else expression

### DIFF
--- a/_overviews/scala3-book/domain-modeling-tools.md
+++ b/_overviews/scala3-book/domain-modeling-tools.md
@@ -219,7 +219,7 @@ Here’s an example of a “string utilities” object that contains a set of me
 object StringUtils:
   def truncate(s: String, length: Int): String = s.take(length)
   def containsWhitespace(s: String): Boolean = s.matches(".*\\s.*")
-  def isNullOrEmpty(s: String): Boolean = s==null || s.trim.isEmpty
+  def isNullOrEmpty(s: String): Boolean = s == null || s.trim.isEmpty
 ```
 
 We can use the object as follows:

--- a/_overviews/scala3-book/domain-modeling-tools.md
+++ b/_overviews/scala3-book/domain-modeling-tools.md
@@ -219,8 +219,7 @@ Here’s an example of a “string utilities” object that contains a set of me
 object StringUtils:
   def truncate(s: String, length: Int): String = s.take(length)
   def containsWhitespace(s: String): Boolean = s.matches(".*\\s.*")
-  def isNullOrEmpty(s: String): Boolean =
-    if s == null || s.trim.equals("") then true else false
+  def isNullOrEmpty(s: String): Boolean = s==null || s.trim.isEmpty
 ```
 
 We can use the object as follows:

--- a/_overviews/scala3-book/taste-objects.md
+++ b/_overviews/scala3-book/taste-objects.md
@@ -27,7 +27,7 @@ For example, this `StringUtils` object contains a small collection of string-rel
 
 ```scala
 object StringUtils:
-  def isNullOrEmpty(s: String): Boolean = s==null || s.trim == ""
+  def isNullOrEmpty(s: String): Boolean = s==null || s.trim.isEmpty
   def leftTrim(s: String): String = s.replaceAll("^\\s+", "")
   def rightTrim(s: String): String = s.replaceAll("\\s+$", "")
 ```

--- a/_overviews/scala3-book/taste-objects.md
+++ b/_overviews/scala3-book/taste-objects.md
@@ -27,7 +27,7 @@ For example, this `StringUtils` object contains a small collection of string-rel
 
 ```scala
 object StringUtils:
-  def isNullOrEmpty(s: String): Boolean = s==null || s.trim.isEmpty
+  def isNullOrEmpty(s: String): Boolean = s == null || s.trim.isEmpty
   def leftTrim(s: String): String = s.replaceAll("^\\s+", "")
   def rightTrim(s: String): String = s.replaceAll("\\s+$", "")
 ```
@@ -90,6 +90,5 @@ NOTE: I don’t know if this is worth keeping, but I’m leaving it here as a co
 > You may read that objects are used to _reify_ traits into modules.
 > _Reify_ means, “to take an abstract concept and turn it into something concrete.” This is what happens in these examples, but “implement” is a more familiar word for most people than “reify.”
 {% endcomment %}
-
 
 

--- a/_overviews/scala3-book/taste-objects.md
+++ b/_overviews/scala3-book/taste-objects.md
@@ -27,8 +27,7 @@ For example, this `StringUtils` object contains a small collection of string-rel
 
 ```scala
 object StringUtils:
-  def isNullOrEmpty(s: String): Boolean =
-    if (s==null || s.trim.equals("")) true else false
+  def isNullOrEmpty(s: String): Boolean = s==null || s.trim.equals("")
   def leftTrim(s: String): String = s.replaceAll("^\\s+", "")
   def rightTrim(s: String): String = s.replaceAll("\\s+$", "")
 ```

--- a/_overviews/scala3-book/taste-objects.md
+++ b/_overviews/scala3-book/taste-objects.md
@@ -27,7 +27,7 @@ For example, this `StringUtils` object contains a small collection of string-rel
 
 ```scala
 object StringUtils:
-  def isNullOrEmpty(s: String): Boolean = s==null || s.trim.equals("")
+  def isNullOrEmpty(s: String): Boolean = s==null || s.trim == ""
   def leftTrim(s: String): String = s.replaceAll("^\\s+", "")
   def rightTrim(s: String): String = s.replaceAll("\\s+$", "")
 ```


### PR DESCRIPTION
`if (<condition>) <doThis> else <doThat>` syntax is from Scala 2. Use `if <condition> then <doThis> else <doThat>` instead or simplify it by removing the if-else expression. If-else is unnecessary so i removed it. I already tested this code using REPL. It does work as intended

```
$ scala3-repl
scala> def isNullOrEmpty(s: String): Boolean = s==null || s.trim.equals("")
def isNullOrEmpty(s: String): Boolean

scala> isNullOrEmpty (null)
val res0: Boolean = true

scala> isNullOrEmpty ("")                                                                            
val res3: Boolean = true

scala> isNullOrEmpty ("hello")                                                                     
val res1: Boolean = false
```