### PR TITLE
Minor mistakes in ca-context-bounds.md

### DIFF
--- a/_overviews/scala3-book/ca-context-bounds.md
+++ b/_overviews/scala3-book/ca-context-bounds.md
@@ -22,14 +22,14 @@ In that case you don’t have to define a parameter name, and can just provide t
 For example, this `maximum` method takes a _context parameter_ of type `Ord`, only to pass it on as an argument to `max`:
 
 ```scala
-def maximum[T](xs: List[A])(using ord: Ord[A]): A =
+def maximum[A](xs: List[A])(using ord: Ord[A]): A =
   xs.reduceLeft(max(ord))
 ```
 
 In that code the parameter name `ord` isn’t actually required; it can be passed on as an inferred argument to `max`, so you just state that `maximum` uses the type `Ord[A]` without giving it a name:
 
 ```scala
-def maximum[T](xs: List[A])(using Ord[A]): A =
+def maximum[A](xs: List[A])(using Ord[A]): A =
   xs.reduceLeft(max)
 ```
 


### PR DESCRIPTION
First, let me preface this by saying that I'm very new to Scala.

I was reading about context bounds in the Scala 3 book and the code snippets here looked off to me. I'm pretty sure these `[T]` parameters were supposed to be `[A]`s. Also, I'm not sure if these examples are written hypothetically, but there is no `Ord` in the standard library AFAIK. This is `Ordering` which is kind of close. Also, I don't know what `max` is, there is an `Ordering.max` function which is another indicator that the original author probably meant `Ordering` and not `Ord`. A working alternative to

```scala
def maximum[T](xs: List[A])(using ord: Ord[A]): A =
  xs.reduceLeft(max(ord))
```

 would be:

```scala
def maximum[A](xs: List[A])(using ord: Ordering[A]): A =
  xs.reduceLeft(ord.max)
```

and an alternative to

```scala
def maximum[T](xs: List[A])(using Ord[A]): A =
  xs.reduceLeft(max)
```

would be

```scala
def maximum[A](xs: List[A])(using Ordering[A]): A =
  xs.reduceLeft(implicitly[Ordering[A]].max)
```

Edit: So, apparently `max` was defined in a previous section in the book. For context,

```scala
def max[T](x: T, y: T)(using ord: Ord[T]): T =
  if ord.compare(x, y) < 0 then y else x
```

So, `max` is alright, and only the  `Ord` -> `Ordering` change is necessary (along with the changes in the PR) for the example to be valid, unless I also missed the definition of `Ord` somewhere in the book.

```scala
def maximum[A](xs: List[A])(using ord: Ordering[A]): A =
  xs.reduceLeft(max(ord))
```

```scala
def maximum[A](xs: List[A])(using Ordering[A]): A =
  xs.reduceLeft(max)
```

Edit 2: This is embarrassing. `Ord` is also previously defined in another section. So everything checks out except the changes in the PR.