### PR TITLE
add lazy for elemInstances in derivation.md

### DIFF
--- a/_scala3-reference/contextual/derivation.md
+++ b/_scala3-reference/contextual/derivation.md
@@ -218,7 +218,7 @@ instance for the appropriate ADT subtype using the auxiliary method `check` (4).
 ```scala
 import scala.deriving.Mirror
 
-def eqSum[T](s: Mirror.SumOf[T], elems: List[Eq[_]]): Eq[T] =
+def eqSum[T](s: Mirror.SumOf[T], elems: => List[Eq[_]]): Eq[T] =
   new Eq[T]:
     def eqv(x: T, y: T): Boolean =
       val ordx = s.ordinal(x)                            // (3)

--- a/_scala3-reference/contextual/derivation.md
+++ b/_scala3-reference/contextual/derivation.md
@@ -184,7 +184,7 @@ a `Mirror[T]`. Here is a possible implementation,
 import scala.deriving.Mirror
 
 inline given derived[T](using m: Mirror.Of[T]): Eq[T] =
-  val elemInstances = summonAll[m.MirroredElemTypes]           // (1)
+  lazy val elemInstances = summonAll[m.MirroredElemTypes]           // (1)
   inline m match                                               // (2)
     case s: Mirror.SumOf[T]     => eqSum(s, elemInstances)
     case p: Mirror.ProductOf[T] => eqProduct(p, elemInstances)


### PR DESCRIPTION
I don't know why, but I seem to get a stack overflow error at compile time if I don't use lazy val.
In the code at the bottom of the page, it is lazy val.

If the elems argument of eqSum() is not a call-by-name, it seems to stack overflow.

tested with scala 3.0.1