### PR TITLE
Fix a syntax error

### DIFF
--- a/_overviews/scala3-book/types-union.md
+++ b/_overviews/scala3-book/types-union.md
@@ -35,7 +35,7 @@ help("hi")   // error: Found: ("hi" : String)
 You’ll also get an error if you attempt to add a `case` to the `match` expression that doesn’t match the `Username` or `Password` types:
 
 ```scala
-case 1.0 = > ???   // ERROR: this line won’t compile
+case 1.0 => ???   // ERROR: this line won’t compile
 ```
 
 ### Alternative to Union Types


### PR DESCRIPTION
This PR removes an extraneous space character in the [*Union Types*](https://docs.scala-lang.org/scala3/book/types-union.html) page of the Scala 3 Book. Currently, the code doesn’t compile, but not for the reason mentioned in the paragraph above the code block.