### PR TITLE
Tutorials as a new category on the overviews page

### DIFF
--- a/_data/doc-nav-header.yml
+++ b/_data/doc-nav-header.yml
@@ -5,21 +5,6 @@
       url: https://www.scala-lang.org/api/current/
     - title: All Versions
       url: "/api/all.html"
-- title: Learn
-  url: "#"
-  submenu:
-    - title: Getting Started
-      url: "/getting-started/index.html"
-    - title: Tour of Scala
-      url: "/tour/tour-of-scala.html"
-    - title: Scala Book
-      url: "/overviews/scala-book/introduction.html"
-    - title: Scala for Java Programmers
-      url: "/tutorials/scala-for-java-programmers.html"
-    - title: Scala on Android
-      url: "/tutorials/scala-on-android.html"
-    - title: Online Resources
-      url: "/learn.html"
 - title: Reference
   url: "#"
   submenu:

--- a/_data/overviews.yml
+++ b/_data/overviews.yml
@@ -78,6 +78,48 @@
       icon: diamond
       url: "core/value-classes.html"
 
+- category: Tutorials
+  description: "Guides and overviews covering various topics, from basics of the Scala language to usage in non-standard projects."
+  overviews:
+    - title: Getting Started
+      by:  Meriam Lachkar
+      icon: space-shuttle
+      url: "../getting-started/index.html"
+    - title: Tour of Scala
+      by: Heather Miller
+      description: "This tour contains bite-sized introductions to the most frequently used features of Scala. It is intended for newcomers to the language."
+      icon: taxi
+      url: "../tour/tour-of-scala.html"
+    - title: Scala Book
+      by: Alvin Alexander and Meriam Lachkar
+      description: "Scala Book provides a quick introduction and overview of the Scala programming language. The book is written in an informal style, and consists of more than 50 small lessons. Each lesson is long enough to give you an idea of how the language features in that lesson work, but short enough that you can read it in fifteen minutes or less."
+      icon: book
+      url: "scala-book/introduction.html"
+    - title: Scala for Java Programmers
+      by: Michel Schinz and Philipp Haller
+      description: "A quick intro to the Scala language and compiler intended for people who already have some programming experience and want an overview of what they can do with Scala. A basic knowledge of object-oriented programming, especially in Java, is assumed."
+      icon: coffee
+      url: "tutorials/scala-for-java-programmers.html"
+    - title: Scala on Android
+      by: Maciej Gorywoda
+      description: "A tutorial on how to write a modern Android app with Scala that uses GraalVM Native Image and JavaFX."
+      icon: rebel
+      url: "tutorials/scala-on-android.html"
+    - title: Binary Compatibility for Library Authors
+      by: Jacob Wang
+      description: "This guide covers the topic of binary compatibility: how binary incompatibility can cause production failures in your applications, how to avoid breaking binary compatibility, how to reason about and communicate the impact of their code changes."
+      icon: diamond
+      url: "core/binary-compatibility-for-library-authors.html"
+    - title: Scala with Maven
+      by: Adrian Null
+      description: "Maven is a build/project management tool. It favours \"convention over configuration\"; it can greatly simplify builds for \"standard\" projects and a Maven user can usually understand the structure of another Maven project just by looking at its `pom.xml` (Project Object Model)."
+      icon: rebel
+      url: "tutorials/scala-with-maven.html"
+    - title: Online Resources
+      by: Julien Richard-Foy
+      icon: paper-plane
+      url: "../learn.html"
+
 - category: Authoring Libraries
   description: "Guides for contributing open source libraries to the Scala ecosystem."
   overviews:

--- a/_overviews/tutorials/scala-for-java-programmers.md
+++ b/_overviews/tutorials/scala-for-java-programmers.md
@@ -5,7 +5,7 @@ title: A Scala Tutorial for Java Programmers
 partof: scala-for-java-programmers
 
 languages: [es, ko, de, it, ja, zh-tw]
-permalink: /tutorials/:title.html
+permalink: /overviews/tutorials/:title.html
 ---
 
 By Michel Schinz and Philipp Haller

--- a/_overviews/tutorials/scala-on-android.md
+++ b/_overviews/tutorials/scala-on-android.md
@@ -4,7 +4,7 @@ title: A Tutorial on writing Scala apps on Android
 
 partof: scala-on-android
 
-permalink: /tutorials/:title.html
+permalink: /overviews/tutorials/:title.html
 ---
 
 By Maciej Gorywoda

--- a/_overviews/tutorials/scala-with-maven.md
+++ b/_overviews/tutorials/scala-with-maven.md
@@ -1,7 +1,7 @@
 ---
 layout: singlepage-overview
 title: Scala with Maven
-permalink: /tutorials/:title.html
+permalink: /overviews/tutorials/:title.html
 ---
 
 By Adrian Null


### PR DESCRIPTION
Currently some of the learning materials are accessed through the "overviews" page while others are under the "Learn" meanu in the header. The header is not intuitive. It's not visible on the main page, so the user needs to click on the overviews to be able to access the materials under the header, which defeats the purpose of having them there if there ever was one. (I suspect the current situation is a side-effect of some other changes, not a conscious decision). On top of that, "Scala with Maven" and "Binary Compatibility for Library Authors" are nowhere to be found.

My proposal is to remove the "Learn" menu from the header and instead to have a new category in the "overviews" page, called "Tutorials", directly under "Language", so it's pretty high on the webpage and easy to find. I discussed it on the Scala discord and I got an impression that even though it's not a perfect solution, it's at least a step in the right direction.

I moved all the links from the "Learn" menu to that new category and added short descriptions and authors' names in places where I was pretty sure what to do. Please review also from this angle: maybe there should more names under the author's tag or it's better to remove them completely, and maybe someone could update the descriptions.