### PR TITLE
Fix a typo in a Java code example

### DIFF
--- a/_overviews/scala3-book/scala-for-java-devs.md
+++ b/_overviews/scala3-book/scala-for-java-devs.md
@@ -181,11 +181,7 @@ equivalent to the Scala code that follows it.
         <br>&nbsp; }
         <br>
         <br>&nbsp; // zero-arg constructor
-        <br>&nbsp; public Person(
-        <br>&nbsp;&nbsp;&nbsp; String firstName, 
-        <br>&nbsp;&nbsp;&nbsp; String lastName, 
-        <br>&nbsp;&nbsp;&nbsp; int age
-        <br>&nbsp; ) {
+        <br>&nbsp; public Person() {
         <br>&nbsp;&nbsp;&nbsp; this("", "", 0);
         <br>&nbsp; }
         <br>


### PR DESCRIPTION
This pull request fixes what looks like a typo in the [*Scala for Java Developers*](https://docs.scala-lang.org/scala3/book/scala-for-java-devs.html#auxiliary-constructors) page.

The Java code example isn’t currently compiling, because two constructors of `Person` have the same signature.