### PR TITLE
Fix typo in syntax.md

### DIFF
--- a/_scala3-reference/syntax.md
+++ b/_scala3-reference/syntax.md
@@ -116,7 +116,7 @@ given     if        implicit  import    lazy      match     new
 null      object    override  package   private   protected return
 sealed    super     then      throw     trait     true      try
 type      val       var       while     with      yield
-:         =         <-        =>        <:        :>        #
+:         =         <-        =>        <:        >:        #
 @         =>>       ?=>
 ```
 


### PR DESCRIPTION
The lower type bound symbol was ':>' instead of '>:'