### PR TITLE
restore stickyness for scala 3 docs

### DIFF
--- a/_sass/layout/toc.scss
+++ b/_sass/layout/toc.scss
@@ -6,6 +6,8 @@
   position: -webkit-sticky;
   position: sticky;
   top: 0;
+  max-height: 85vh;
+  overflow-y: auto;
 
   @include bp(large) {
     position: relative;
@@ -81,11 +83,6 @@
       }
     }
   }
-}
-
-// disable floating for the book, since the TOC can become very large
-.scala3 .sidebar-toc-wrapper {
-  position: relative;
 }
 
 .book #toc {


### PR DESCRIPTION
I was annoyed that the sidebar did not stick to the top of the page in the Scala 3 docs, this also fixes the height and allows scrolling of the sidebar independently of the main body.

- look at scala 3 book, scala 2 book, and perhaps the style guide