### PR TITLE
Fix compile

### DIFF
--- a/_scala3-reference/metaprogramming/compiletime-ops.md
+++ b/_scala3-reference/metaprogramming/compiletime-ops.md
@@ -215,7 +215,7 @@ would use it as follows:
 import scala.compiletime.summonFrom
 
 inline def setFor[T]: Set[T] = summonFrom {
-  case ord: Ordering[T] => new TreeSet[T](using ord)
+  case ord: Ordering[T] => new TreeSet[T]()(using ord)
   case _                => new HashSet[T]
 }
 ```


### PR DESCRIPTION
In scala-library 2.13.6, I confirmed that there are two argument lists, but in https://dotty.epfl.ch/api/scala/collection/immutable/TreeSet.html, it looks like there is only one argument list for the constructor.

I tried with `scalaVersion := "3.0.1"` then scala-libary 2.13.6 is used. I don't know where there's the updated stdlib.