### PR TITLE
Update matchable.md

### DIFF
--- a/_scala3-reference/other-new-features/matchable.md
+++ b/_scala3-reference/other-new-features/matchable.md
@@ -122,10 +122,10 @@ For instance, consider the definitions
 
 ```scala
 opaque type Meter = Double
-def Meter(x: Double) = x
+def Meter(x: Double): Meter = x
 
 opaque type Second = Double
-def Second(x: Double) = x
+def Second(x: Double): Second = x
 ```
 
 Here, universal `equals` will return true for
@@ -137,6 +137,7 @@ Here, universal `equals` will return true for
 even though this is clearly false mathematically. With [multiversal equality](../contextual/multiversal-equality.html) one can mitigate that problem somewhat by turning
 
 ```scala
+  import scala.language.strictEquality
   Meter(10) == Second(10)
 ```
 


### PR DESCRIPTION
The type has to of the method has to be specified or else the return types will just be a Double in both cases and the tests will pass. 
Strict Equality has to be set for the compiler to fail.