### PR TITLE
显示 -> 显式

### DIFF
--- a/_zh-cn/tour/basics.md
+++ b/_zh-cn/tour/basics.md
@@ -58,7 +58,7 @@ println(x) // 2
 x = 3 // This does not compile.
 ```
 
-常量（`values`）的类型可以被推断，或者你也可以显示地声明类型，例如：
+常量（`values`）的类型可以被推断，或者你也可以显式地声明类型，例如：
 
 ```scala mdoc:nest
 val x: Int = 1 + 1
@@ -76,7 +76,7 @@ x = 3 // This compiles because "x" is declared with the "var" keyword.
 println(x * x) // 9
 ```
 
-和常量一样，你可以显示地声明类型：
+和常量一样，你可以显式地声明类型：
 
 ```scala mdoc:nest
 var x: Int = 1 + 1


### PR DESCRIPTION
Hello, I am a chinese. We usually use “显式”(or "显式地") instead of “显示” when we want to express the word "explicitly".
“显示” in chinese means something like "display" or "show"
 I also tried with google translate (https://translate.google.cn/?sl=en&tl=zh-CN&text=explicitly&op=translate)
 
![image](https://user-images.githubusercontent.com/3983683/134111653-b5beeb3d-f7b8-46b0-bf92-c7180414d8f7.png)


The modification is shown as follows
![image](https://user-images.githubusercontent.com/3983683/134176397-4b9c3938-5ea7-4954-8ac1-d84a89963b18.png)
