### PR TITLE
Fix docker port in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To build and view site with docker:
 
     docker-compose up
 
-It will incrementally build and serve site at `http://localhost:8080`
+It will incrementally build and serve site at `http://localhost:4000`
 
 ## Contributing ##
 


### PR DESCRIPTION
Hi *,
I found that the readme was not up to date regarding docker-compose.

The [docker-compose.yml](https://github.com/scala/docs.scala-lang/blob/69520e5ed9a5590222ecb7295f9ba496fd44cb31/docker-compose.yml#L7) exposes the port on 4000 not 8080 since 17e9c0ebe41f9e20c3614ed3c732fcd42ea35602.