### PR TITLE
Updated example for filtering keys from Map

### DIFF
--- a/_overviews/scala-book/collections-maps.md
+++ b/_overviews/scala-book/collections-maps.md
@@ -55,7 +55,7 @@ scala> val ucMap = m.transform((k,v) => v.toUpperCase)
 ucMap: scala.collection.immutable.Map[Int,String] = Map(1 -> A, 2 -> B, 3 -> C, 4 -> D)
 
 // how to filter a Map by its keys
-scala> val twoAndThree = m.view.filterKeys(Set(2,3)).toMap
+scala> val twoAndThree = m.filterKeys(Set(2,3))
 twoAndThree: scala.collection.immutable.Map[Int,String] = Map(2 -> b, 3 -> c)
 
 // how to take the first two elements from a Map


### PR DESCRIPTION
This is regarding below example:
"val twoAndThree = m.view.filterKeys(Set(2,3)).toMap"

`filterKeys` is not a member of `scala.collection.IterableView`, so the example mentioned gives compile time error. Therefore, I updated the example to not use "view" and "toMap".