### PR TITLE
Fix links in scala3 contribution guide which incorrectly referred to html fragments

### DIFF
--- a/_overviews/scala3-contribution/arch-lifecycle.md
+++ b/_overviews/scala3-contribution/arch-lifecycle.md
@@ -78,7 +78,7 @@ tools // contains helpers and the `scala` generic runner
 └── scripting // scala runner for the -script argument
 ```
 
-[1]: {% link _overviews/scala3-contribution/contribution-intro.md %}/#what-is-a-compiler
+[1]: {% link _overviews/scala3-contribution/contribution-intro.md %}#what-is-a-compiler
 [2]: https://github.com/lampepfl/dotty/blob/master/compiler/src/dotty/tools/dotc/Run.scala
 [3]: https://github.com/lampepfl/dotty/blob/master/compiler/src/dotty/tools/dotc/core/Phases.scala
 [4]: https://github.com/lampepfl/dotty/blob/master/compiler/src/dotty/tools/dotc/Compiler.scala

--- a/_overviews/scala3-contribution/arch-phases.md
+++ b/_overviews/scala3-contribution/arch-phases.md
@@ -86,7 +86,7 @@ suitable for the runtime system, with two sub-groupings:
 ### `backendPhases`
 These map the transformed trees to Java classfiles or SJSIR files.
 
-[1]: {% link _overviews/scala3-contribution/arch-lifecycle.md %}/#phases
+[1]: {% link _overviews/scala3-contribution/arch-lifecycle.md %}#phases
 [2]: https://github.com/lampepfl/dotty/blob/master/compiler/src/dotty/tools/dotc/CompilationUnit.scala
 [Compiler]: https://github.com/lampepfl/dotty/blob/master/compiler/src/dotty/tools/dotc/Compiler.scala
 [Phase]: https://github.com/lampepfl/dotty/blob/master/compiler/src/dotty/tools/dotc/core/Phases.scala

--- a/_overviews/scala3-contribution/arch-types.md
+++ b/_overviews/scala3-contribution/arch-types.md
@@ -149,4 +149,4 @@ Type -+- proxy_type --+- NamedType --------+- TypeRef
 
 [Types.scala]: https://github.com/lampepfl/dotty/blob/master/compiler/src/dotty/tools/dotc/core/Types.scala
 [2]: https://github.com/lampepfl/dotty/blob/master/compiler/test/dotty/tools/DottyTypeStealer.scala
-[3]: {% link _overviews/scala3-contribution/procedures-inspection.md %}/#inspecting-representation-of-types
+[3]: {% link _overviews/scala3-contribution/procedures-inspection.md %}#inspecting-representation-of-types

--- a/_overviews/scala3-contribution/procedures-inspection.md
+++ b/_overviews/scala3-contribution/procedures-inspection.md
@@ -180,7 +180,7 @@ class StealBox:
 
 [1]: https://github.com/lampepfl/dotty/blob/master/compiler/test/dotty/tools/DottyTypeStealer.scala
 [2]: {% link _overviews/scala3-contribution/arch-types.md %}
-[3]: {% link _overviews/scala3-contribution/arch-lifecycle.md %}/#phases
+[3]: {% link _overviews/scala3-contribution/arch-lifecycle.md %}#phases
 [ScalaSettings.scala]: https://github.com/lampepfl/dotty/blob/master/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
 [symbols]: https://github.com/lampepfl/dotty/blob/master/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
-[reproduce]: {% link _overviews/scala3-contribution/procedures-reproduce.md %}/#dotty-issue-workspace
+[reproduce]: {% link _overviews/scala3-contribution/procedures-reproduce.md %}#dotty-issue-workspace


### PR DESCRIPTION
Hi, I found that some links in the scala3-contribution guide are broken because they incorrectly include `/` character before `#` when referring to html fragments.

This PR fixes those links.