### PR TITLE
Fix a typo in Domain Modeling / Tools

### DIFF
--- a/_overviews/scala3-book/domain-modeling-tools.md
+++ b/_overviews/scala3-book/domain-modeling-tools.md
@@ -66,7 +66,7 @@ p.vocation = "Musician"
 
 ### Fields and methods
 
-Classes can have also have methods and additional fields that are not part of constructors.
+Classes can also have methods and additional fields that are not part of constructors.
 They are defined in the body of the class.
 The body is initialized as part of the default constructor:
 


### PR DESCRIPTION
I believe `have also have` is not grammatical. Should be `also have`