### PR TITLE
Make inspect argument call by name

### DIFF
--- a/_overviews/scala3-macros/tutorial/macros.md
+++ b/_overviews/scala3-macros/tutorial/macros.md
@@ -30,7 +30,7 @@ After printing the argument expression, we return the original argument as a Sca
 As foreshadowed in the section on [Inline][inline], inline methods provide the entry point for macro definitions:
 
 ```scala
-inline def inspect(inline x: Any): Any = ${ inspectCode('x) }
+inline def inspect(inline x: => Any): Any = ${ inspectCode('x) }
 ```
 All macros are defined with an `inline def`.
 The implementation of this entry point always has the same shape:


### PR DESCRIPTION
`def inspect(inline x: Any): Any` doesn't trigger behaviour as described a few lines bellow ( "Calling our `inspect` macro `inspect(sys error "abort")` prints a string representation of the argument expression at compile time").
To behave like described, I needed to make the argument by name `inline def inspect(inline x: => Any): Any = ${ inspectCode('x) }`