### PR TITLE
Grammar and Cleanup in Scala 3 Macro Documentation

### DIFF
--- a/_overviews/scala3-macros/best-practices.md
+++ b/_overviews/scala3-macros/best-practices.md
@@ -6,7 +6,7 @@ num: 8
 ## Inline
 
 ### Be careful when inlining for performance
-To take the most advantage of the JVM JIT optimisations you want to avoid generating large methods.
+To take the most advantage of the JVM JIT optimisations, you want to avoid generating large methods.
 
 
 ## Macros
@@ -16,24 +16,24 @@ To take the most advantage of the JVM JIT optimisations you want to avoid genera
 ## Quoted code
 
 ### Keep quotes readable
-* Try to avoid `${..}` with arbitrary expressions inside
+* Try to avoid `${...}` with arbitrary expressions inside
   * Use `$someExpr`
   * Use `${ someExprFrom('localExpr) }`
 
 To illustrate, consider the following example:
 ```scala
-val x: StringContext = ...
-'{ StringContext(${Varargs(stringContext.parts.map(Expr(_)))}: _*) }
+val sc: StringContext = ...
+'{ StringContext(${Varargs(sc.parts.map(Expr(_)))}: _*) }
 ```
-Instead we can write the following:
+Instead, we can write the following:
 
 ```scala
-val x: StringContext = ...
-val partExprs = stringContext.parts.map(Expr(_))
+val sc: StringContext = ...
+val partExprs = sc.parts.map(Expr(_))
 val partsExpr = Varargs(partExprs)
 '{ StringContext($partsExpr: _*) }
 ```
-The contents of the quote are cleared this way.
+The contents of the quote are much more clear in the second example.
 
 ### Avoid nested contexts
 
@@ -74,34 +74,29 @@ val leafSym: Symbol   = leafTpe.typeSymbol
 
 ### Avoid `Symbol.tree`
 
-On an object `sym: Symbol`, `sym.tree` returns the `Tree` associated to the
-symbol. Be careful when using this method as the tree for a symbol might not be
-defined. When the code associated to the symbol is defined in a different
-moment than this access, if the `-Yretain-trees` compilation option is not
-used, then the `tree` of the symbol will not be available. Symbols originated
-from Java code do not have an associated `tree`.
+On an object `sym: Symbol`, `sym.tree` returns the `Tree` associated with the symbol.
+Be careful when using this method, as the tree for a symbol might not be defined.
+When the code associated with a symbol is defined at a different time than this access, if the `-Yretain-trees` compilation option is not used, then the `tree` of the symbol will not be available.
+Symbols originating from Java code do not have an associated `tree`.
 
 ### Obtaining a `TypeRepr` from a `Symbol`
 
-In the previous paragraph we saw that `Symbol.tree` should be avoided and
-therefore you should not use `sym.tree.tpe` on `sym: Symbol`.  Thus to obtain
-the `TypeRepr` corresponding to a `Symbol`, it is recommended to use
-`tpe.memberType` on objects `tpe: TypeRepr`.
+In the previous heading, we saw that `Symbol.tree` should be avoided and that therefore you should not use `sym.tree.tpe` on `sym: Symbol`.
+Thus, to obtain the `TypeRepr` corresponding to a `Symbol`, it is recommended to use `tpe.memberType` on `tpe: TypeRepr` objects.
 
 We can obtain the `TypeRepr` of `Leaf` in two ways:
   1. `TypeRepr.of[Box.Leaf]`
-  2. `boxTpe.memberType(leafSym)`, in other words we request the `TypeRepr` of
-     the member of `Box` whose symbol is equal to the symbol of sym
+  2. `boxTpe.memberType(leafSym)`
+(In other words, we request the `TypeRepr` of the member of `Box` whose symbol is equal to the symbol of `leafSym`.)
 
-while the two approaches are equivalent, the first is possible only if you
-already know that you are looking for `Box.Leaf`. The second approach allows
-you to explore an uknown API.
+While the two approaches are equivalent, the first is only possible if you already know that you are looking for the type `Box.Leaf`.
+The second approach allows you to explore an unknown API.
 
 ### Use `Symbol`s to compare definitions
 
 Read more about Symbols [here][symbol].
 
