### PR TITLE
Improve consistency

### DIFF
--- a/_overviews/contributors/index.md
+++ b/_overviews/contributors/index.md
@@ -266,8 +266,7 @@ In my case, I have one key pair, whose ID is `BE614499`.
 Then:
 
  1. Create a new Secret containing the passphrase of your PGP key named `PGP_PASSPHRASE`.
- 2. Create a new Secret containing the base64 encoded secret of your private key, which you can obtain
- by running:
+ 2. Create a new Secret containing the base64 encoded secret of your private key named `PGP_SECRET`. The encoded secret can obtain by running:
 ```
 # macOS
 gpg --armor --export-secret-keys $LONG_ID | base64


### PR DESCRIPTION
The name of the new Secret could be only inferred from the the contents of the file `.github/workflows/publish.yml`, which is also located below the edited section. Stating the name of the new Secret is more consistent to the expectation of the reader.