### PR TITLE
Fix function reference in "types-variance" chapter

### DIFF
--- a/_overviews/scala3-book/types-variance.md
+++ b/_overviews/scala3-book/types-variance.md
@@ -136,7 +136,7 @@ val f: Function[Buyable, Buyable] = b => b
 val g: Function[Buyable, Item] = f
 
 // OK to provide a Book where a Buyable is expected
-val h: Function[Book, Buyable] = g
+val h: Function[Book, Buyable] = f
 ```
 
 ## Summary


### PR DESCRIPTION
The last paragraph of the "types-variance" chapter explains how type variance applies to Scala functions. 

In the last of the 3 examples that "illustrate the subtyping relationships induced by variance annotations on functions", there is a typo:
`val h: Function[Book, Buyable] = g`

`g` cannot be assigned to `h`, as `B` is not (and cannot) be contravariant. 

I believe the intention was to assign `g` to `f`, to illustrate the contravariance of `A`.

Alternatively, the type of `h` can be modified to `Function[Book, Item]` to allow the assignment.