-Symbols allow comparing definitions using `==`:
+Symbols allow you to compare definitions using `==`:
 ```scala
 leafSym == baseSym.children.head // Is true
 ```
@@ -113,7 +108,7 @@ boxTpe.memberType(baseSym.children.head) == leafTpe // Is false
 
 ### Obtaining a Symbol for a type
 
-There is a handy shortcut to get the symbol of the definition of `T`.
+There is a handy shortcut to get the symbol for the definition of `T`.
 Instead of
 
 ```scala

--- a/_overviews/scala3-macros/tutorial/macros.md
+++ b/_overviews/scala3-macros/tutorial/macros.md
@@ -73,7 +73,7 @@ As a technicaly consequence, we cannot define and use a macro in the **same clas
 However, it is possible to have the macro definition and its call in the **same project** as long as the implementation of the macro can be compiled first.
 
 > ##### Suspended Files
-> To allow defining and using macros in the same project, only those calls to macros are expanded, where the macro has already been compiled.
+> To allow defining and using macros in the same project, only those calls to macros that have already been compiled are expanded.
 > For all other (unknown) macro calls, the compilation of the file is _suspended_.
 > Suspended files are only compiled after all non suspended files have been successfully compiled.
 > In some cases, you will have _cyclic dependencies_ that will block the completion of the compilation.
@@ -206,7 +206,7 @@ def sumCode(nums: Expr[Seq[Int]])(using Quotes): Expr[Int] =
 The extractor will match a call to `sumNow(1, 2, 3)` and extract a `Seq[Expr[Int]]` containing the code of each parameter.
 But, if we try to match the argument of the call `sumNow(nums: _*)`, the extractor will not match.
 
-`Varargs` can also be used as a constructor, `Varargs(Expr(1), Expr(2), Expr(3))` will return a `Expr[Seq[Int]]`.
+`Varargs` can also be used as a constructor. `Varargs(Expr(1), Expr(2), Expr(3))` will return an `Expr[Seq[Int]]`.
 We will see how this can be useful later.
 
 
@@ -226,8 +226,8 @@ while subsequent chapters introduce the more advanced APIs.
 ### Collections
 
 We have seen how to convert a `List[Int]` into an `Expr[List[Int]]` using `Expr.apply`.
-How about converting a `List[Expr[Int]]` into `Expr[List[Int]]`?
-We mentioned that `Varargs.apply` can do this for sequences -- likewise for other collection types, corresponding methods are available:
+How about converting a `List[Expr[Int]]` into an `Expr[List[Int]]`?
+We mentioned that `Varargs.apply` can do this for sequences; likewise, for other collection types, corresponding methods are available:
 
 * `Expr.ofList`: Transform a `List[Expr[T]]` into `Expr[List[T]]`
 * `Expr.ofSeq`: Transform a `Seq[Expr[T]]` into `Expr[Seq[T]]` (just like `Varargs`)
@@ -269,7 +269,7 @@ Note, that `matches` only performs a limited amount of normalization and while f
 ### Arbitrary Expressions
 
 Last but not least, it is possible to create an `Expr[T]` from arbitary Scala code by enclosing it in [quotes][quotes].
-For example `'{ ${expr}; true }` will generate an `Expr[Int]` equivalent to `Expr.block(List(expr), Expr(true))`.
+For example, `'{ ${expr}; true }` will generate an `Expr[Int]` equivalent to `Expr.block(List(expr), Expr(true))`.
 The subsequent section on [Quoted Code][quotes] presents quotes in more detail.
 
 [contributing]: {% link scala3/contribute-to-docs.md %}

--- a/_overviews/scala3-macros/tutorial/quotes.md
+++ b/_overviews/scala3-macros/tutorial/quotes.md
@@ -20,7 +20,7 @@ println(printHello.show) // print("Hello")
 
 In general, the quote delays the execution while the splice makes it happen before the surrounding code.
 This generalisation allows us to also give meaning to a `${ ... }` that is not within a quote. This evaluates the code within the splice at compile-time and places the result in the generated code.
