### PR TITLE
Removed 'do' line from the Scala 2 while section

### DIFF
--- a/_overviews/scala3-book/taste-control-structures.md
+++ b/_overviews/scala3-book/taste-control-structures.md
@@ -239,7 +239,6 @@ In Scala 2, the syntax was a bit different. The condition was surrounded by pare
 there was no `do` keyword:
 
 ```scala
-while (x >= 0) do x = f(x)
 while (x >= 0) { x = f(x) }
 ```
 


### PR DESCRIPTION
In the Control Structures section of the Scala 3 Book, removed the line describing while loops in Scala 2 (included do)