### PR TITLE
Update generics: use `xs.prepended(x)` instead of `x :: xs`

### DIFF
--- a/_overviews/scala3-book/types-generics.md
+++ b/_overviews/scala3-book/types-generics.md
@@ -20,7 +20,7 @@ class Stack[A]:
   //                         ^
   //  Here we refer to the type parameter
   //          v
-  def push(x: A): Unit = { elements = x :: elements }
+  def push(x: A): Unit = { elements = elements.prepended(x) }
   def peek: A = elements.head
   def pop(): A =
     val currentTop = peek


### PR DESCRIPTION
Addresses a simple issue https://github.com/scala/docs.scala-lang/issues/1984

Using a more [human readable method name](https://scala-lang.org/api/3.x/scala/collection/immutable/List.html#prepended-c0e), instead of a [prefix notation cons operator](https://scala-lang.org/api/3.x/scala/collection/immutable/::.html) which might be confusing to newcomers


