### PR TITLE
API documentation is now hosted on scala-lang.org/api/3.x/

### DIFF
--- a/_data/scala3-doc-nav-header.yml
+++ b/_data/scala3-doc-nav-header.yml
@@ -14,4 +14,4 @@
 - title: Reference
   url: "/scala3/reference/overview.html"
 - title: API
-  url: "https://dotty.epfl.ch/api/index.html"
+  url: "https://scala-lang.org/api/3.x/"

--- a/_ja/index.md
+++ b/_ja/index.md
@@ -35,7 +35,7 @@ scala3-sections:
       - title: "API"
         description: "Scala 3 の全バージョンのAPIドキュメント"
         icon: "fa fa-file-text"
-        link: https://dotty.epfl.ch/api/index.html
+        link: https://scala-lang.org/api/3.x/
       - title: "Language Reference"
         description: "Scala 3 の言語仕様"
         icon: "fa fa-book"

--- a/_ja/scala3/index.md
+++ b/_ja/scala3/index.md
@@ -36,7 +36,7 @@ sections:
       - title: "API"
         description: "Scala 3 の全バージョンのAPIドキュメント"
         icon: "fa fa-file-text"
-        link: https://dotty.epfl.ch/api/index.html
+        link: https://scala-lang.org/api/3.x/
       - title: "Language Reference"
         description: "Scala 3 の言語仕様"
         icon: "fa fa-book"

--- a/_overviews/scala3-book/first-look-at-types.md
+++ b/_overviews/scala3-book/first-look-at-types.md
@@ -276,5 +276,5 @@ Alternatives to `null` are discussed in the [Functional Programming chapter][fp]
 [matchable]: {{ site.scala3ref }}/other-new-features/matchable.html
 [interpolation]: {% link _overviews/core/string-interpolation.md %}
 [fp]: {% link _overviews/scala3-book/fp-intro.md %}
-[option-api]: https://dotty.epfl.ch/api/scala/Option.html
+[option-api]: https://scala-lang.org/api/3.x/scala/Option.html
 [safe-null]: {{ site.scala3ref }}/other-new-features/explicit-nulls.html

--- a/_overviews/scala3-book/taste-collections.md
+++ b/_overviews/scala3-book/taste-collections.md
@@ -114,5 +114,5 @@ See the [Reference documentation][reference] for more tuple details.
 
 
 [collections]: {% link _overviews/scala3-book/collections-intro.md %}
-[api]: https://dotty.epfl.ch/api/index.html
+[api]: https://scala-lang.org/api/3.x/
 [reference]: {{ site.scala3ref }}/overview.html

--- a/_overviews/scala3-macros/tutorial/compiletime.md
+++ b/_overviews/scala3-macros/tutorial/compiletime.md
@@ -72,4 +72,4 @@ On the other hand, `summonInline` will summon after inlining if the call is not 
 *Coming soon*
 
 
-[compiletime-api]: https://dotty.epfl.ch/api/scala/compiletime.html
+[compiletime-api]: https://scala-lang.org/api/3.x/scala/compiletime.html

--- a/_overviews/scala3-macros/tutorial/reflection.md
+++ b/_overviews/scala3-macros/tutorial/reflection.md
@@ -50,9 +50,9 @@ the types in the API. For each type `Foo` in the tree:
  - the trait `FooModule` contains the static methods available on the object `Foo`. Most notably, constructors (`apply/copy`) and the `unapply` method which provides the extractor(s) required for pattern matching.
  - For all types `Upper` such that `Foo <: Upper`, the methods defined in `UpperMethods` are available on `Foo` as well.
 
