### PR TITLE
Fix invalid link links to the type classes paper

### DIFF
--- a/_overviews/quasiquotes/lifting.md
+++ b/_overviews/quasiquotes/lifting.md
@@ -24,7 +24,7 @@ This code runs successfully because `Int` is considered to be `Liftable` by defa
       def apply(value: T): Tree
     }
 
-Whenever there is an implicit value of `Liftable[T]` available, one can unquote `T` in quasiquotes. This design pattern is known as a *type class*. You can read more about it in ["Type Classes as Objects and Implicits"](https://ropas.snu.ac.kr/~bruno/papers/TypeClasses.pdf).
+Whenever there is an implicit value of `Liftable[T]` available, one can unquote `T` in quasiquotes. This design pattern is known as a *type class*. You can read more about it in ["Type Classes as Objects and Implicits"](https://infoscience.epfl.ch/record/150280/files/TypeClasses.pdf).
 
 A number of data types that are supported natively by quasiquotes will never trigger the usage of a `Liftable` representation, even if it\'s available: subtypes of `Tree`, `Symbol`, `Name`, `Modifiers` and `FlagSet`.
 

--- a/_overviews/scala3-book/types-type-classes.md
+++ b/_overviews/scala3-book/types-type-classes.md
@@ -47,6 +47,6 @@ toHtml(42)(ShowInt())
 Since type classes are a very important way to structure software, Scala 3 offers additional features that make working with them very convenient.
 We discuss these additional features (which fall into the category of *Contextual Abstractions*) in a [later chapter][typeclasses-chapter] of this book.
 
-[typeclasses-paper]: https://ropas.snu.ac.kr/~bruno/papers/TypeClasses.pdf
+[typeclasses-paper]: https://infoscience.epfl.ch/record/150280/files/TypeClasses.pdf
 [typeclasses-chapter]: {% link _overviews/scala3-book/ca-type-classes.md %}
 [comparator]: https://docs.oracle.com/javase/8/docs/api/java/util/Comparator.html


### PR DESCRIPTION
Close #2213.
Fix invalid link links to the paper "Type Classes as Objects and Implicits".