### PR TITLE
Fix problem that language dropdown lost when change to ja language.

### DIFF
--- a/_ja/index.md
+++ b/_ja/index.md
@@ -2,6 +2,7 @@
 layout: documentation
 title: ドキュメント
 language: ja
+partof: documentation
 more-resources-label: その他のリソース
 
 


### PR DESCRIPTION
Fix problem:
On the home page of docs, change language to `日本語`, and on the new page, language dropdown would disappear.