-For example [`TypeBounds`](https://dotty.epfl.ch/api/scala/quoted/Quotes$reflectModule.html#TypeBounds-0), a subtype of `TypeRepr`, represents a type tree of the form `T >: L <: U`: a type `T` which is a super type of `L`
-and a subtype of `U`. In [`TypeBoundsMethods`](https://dotty.epfl.ch/api/scala/quoted/Quotes$reflectModule$TypeBoundsMethods.html), you will find the methods `low` and `hi`, which allow you to access the
-representations of `L` and `U`. In [`TypeBoundsModule`](https://dotty.epfl.ch/api/scala/quoted/Quotes$reflectModule$TypeBoundsModule.html), you will find the `unapply` method, which allows you to write:
+For example [`TypeBounds`](https://scala-lang.org/api/3.x/scala/quoted/Quotes$reflectModule.html#TypeBounds-0), a subtype of `TypeRepr`, represents a type tree of the form `T >: L <: U`: a type `T` which is a super type of `L`
+and a subtype of `U`. In [`TypeBoundsMethods`](https://scala-lang.org/api/3.x/scala/quoted/Quotes$reflectModule$TypeBoundsMethods.html), you will find the methods `low` and `hi`, which allow you to access the
+representations of `L` and `U`. In [`TypeBoundsModule`](https://scala-lang.org/api/3.x/scala/quoted/Quotes$reflectModule$TypeBoundsModule.html), you will find the `unapply` method, which allows you to write:
 
 ```scala
 def f(tpe: TypeRepr) =
@@ -121,7 +121,7 @@ In addition `Symbol` exposes and is used by many useful methods. For example:
  - `TypeRepr.baseClasses` returns the list of symbols of classes extended by a type. 
  - `Symbol.pos` gives you access to the position where the symbol is defined, the source code of the definition
  and even the filename where the symbol is defined.
- - and many useful others that you can find in [`SymbolMethods`](https://dotty.epfl.ch/api/scala/quoted/Quotes$reflectModule$SymbolMethods.html)
+ - and many useful others that you can find in [`SymbolMethods`](https://scala-lang.org/api/3.x/scala/quoted/Quotes$reflectModule$SymbolMethods.html)
 
 ### To Symbol and back
 
@@ -230,6 +230,6 @@ We can make this printer the default if needed
 *Coming soon*
 
 [tasty inspection]: {{ site.scala3ref }}/metaprogramming/tasty-inspect.html
-[reflection doc]: https://dotty.epfl.ch/api/scala/quoted/Quotes$reflectModule.html?query=trait%20reflectModule
+[reflection doc]: https://scala-lang.org/api/3.x/scala/quoted/Quotes$reflectModule.html
 
 [best practices]: {% link _overviews/scala3-macros/best-practices.md %}

--- a/_overviews/scala3-migration/scaladoc-settings-compatibility.md
+++ b/_overviews/scala3-migration/scaladoc-settings-compatibility.md
@@ -71,7 +71,7 @@ This setting is a generalized form of the old settings for javadoc/scaladoc.
 
 Example external mapping is:
 ```
--external-mappings:.*scala.*::scaladoc3::http://dotty.epfl.ch/api/,.*java.*::javadoc::https://docs.oracle.com/javase/8/docs/api/
+-external-mappings:.*scala.*::scaladoc3::https://scala-lang.org/api/3.x/,.*java.*::javadoc::https://docs.oracle.com/javase/8/docs/api/
 ```
 
 A mapping is of the form '\<regex>::\[scaladoc3|scaladoc|javadoc]::\<path>'. You can supply several mappings, separated by commas, as shown in the example.

--- a/_scala3-reference/changed-features/main-functions.md
+++ b/_scala3-reference/changed-features/main-functions.md
@@ -59,7 +59,7 @@ The Scala compiler generates a program from a `@main` method `f` as follows:
  - The class has a static method `main` with the usual signature. It takes an `Array[String]`
    as argument and returns `Unit`.
  - The generated `main` method calls method `f` with arguments converted using
-   methods in the [`scala.util.CommandLineParser`](https://dotty.epfl.ch/api/scala/util/CommandLineParser$.html) object.
+   methods in the [`scala.util.CommandLineParser`](https://scala-lang.org/api/3.x/scala/util/CommandLineParser$.html) object.
 
 For instance, the `happyBirthDay` method above would generate additional code equivalent to the following class:
 
@@ -87,5 +87,5 @@ object happyBirthday extends App:
   ...
 ```
 
-The previous functionality of `App`, which relied on the "magic" [`DelayedInit`]({% link _scala3-reference/dropped-features/delayed-init.md %}) trait, is no longer available. [`App`](https://dotty.epfl.ch/api/scala/App.html) still exists in limited form for now, but it does not support command line arguments and will be deprecated in the future. If programs need to cross-build
+The previous functionality of `App`, which relied on the "magic" [`DelayedInit`]({% link _scala3-reference/dropped-features/delayed-init.md %}) trait, is no longer available. [`App`](https://scala-lang.org/api/3.x/scala/App.html) still exists in limited form for now, but it does not support command line arguments and will be deprecated in the future. If programs need to cross-build
 between Scala 2 and Scala 3, it is recommended to use an explicit `main` method with an `Array[String]` argument instead.

--- a/_scala3-reference/contextual/derivation-macro.md
+++ b/_scala3-reference/contextual/derivation-macro.md
@@ -98,7 +98,7 @@ One additional difference with the body of `derived` here as opposed to the one
 with `inline` is that with macros we need to synthesize the body of the code during the
 macro-expansion time. That is the rationale behind the `eqProductBody` function.
 Assuming that we calculate the equality of two `Person`s defined with a case
-class that holds a name of type [`String`](https://dotty.epfl.ch/api/scala/Predef$.html#String)
+class that holds a name of type [`String`](https://scala-lang.org/api/3.x/scala/Predef$.html#String-0)
 and an age of type `Int`, the equality check we want to generate is the following:
 
 ```scala

--- a/_scala3-reference/dropped-features/limit22.md
+++ b/_scala3-reference/dropped-features/limit22.md
@@ -10,10 +10,10 @@ The limits of 22 for the maximal number of parameters of function types and the
 maximal number of fields in tuple types have been dropped.
 
 * Functions can now have an arbitrary number of parameters. Functions beyond
-  [`scala.Function22`](https://www.scala-lang.org/api/current/scala/Function22.html) are erased to a new trait [`scala.runtime.FunctionXXL`](https://dotty.epfl.ch/api/scala/runtime/FunctionXXL.html).
+  [`scala.Function22`](https://www.scala-lang.org/api/current/scala/Function22.html) are erased to a new trait [`scala.runtime.FunctionXXL`](https://scala-lang.org/api/3.x/scala/runtime/FunctionXXL.html).
 
 * Tuples can also have an arbitrary number of fields. Tuples beyond [`scala.Tuple22`](https://www.scala-lang.org/api/current/scala/Tuple22.html)
-  are erased to a new class [`scala.runtime.TupleXXL`](https://dotty.epfl.ch/api/scala/runtime/TupleXXL.html) (which extends the trait [`scala.Product`](https://dotty.epfl.ch/api/scala/Product.html)). Furthermore, they support generic
+  are erased to a new class [`scala.runtime.TupleXXL`](https://scala-lang.org/api/3.x/scala/runtime/TupleXXL.html) (which extends the trait [`scala.Product`](https://scala-lang.org/api/3.x/scala/Product.html)). Furthermore, they support generic
   operation such as concatenation and indexing.
 
 Both of these are implemented using arrays.

--- a/_scala3-reference/dropped-features/nonlocal-returns.md
+++ b/_scala3-reference/dropped-features/nonlocal-returns.md
@@ -8,7 +8,7 @@ Returning from nested anonymous functions has been deprecated.
 
 Nonlocal returns are implemented by throwing and catching `scala.runtime.NonLocalReturnException`-s. This is rarely what is intended by the programmer. It can be problematic because of the hidden performance cost of throwing and catching exceptions. Furthermore, it is a leaky implementation: a catch-all exception handler can intercept a `NonLocalReturnException`.
 
-A drop-in library replacement is provided in [`scala.util.control.NonLocalReturns`](http://dotty.epfl.ch/api/scala/util/control/NonLocalReturns$.html). Example:
+A drop-in library replacement is provided in [`scala.util.control.NonLocalReturns`](https://scala-lang.org/api/3.x/scala/util/control/NonLocalReturns$.html). Example:
 
 ```scala
 import scala.util.control.NonLocalReturns.*

--- a/_scala3-reference/metaprogramming/compiletime-ops.md
+++ b/_scala3-reference/metaprogramming/compiletime-ops.md
@@ -8,7 +8,7 @@ next-page: /scala3/reference/metaprogramming/macros
 
 ## The `scala.compiletime` Package
 
-The [`scala.compiletime`](https://dotty.epfl.ch/api/scala/compiletime.html) package contains helper definitions that provide support for compile-time operations over values. They are described in the following.
+The [`scala.compiletime`](https://scala-lang.org/api/3.x/scala/compiletime.html) package contains helper definitions that provide support for compile-time operations over values. They are described in the following.
 
 ### `constValue` and `constValueOpt`
 
@@ -128,7 +128,7 @@ fail(identity("foo")) // error: failed on: identity("foo")
 
 ### The `scala.compiletime.ops` package
 
-The [`scala.compiletime.ops`](https://dotty.epfl.ch/api/scala/compiletime/ops.html) package contains types that provide support for
+The [`scala.compiletime.ops`](https://scala-lang.org/api/3.x/scala/compiletime/ops.html) package contains types that provide support for
 primitive operations on singleton types. For example,
 `scala.compiletime.ops.int.*` provides support for multiplying two singleton
 `Int` types, and `scala.compiletime.ops.boolean.&&` for the conjunction of two

--- a/_scala3-reference/metaprogramming/macros.md
+++ b/_scala3-reference/metaprogramming/macros.md
@@ -20,7 +20,7 @@ schemes with the familiar string interpolation syntax.
 println(s"Hello, $name, here is the result of 1 + 1 = ${1 + 1}")
 ```
 
-In string interpolation we _quoted_ a string and then we _spliced_ into it, two others. The first, `name`, is a reference to a value of type [`String`](https://dotty.epfl.ch/api/scala/Predef$.html#String), and the second is an arithmetic expression that will be _evaluated_ followed by the splicing of its string representation.
+In string interpolation we _quoted_ a string and then we _spliced_ into it, two others. The first, `name`, is a reference to a value of type [`String`](https://scala-lang.org/api/3.x/scala/Predef$.html#String-0), and the second is an arithmetic expression that will be _evaluated_ followed by the splicing of its string representation.
 
 Quotes and splices in this section allow us to treat code in a similar way,
 effectively supporting macros. The entry point for macros is an inline method
@@ -85,7 +85,7 @@ and it takes types `T` to expressions of type `Type[T]`. Splicing
 takes expressions of type `Expr[T]` to expressions of type `T` and it
 takes expressions of type `Type[T]` to types `T`.
 
-The two types can be defined in package [`scala.quoted`](https://dotty.epfl.ch/api/scala/quoted.html) as follows:
+The two types can be defined in package [`scala.quoted`](https://scala-lang.org/api/3.x/scala/quoted.html) as follows:
 
 ```scala
 package scala.quoted

--- a/_scala3-reference/new-types/dependent-function-types.md
+++ b/_scala3-reference/new-types/dependent-function-types.md
@@ -38,7 +38,7 @@ This type describes function values that take any argument `e` of type
 `Entry` and return a result of type `e.Key`.
 
 Recall that a normal function type `A => B` is represented as an
-instance of the [`Function1` trait](https://dotty.epfl.ch/api/scala/Function1.html)
+instance of the [`Function1` trait](https://scala-lang.org/api/3.x/scala/Function1.html)
 (i.e. `Function1[A, B]`) and analogously for functions with more parameters. Dependent functions
 are also represented as instances of these traits, but they get an additional
 refinement. In fact, the dependent function type above is just syntactic sugar for

--- a/_scala3-reference/other-new-features/transparent-traits.md
+++ b/_scala3-reference/other-new-features/transparent-traits.md
@@ -44,7 +44,7 @@ appear in the inferred type.
 
 The traits `scala.Product`, `java.lang.Serializable` and `java.lang.Comparable`
 are treated automatically as transparent. Other traits are turned into transparent traits using the modifier `transparent`. Scala 2 traits can also be made transparent
-by adding a [`@transparentTrait` annotation](https://dotty.epfl.ch/api/scala/annotation/transparentTrait.html). This annotation is defined in `scala.annotation`. It will be deprecated and phased out once Scala 2/3 interopability is no longer needed.
+by adding a [`@transparentTrait` annotation](https://scala-lang.org/api/3.x/scala/annotation/transparentTrait.html). This annotation is defined in `scala.annotation`. It will be deprecated and phased out once Scala 2/3 interopability is no longer needed.
 
 Typically, transparent traits are traits
 that influence the implementation of inheriting classes and traits that are not usually used as types by themselves. Two examples from the standard collection library are:

--- a/_zh-cn/index.md
+++ b/_zh-cn/index.md
@@ -36,7 +36,7 @@ scala3-sections:
     - title: "API"
       description: "Scala 3 各个版本的API"
       icon: "fa fa-file-text"
-      link: https://dotty.epfl.ch/api/index.html
+      link: https://scala-lang.org/api/3.x/
     - title: "语言参考手册"
       description: "Scala 3 语言参考手册"
       icon: "fa fa-book"

--- a/index.md
+++ b/index.md
@@ -35,7 +35,7 @@ scala3-sections:
       - title: "API"
         description: "API documentation for every version of Scala 3."
         icon: "fa fa-file-text"
-        link: https://dotty.epfl.ch/api/index.html
+        link: https://scala-lang.org/api/3.x/
       - title: "Language Reference"
         description: "The Scala 3 language reference."
         icon: "fa fa-book"

--- a/scala3/index.md
+++ b/scala3/index.md
@@ -35,7 +35,7 @@ sections:
       - title: "API"
         description: "API documentation for every version of Scala 3."
         icon: "fa fa-file-text"
-        link: https://dotty.epfl.ch/api/index.html
+        link: https://scala-lang.org/api/3.x/
       - title: "Language Reference"
         description: "The Scala 3 language reference."
         icon: "fa fa-book"


### PR DESCRIPTION
@romanowski I generated the API documentation by removing the `-siteroot` argument, and I uploaded the content to https://scala-lang.org/api/3.0.0/, https://scala-lang.org/api/3.0.1/, and https://scala-lang.org/api/3.x/ (which is a symbolic link to the latest stable release). One thing that annoys me is that the URLs now contain “api” twice, e.g.: https://scala-lang.org/api/3.x/api/scala/util/CommandLineParser$.html

It is still time to change that, I believe. How would you recommend fixing this issue?