### PR TITLE
To fix syntax rules

### DIFF
--- a/_scala3-reference/new-types/type-lambdas-spec.md
+++ b/_scala3-reference/new-types/type-lambdas-spec.md
@@ -114,6 +114,3 @@ The body of a type lambda can again be a type lambda. Example:
 type TL = [X] =>> [Y] =>> (X, Y)
 ```
 Currently, no special provision is made to infer type arguments to such curried type lambdas. This is left for future work.
-
-
-


### PR DESCRIPTION
The syntax in this page does not conform to the syntax in https://docs.scala-lang.org/scala3/reference/syntax.html:
Type            ::=  ... |  TypeParamClause ‘=>>’ Type
TypeParamClause ::=  ‘[’ TypeParam {‘,’ TypeParam} ‘]’
TypeParam       ::=  {Annotation} (id [HkTypeParamClause] | ‘_’) TypeBounds
TypeBounds      ::=  [‘>:’ Type] [‘<:’ Type]