### PR TITLE
Fix a typo in FP Modeling

### DIFF
--- a/_overviews/scala3-book/domain-modeling-fp.md
+++ b/_overviews/scala3-book/domain-modeling-fp.md
@@ -160,7 +160,7 @@ def toppingPrice(t: Topping): Double = t match
   case Cheese | Onions => 0.5
   case Pepperoni | BlackOlives | GreenOlives => 0.75
 ```
-Similarly, since `toppingPrice` is an enumeration, we use pattern matching to distinguish between the different variants.
+Similarly, since `Topping` is an enumeration, we use pattern matching to distinguish between the different variants.
 Cheese and onions are priced at 50ct while the rest is priced at 75ct each.
 ```scala
 def crustPrice(s: CrustSize, t: CrustType): Double =


### PR DESCRIPTION
This PR fixes a typo in the [*FP Modeling*](https://docs.scala-lang.org/scala3/book/domain-modeling-fp.html#modeling-the-operations) page. The current version doesn’t seem to make sense, since `toppingPrice` is a method and not an enumeration.

The sentence is reworded in a way that is coherent with the previous paragraph (*“since `Pizza` is a case class”*).