### PR TITLE
Fix deprecation warning in scala-for-java-programmers.md

### DIFF
--- a/_overviews/tutorials/scala-for-java-programmers.md
+++ b/_overviews/tutorials/scala-for-java-programmers.md
@@ -675,7 +675,7 @@ empty or point to an object of some type.
 
     class Reference[T] {
       private var contents: T = _
-      def set(value: T) { contents = value }
+      def set(value: T): Unit = { contents = value }
       def get: T = contents
     }
 


### PR DESCRIPTION
Today I was learning Scala with the text and found `scalac` reported deprecation warning:

```
generics.scala:3: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `set`'s return type
  def set(value: T) { contents = value }
                    ^
1 warning
```

This PR fixes the warning.