### PR TITLE
add transparent modifier to defaultValue

### DIFF
--- a/_scala3-reference/metaprogramming/compiletime-ops.md
+++ b/_scala3-reference/metaprogramming/compiletime-ops.md
@@ -54,7 +54,7 @@ Using `erasedValue`, we can then define `defaultValue` as follows:
 ```scala
 import scala.compiletime.erasedValue
 
-inline def defaultValue[T] =
+transparent inline def defaultValue[T] =
   inline erasedValue[T] match
     case _: Byte    => Some(0: Byte)
     case _: Char    => Some(0: Char)


### PR DESCRIPTION
`val dInt: Some[Int] = defaultValue[Int]` etc. fail to compile  without transparent.