-Due to some technical considerations, only non-quoted splices are allowed directly within `inline` definitions that we call a [macro][macros].
+Due to some technical considerations, only top-level splices are allowed directly within `inline` definitions that we call a [macro][macros].
 
 It is possible to write a quote within a quote, but this pattern is not common when writing macros.
 
@@ -103,7 +103,7 @@ The less verbose version is usually the best way to write the types as it is muc
 In some cases, we will not statically know the type within the `Type` and will need to use the `t.Underlying` to refer to it.
 
 When do we need this extra `Type` parameter?
-* When a type is abstract and it is used at a level that is deeper than the current level.
+* When a type is abstract and it is used at a level that is higher than the current level.
 
 When you add a `Type` contextual parameter to a method, you will either get it from another context parameter or implicitly with a call to `Type.of`:
 ```scala
@@ -276,7 +276,7 @@ def exprOfOptionOf[T: Type](x: Expr[Option[Any]])(using Quotes): Option[Expr[T]]
     case '{ Some($x: T) } => Some(x) // x: Expr[T]
     case _ => None
 ```
-This time, the pattern `Some($x: T)` will only match if the type of the Option is `Some[T]`.
+This time, the pattern `Some($x: T)` will only match if the type of the `Option` is `Some[T]`.
 
 ```scala
 exprOfOptionOf[Int]('{ Some(3) })   // Some('{3})

--- a/_overviews/scala3-macros/tutorial/reflection.md
+++ b/_overviews/scala3-macros/tutorial/reflection.md
@@ -7,7 +7,7 @@ previous-page: quotes
 ---
 
 The reflection API provides a more complex and comprehensive view on the structure of the code.
-It provides a view on the *Typed Abstract Syntax Trees* and their properties such as types, symbols, positions and comments.
+It provides a view of *Typed Abstract Syntax Trees* and their properties such as types, symbols, positions and comments.
 
 The API can be used in macros as well as for [inspecting TASTy files][tasty inspection].
 
@@ -16,8 +16,8 @@ The API can be used in macros as well as for [inspecting TASTy files][tasty insp
 The reflection API is defined in the type `Quotes` as `reflect`.
 The actual instance depends on the current scope, in which quotes or quoted pattern matching is used.
 Hence, every macro method receives Quotes as an additional argument.
-Since `Quotes` is contextual, to access its members we either need to name the parameter, or summon it.
-The following definition of the standard library provides the canonical way of accessing it.
+Since `Quotes` is contextual, to access its members we either need to name the parameter or summon it.
+The following definition from the standard library details the canonical way of accessing it:
 
 ```scala
 package scala.quoted
@@ -25,10 +25,10 @@ package scala.quoted
 transparent inline def quotes(using inline q: Quotes): q.type = q
 ```
 
-We can use `scala.quoted.quotes` to import it the current `Quotes` in scope like this
+We can use `scala.quoted.quotes` to import the current `Quotes` in scope:
 
 ```scala
-import scala.quoted.* // Import `quotes`, `Quotes` and `Expr`
+import scala.quoted.* // Import `quotes`, `Quotes`, and `Expr`
 
 def f(x: Expr[Int])(using Quotes): Expr[Int] =
   import quotes.reflect.* // Import `Tree`, `TypeRepr`, `Symbol`, `Position`, .....
@@ -41,16 +41,17 @@ This will import all the types and modules (with extension methods) of the API.
 ## How to navigate the API
 
 The full API can be found in the [API documentation for `scala.quoted.Quotes.reflectModule`][reflection doc].
-Unfortunately, at this stage, this automatically generated documentation is not very easy to navigate.
+Unfortunately, at this stage, this automatically-generated documentation is not very easy to navigate.
 
 The most important element on the page is the hierarchy tree which provides a synthetic overview of the subtyping relationships of
 the types in the API. For each type `Foo` in the tree:
 
  - the trait `FooMethods` contains the methods available on the type `Foo`
