### PR TITLE
Fixed code example for derivation with shapeless 3

### DIFF
--- a/_scala3-reference/contextual/derivation.md
+++ b/_scala3-reference/contextual/derivation.md
@@ -332,7 +332,7 @@ given eqProduct[A](using inst: K0.ProductInstances[Eq, A]): Eq[A] with
   )
 
 inline def derived[A](using gen: K0.Generic[A]): Eq[A] =
-  gen.derive(eqSum, eqProduct)
+  gen.derive(eqProduct, eqSum)
 ```
 
 The framework described here enables all three of these approaches without mandating any of them.


### PR DESCRIPTION
While running code examples form the derivation page, I noticed that the extension method `derive` in shapeless 3 has a different order of arguments. Here's it's current signature (version `3.0.2`):
```scala
extension [F[_], T](gen: Generic[T])
  inline def derive(f: => (ProductGeneric[T] & gen.type) ?=> F[T], g: => (CoproductGeneric[T] & gen.type) ?=> F[T]): F[T] =
    inline gen match {
      case p: ProductGeneric[T]   => f(using p.asInstanceOf)
      case c: CoproductGeneric[T] => g(using c.asInstanceOf)
    }
```