### PR TITLE
docs: reword pattern matching comment

### DIFF
--- a/_tour/pattern-matching.md
+++ b/_tour/pattern-matching.md
@@ -36,8 +36,8 @@ def matchTest(x: Int): String = x match {
   case 2 => "two"
   case _ => "other"
 }
-matchTest(3)  // prints other
-matchTest(1)  // prints one
+matchTest(3)  // returns other
+matchTest(1)  // returns one
 ```
 This match expression has a type String because all of the cases return String. Therefore, the function `matchTest` returns a String.
 


### PR DESCRIPTION
Hey, I feel that `returns` fit better here since the method does not print the message.

Or if you want to have `prints` I have another pr. :)
https://github.com/scala/docs.scala-lang/pull/2189