- - the trait `FooModule` contains the static methods available on the object `Foo`. Most notably, constructors (`apply/copy`) and the `unapply` method which provides the extractor(s) required for pattern matching.
- - For all types `Upper` such that `Foo <: Upper`, the methods defined in `UpperMethods` are available on `Foo` as well.
+ - the trait `FooModule` contains the static methods available on the object `Foo`.
+Most notably, constructors (`apply/copy`) and the `unapply` method which provides the extractor(s) required for pattern matching are found here
+ - For all types `Upper` such that `Foo <: Upper`, the methods defined in `UpperMethods` are also available on `Foo`
 
-For example [`TypeBounds`](https://scala-lang.org/api/3.x/scala/quoted/Quotes$reflectModule.html#TypeBounds-0), a subtype of `TypeRepr`, represents a type tree of the form `T >: L <: U`: a type `T` which is a super type of `L`
+For example, [`TypeBounds`](https://scala-lang.org/api/3.x/scala/quoted/Quotes$reflectModule.html#TypeBounds-0), a subtype of `TypeRepr`, represents a type tree of the form `T >: L <: U`: a type `T` which is a super type of `L`
 and a subtype of `U`. In [`TypeBoundsMethods`](https://scala-lang.org/api/3.x/scala/quoted/Quotes$reflectModule$TypeBoundsMethods.html), you will find the methods `low` and `hi`, which allow you to access the
 representations of `L` and `U`. In [`TypeBoundsModule`](https://scala-lang.org/api/3.x/scala/quoted/Quotes$reflectModule$TypeBoundsModule.html), you will find the `unapply` method, which allows you to write:
 
@@ -60,8 +61,7 @@ def f(tpe: TypeRepr) =
     case TypeBounds(l, u) =>
 ```
 
-Remember also that `TypeBounds <: TypeRepr`, therefore all the methods defined in `TypeReprMethods` are
-available on `TypeBounds` values as in:
+Because `TypeBounds <: TypeRepr`, all the methods defined in `TypeReprMethods` are available on `TypeBounds` values:
 
 ```scala
 def f(tpe: TypeRepr) =
@@ -75,12 +75,12 @@ def f(tpe: TypeRepr) =
 
 ### Expr and Term
 
-Expressions `Expr[T]` can be seen as wrappers around a `Term`, where `T` is the statically known type of the term.
-Below we use the extension method `asTerm` to transform the expression into a term.
+Expressions (`Expr[T]`) can be seen as wrappers around a `Term`, where `T` is the statically-known type of the term.
+Below, we use the extension method `asTerm` to transform an expression into a term.
 This extension method is only available after importing `quotes.reflect.asTerm`.
 Then we use `asExprOf[Int]` to transform the term back into `Expr[Int]`.
-This operation will fail if the term does not have the provided type (here `Int`) or if the term is not a valid expression.
-For example, a `Ident(fn)` is non-valid term if the method `fn` takes type parameters, in which case we would need an `Apply(Ident(fn), args)`.
+This operation will fail if the term does not have the provided type (in this case, `Int`) or if the term is not a valid expression.
+For example, an `Ident(fn)` is an invalid term if the method `fn` takes type parameters, in which case we would need an `Apply(Ident(fn), args)`.
 
 ```scala
 def f(x: Expr[Int])(using Quotes): Expr[Int] =
@@ -92,10 +92,10 @@ def f(x: Expr[Int])(using Quotes): Expr[Int] =
 
 ### Type and TypeRepr
 
-Similarly, we can also see `Type[T]` as a wrapper over `TypeRepr`, with `T` being the statically known type.
-To get a `TypeRepr` we use `TypeRepr.of[X]` which expects a given `Type[X]` in scope (similar to `Type.of[X]`).
+Similarly, we can also see `Type[T]` as a wrapper over `TypeRepr`, with `T` being the statically-known type.
+To get a `TypeRepr`, we use `TypeRepr.of[T]`, which expects a given `Type[T]` in scope (similar to `Type.of[T]`).
 We can also transform it back into a `Type[?]` using the `asType` method.
-As the type of `Type[?]` is not statically know we need to name it with an existential type to use it. This can be achieved using a `'[t]` pattern.
+As the type of `Type[?]` is not statically known, we need to name it with an existential type to use it. This can be achieved using the `'[t]` pattern.
 
 ```scala
 def g[T: Type](using Quotes) =
@@ -108,39 +108,39 @@ def g[T: Type](using Quotes) =
 
 ## Symbols
 
-The APIs of `Term` and `TypeRepr` are relatively *closed* in the sense that methods produce and accept values
-whose types are defined in the API. You might notice however the presence of `Symbol`s which identify definitions.
+The APIs of `Term` and `TypeRepr` are relatively *closed* in the sense that methods produce and accept values whose types are defined in the API.
+However, you might notice the presence of `Symbol`s which identify definitions.
 
-Both `Term` or `TypeRepr` (therefore `Expr` and `Type`) have an associated symbol.
+Both `Term`s and `TypeRepr`s (and therefore `Expr`s and `Type`s) have an associated symbol.
 `Symbol`s make it possible to compare two definitions using `==` to know if they are the same.
-In addition `Symbol` exposes and is used by many useful methods. For example:
+In addition, `Symbol` exposes and is used by many useful methods. For example:
 
  - `declaredFields` and `declaredMethods` allow you to iterate on the fields and members defined inside a symbol
  - `flags` allows you to check multiple properties of a symbol
- - `companionObject` and `companionModule` provide a way to jump to and from the companion object/class.
- - `TypeRepr.baseClasses` returns the list of symbols of classes extended by a type. 
- - `Symbol.pos` gives you access to the position where the symbol is defined, the source code of the definition
- and even the filename where the symbol is defined.
- - and many useful others that you can find in [`SymbolMethods`](https://scala-lang.org/api/3.x/scala/quoted/Quotes$reflectModule$SymbolMethods.html)
+ - `companionObject` and `companionModule` provide a way to jump to and from the companion object/class
+ - `TypeRepr.baseClasses` returns the list of symbols of classes extended by a type
+ - `Symbol.pos` gives you access to the position where the symbol is defined, the source code of the definition, and even the filename where the symbol is defined
+ - many others that you can find in [`SymbolMethods`](https://scala-lang.org/api/3.x/scala/quoted/Quotes$reflectModule$SymbolMethods.html)
 
 ### To Symbol and back
 
 Consider an instance of the type `TypeRepr` named `val tpe: TypeRepr = ...`. Then:
 
  - `tpe.typeSymbol` returns the symbol of the type represented by `TypeRepr`. The recommended way to obtain a `Symbol` given a `Type[T]` is `TypeRepr.of[T].typeSymbol`
- - For a singleton type, `tpe.termSymbol` returns the symbol of the underlying object or value.
+ - For a singleton type, `tpe.termSymbol` returns the symbol of the underlying object or value
  - `tpe.memberType(symbol)` returns the `TypeRepr` of the provided symbol
- - On objects `t: Tree`, `t.symbol` returns the symbol associated to a tree. Given that `Term <: Tree`,
- `Expr.asTerm.symbol` is the best way to obtain the symbol associated to an `Expr[T]`
- - On objects `sym : Symbol`, `sym.tree` returns the `Tree` associated to the symbol. Be careful when using this
- method as the tree for a symbol might not be defined. Read more on the [best practices page][best practices]
+ - On objects `t: Tree`, `t.symbol` returns the symbol associated with a tree.
+ Given that `Term <: Tree`, `Expr.asTerm.symbol` is the best way to obtain the symbol associated with an `Expr[T]`
+ - On objects `sym: Symbol`, `sym.tree` returns the `Tree` associated to the symbol.
+Be careful when using this method as the tree for a symbol might not be defined.
+Read more on the [best practices page][best practices]
 
 ## Macro API design
 
-It will be often useful to create helper methods or extractors that perform some common logic of your macros.
+It will often be useful to create helper methods or extractors that perform some common logic of your macros.
 
 The simplest methods will be those that only mention `Expr`, `Type`, and `Quotes` in their signature.
-Internally they may use reflection but this will not be seen at the use site of the method.
+Internally, they may use reflection, but this will not be seen at the use site of the method.
 
 ```scala
 def f(x: Expr[Int])(using Quotes): Expr[Int] =
@@ -148,8 +148,8 @@ def f(x: Expr[Int])(using Quotes): Expr[Int] =
   ...
 ```
 
-In some cases it is inevitable to require some methods that work on `Tree`s or other types in `quotes.reflect`.
-For these cases, the best is to follow the following example of method signatures.
+In some cases, it may be inevitable that some methods will expect or return `Tree`s or other types in `quotes.reflect`.
+For these cases, the best practice is to follow the following method signature examples:
 
 A method that takes a `quotes.reflect.Term` parameter
 ```scala
@@ -164,7 +164,7 @@ extension (using Quotes)(term: quotes.reflect.Term)
   def g: quotes.reflect.Tree = ...
 ```
 
-An extractor that matches on `quotes.reflect.Term`s.
+An extractor that matches on `quotes.reflect.Term`s
 ```scala
 object MyExtractor:
   def unapply(using Quotes)(x: quotes.reflect.Term) =
@@ -173,32 +173,32 @@ object MyExtractor:
 ```
 
 > **Avoid saving the `Quotes` context in a field.**
-> `Quotes` in fields inevitably make its use harder by hitting errors involving `Quotes` with different paths.
+> `Quotes` in fields inevitably make its use harder by causing errors involving `Quotes` with different paths.
 >
-> Usually these patterns have been seen in code that uses the Scala 2 ways to define extension methods or contextual unapplies.
+> Usually, these patterns have been seen in code that uses the Scala 2 ways to define extension methods or contextual unapplies.
 > Now that we have `given` parameters that can be added before other parameters, all these old workarounds are not needed anymore.
-> The new abstraction make it simpler on the definition site and at use site.
+> The new abstractions make it simpler both at the definition site and at the use site.
 
 ## Debugging
 
 ### Runtime checks
 
-Expressions `Expr[T]` can be seen as wrappers around a `Term`, where `T` is the statically known type of the term.
-Hence these checks will be done at runtime (i.e. compile-time when the macro expands).
+Expressions (`Expr[T]`) can be seen as wrappers around a `Term`, where `T` is the statically-known type of the term.
+Hence, these checks will be done at runtime (i.e. compile-time when the macro expands).
 
 It is recommended to enable the `-Xcheck-macros` flag while developing macros or on the tests for the macro.
 This flag will enable extra runtime checks that will try to find ill-formed trees or types as soon as they are created.
 
 There is also the `-Ycheck:all` flag that checks all compiler invariants for tree well-formedness.
-These check will usually fail with an assertion error.
+These checks will usually fail with an assertion error.
 
 ### Printing the trees
 
-The `toString` methods of types in `quotes.reflect` are not great for debugging as they show the internal representation rather than the `quotes.reflect` representation.
-In many cases these are similar but they may lead the debugging process astray.
+The `toString` methods on types in the `quotes.reflect` package are not great for debugging as they show the internal representation rather than the `quotes.reflect` representation.
+In many cases these are similar, but they may sometimes lead the debugging process astray, so they shouldn't be relied on.
 
-Hence, `quotes.reflect.Printers` provide a set of useful printers for debugging.
-Notably the `TreeStructure`, `TypeReprStructure` and `ConstantStructure` can be quite useful.
+Instead, `quotes.reflect.Printers` provides a set of useful printers for debugging.
+Notably the `TreeStructure`, `TypeReprStructure`, and `ConstantStructure` classes can be quite useful.
 These will print the tree structure following loosely the extractors that would be needed to match it.
 
 ```scala
@@ -218,7 +218,7 @@ tree match
 ```
 This way, if a case is missed the error will report a familiar structure that can be copy-pasted to start fixing the issue.
 
-We can make this printer the default if needed
+You can make this printer the default if desired:
 ```scala
   import quotes.reflect.*
   given Printer[Tree] = Printer.TreeStructure


### PR DESCRIPTION
I was trying to familiarize myself with Scala 3 macros today and found multiple issues in the documentation that I felt I could quickly clean up. There are other bigger issues and missing sections, but I tried to limit myself to just cleaning up the grammar of what was already there.

I made a few code snippet changes as well. For these, I usually tried to make things more consistent without trying to reinvent the code in question.