### PR TITLE
Move “Online Courses” documentation to a dedicated page

### DIFF
--- a/_data/doc-nav-header.yml
+++ b/_data/doc-nav-header.yml
@@ -7,6 +7,8 @@
       url: "/tour/tour-of-scala.html"
     - title: Scala Book
       url: "/overviews/scala-book/introduction.html"
+    - title: Online Courses
+      url: "/online-courses.html"
     - title: Online Resources
       url: "/learn.html"
 - title: Tutorials

--- a/_data/scala3-doc-nav-header.yml
+++ b/_data/scala3-doc-nav-header.yml
@@ -7,6 +7,8 @@
       url: "/scala3/new-in-scala3.html"
     - title: Scala 3 Book
       url: "/scala3/book/introduction.html"
+    - title: Online Courses
+      url: "/online-courses.html"
 - title: Migrate
   url: "/scala3/guides/migration/compatibility-intro.html"
 - title: Reference

--- a/index.md
+++ b/index.md
@@ -52,6 +52,10 @@ scala3-sections:
         description: "Talks about Scala 3 that can be watched online"
         icon: "fa fa-play-circle"
         link: /scala3/talks.html
+      - title: "Online Courses"
+        description: "Online Courses on Scala 3"
+        icon: "fa fa-cloud"
+        link: /online-courses.html
 
 scala2-sections:
   - title: "First Steps..."

--- a/index.md
+++ b/index.md
@@ -53,7 +53,7 @@ scala3-sections:
         icon: "fa fa-play-circle"
         link: /scala3/talks.html
       - title: "Online Courses"
-        description: "Online Courses on Scala 3"
+        description: "MOOCs to learn Scala, for beginners and experienced programmers."
         icon: "fa fa-cloud"
         link: /online-courses.html
 
@@ -72,10 +72,10 @@ scala2-sections:
         description: "Learn Scala by reading a series of short lessons."
         icon: "fa fa-book-open"
         link: /overviews/scala-book/introduction.html
-      - title: Online Resources
-        description: "Online Courses, Exercises, & Blogs."
+      - title: Online Courses
+        description: "MOOCs to learn Scala, for beginners and experienced programmers."
         icon: "fa fa-cloud"
-        link: /learn.html
+        link: /online-courses.html
       - title: Books
         description: "Printed and digital books about Scala."
         icon: "fa fa-book"

--- a/learn.md
+++ b/learn.md
@@ -1,6 +1,6 @@
 ---
 title: Online Resources
-layout: inner-page-no-masthead
+layout: singlepage-overview
 redirect_from:
   - /documentation/books.html
 ---
@@ -11,90 +11,10 @@ There are a handful of websites where you can interactively run Scala code in yo
 
 ## Online courses from the Scala Center
 
-The following online courses provide two main paths to learn Scala. The
-fast path consists of taking the course [Effective Programming in Scala],
-otherwise you can take the full [Scala Specialization], which is made of
-four courses and a capstone project.
-
-All the courses are available for free. Optionally, a subscription gives
-you access to a certificate of completion that attests your accomplishments.
-Learn more about
-[Coursera certificates](https://learners.coursera.help/hc/en-us/articles/209819053-Get-a-Course-Certificate) or
-[edX certificates](https://support.edx.org/hc/en-us/categories/115002269627-Certificates).
-
-### Effective Programming in Scala
-
-[Effective Programming in Scala] teaches non-Scala programmers everything
-they need to be ready to work in Scala. At the end of this hands-on course,
-you will know how to achieve common programming tasks in Scala (e.g.,
-modeling business domains, implementing business logic, designing large
-systems made of components, handling errors, manipulating data, running 
-concurrent tasks in parallel, testing your code). You can learn more about
-this course in the following video:
-
-<div style="text-align: center">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/MSDJ7ehjrqo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
-
-This course is also a good way to upgrade your Scala 2 knowledge to Scala 3.
-
-After taking this course, you might be interested in improving your
-skills in specific areas by taking the courses [Parallel Programming],
-[Big Data Analysis with Scala and Spark], or [Programming Reactive Systems].
-
-### Scala Specialization
-
-The [Scala Specialization] provides a hands-on introduction to functional programming using Scala. You can access the courses
-material and exercises by either signing up for the specialization or auditing the courses individually. The
-   specialization has the following courses.
-* [Functional Programming Principles in Scala],
-* [Functional Program Design in Scala],
-* [Parallel programming],
-* [Big Data Analysis with Scala and Spark],
-* [Functional Programming in Scala Capstone].
-
-These courses provide a deep understanding of the Scala language itself,
-and they also dive into more specific topics such as parallel programming,
-and Spark.
-
-### Programming Reactive Systems
-
-[Programming Reactive Systems] (also available on [edX](https://www.edx.org/course/scala-akka-reactive))
-teaches how to write responsive, scalable, and resilient systems with the
-library Akka.
-
-### Scala Learning Path
-
-The diagram below summarizes the possible learning paths with our courses:
-
-![](/resources/images/learning-path.png)
-
-The “foundational” courses target programmers with no prior experience in Scala, whereas the “deepening”
-courses aim at strengthening Scala programmers skills in a specific domain (such as parallel programming).
-
-We recommend starting with either Effective Programming in Scala, or Functional Programming Principles in
-Scala followed by Functional Program Design. Then, you can complement your Scala skills by taking any
-of the courses Programming Reactive Systems, Parallel Programming, or Big Data Analysis with Scala and Spark.
-In case you take the Scala Specialization, you will end with the Scala Capstone Project.
-
-### Scala 2 Courses
-
-The above courses use Scala 3 (except the Spark courses). If needed, you can find
-the (legacy) Scala 2 version of our courses here:
-
-- [Functional Programming Principles in Scala (Scala 2 version)](https://www.coursera.org/learn/scala2-functional-programming)
-- [Functional Program Design (Scala 2 version)](https://www.coursera.org/learn/scala2-functional-program-design)
-- [Parallel Programming (Scala 2 version)](https://www.coursera.org/learn/scala2-parallel-programming)
-- [Programming Reactive Systems (Scala 2 version)](https://www.coursera.org/learn/scala2-akka-reactive)
-
-[Scala Specialization]: https://www.coursera.org/specializations/scala
-[Effective Programming in Scala]: https://www.coursera.org/learn/effective-scala
-[Functional Programming Principles in Scala]: https://www.coursera.org/learn/scala-functional-programming
-[Functional Program Design in Scala]: https://www.coursera.org/learn/scala-functional-program-design
-[Parallel programming]: https://www.coursera.org/learn/scala-parallel-programming
-[Big Data Analysis with Scala and Spark]: https://www.coursera.org/learn/scala-spark-big-data
-[Functional Programming in Scala Capstone]: https://www.coursera.org/learn/scala-capstone
-[Programming Reactive Systems]: https://www.coursera.org/learn/scala-akka-reactive
+The [Scala Center](https://scala.epfl.ch) is committed to creating high-quality 
+and freely available online courses for learning Scala and functional 
+programming. The course levels range from beginner to advanced.
+More details on [this page]({% link online-courses.md %}).
 
 ## Scala Exercises
 

--- a/online-courses.md
+++ b/online-courses.md
@@ -89,6 +89,11 @@ the (legacy) Scala 2 version of our courses here:
 - [Parallel Programming (Scala 2 version)](https://www.coursera.org/learn/scala2-parallel-programming)
 - [Programming Reactive Systems (Scala 2 version)](https://www.coursera.org/learn/scala2-akka-reactive)
 
+## Other Online Resources
+
+You can find other online resources contributed by the community on
+[this page]({% link learn.md %}).
+
 [Scala Center]: https://scala.epfl.ch
 [Scala Specialization]: https://www.coursera.org/specializations/scala
 [Effective Programming in Scala]: https://www.coursera.org/learn/effective-scala

--- a/online-courses.md
+++ b/online-courses.md
@@ -1,0 +1,101 @@
+---
+title: Online Courses from The Scala Center
+layout: singlepage-overview
+scala3: true
+---
+
+The online courses from the [Scala Center] provide two main paths to learn 
+Scala. The fast path consists of taking the course [Effective Programming 
+in Scala],
+otherwise you can take the full [Scala Specialization], which is made of
+four courses and a capstone project.
+
+All the courses are available for free. Optionally, a subscription gives
+you access to a certificate of completion that attests your accomplishments.
+Learn more about
+[Coursera certificates](https://learners.coursera.help/hc/en-us/articles/209819053-Get-a-Course-Certificate) or
+[edX certificates](https://support.edx.org/hc/en-us/categories/115002269627-Certificates).
+Your subscriptions also supports the work of the [Scala Center], whose mission
+is to create high-quality educational material.
+
+You can learn more about the Scala Center online courses in the following video:
+
+<div style="text-align: center">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/rRCdnTspE_k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+## Scala Learning Path
+
+The diagram below summarizes the possible learning paths with our courses:
+
+![](/resources/images/learning-path.png)
+
+The “foundational” courses target programmers with no prior experience in Scala, whereas the “deepening”
+courses aim at strengthening Scala programmers skills in a specific domain (such as parallel programming).
+
+We recommend starting with either Effective Programming in Scala, or Functional Programming Principles in
+Scala followed by Functional Program Design. Then, you can complement your Scala skills by taking any
+of the courses Programming Reactive Systems, Parallel Programming, or Big Data Analysis with Scala and Spark.
+In case you take the Scala Specialization, you will end with the Scala Capstone Project.
+
+## Effective Programming in Scala
+
+[Effective Programming in Scala] teaches non-Scala programmers everything
+they need to be ready to work in Scala. At the end of this hands-on course,
+you will know how to achieve common programming tasks in Scala (e.g.,
+modeling business domains, implementing business logic, designing large
+systems made of components, handling errors, manipulating data, running
+concurrent tasks in parallel, testing your code). You can learn more about
+this course in the following video:
+
+<div style="text-align: center">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/MSDJ7ehjrqo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+This course is also a good way to upgrade your Scala 2 knowledge to Scala 3.
+
+After taking this course, you might be interested in improving your
+skills in specific areas by taking the courses [Parallel Programming],
+[Big Data Analysis with Scala and Spark], or [Programming Reactive Systems].
+
+## Scala Specialization
+
+The [Scala Specialization] provides a hands-on introduction to functional programming using Scala. You can access the courses
+material and exercises by either signing up for the specialization or auditing the courses individually. The
+specialization has the following courses.
+* [Functional Programming Principles in Scala],
+* [Functional Program Design in Scala],
+* [Parallel programming],
+* [Big Data Analysis with Scala and Spark],
+* [Functional Programming in Scala Capstone].
+
+These courses provide a deep understanding of the Scala language itself,
+and they also dive into more specific topics such as parallel programming,
+and Spark.
+
+## Programming Reactive Systems
+
+[Programming Reactive Systems] (also available on [edX](https://www.edx.org/course/scala-akka-reactive))
+teaches how to write responsive, scalable, and resilient systems with the
+library Akka.
+
+## Scala 2 Courses
+
+The above courses use Scala 3 (except the Spark courses). If needed, you can find
+the (legacy) Scala 2 version of our courses here:
+
+- [Functional Programming Principles in Scala (Scala 2 version)](https://www.coursera.org/learn/scala2-functional-programming)
+- [Functional Program Design (Scala 2 version)](https://www.coursera.org/learn/scala2-functional-program-design)
+- [Parallel Programming (Scala 2 version)](https://www.coursera.org/learn/scala2-parallel-programming)
+- [Programming Reactive Systems (Scala 2 version)](https://www.coursera.org/learn/scala2-akka-reactive)
+
+[Scala Center]: https://scala.epfl.ch
+[Scala Specialization]: https://www.coursera.org/specializations/scala
+[Effective Programming in Scala]: https://www.coursera.org/learn/effective-scala
+[Functional Programming Principles in Scala]: https://www.coursera.org/learn/scala-functional-programming
+[Functional Program Design in Scala]: https://www.coursera.org/learn/scala-functional-program-design
+[Parallel programming]: https://www.coursera.org/learn/scala-parallel-programming
+[Big Data Analysis with Scala and Spark]: https://www.coursera.org/learn/scala-spark-big-data
+[Functional Programming in Scala Capstone]: https://www.coursera.org/learn/scala-capstone
+[Programming Reactive Systems]: https://www.coursera.org/learn/scala-akka-reactive
+

--- a/scala3/index.md
+++ b/scala3/index.md
@@ -52,5 +52,8 @@ sections:
         description: "Talks about Scala 3 that can be watched online"
         icon: "fa fa-play-circle"
         link: /scala3/talks.html
-
+      - title: "Online Courses"
+        description: "Online Courses on Scala 3"
+        icon: "fa fa-cloud"
+        link: /online-courses.html
 ---


### PR DESCRIPTION
The documentation about the Scala Center’s MOOCs was mixed with other online resources, in https://docs.scala-lang.org/learn.html:

![Screenshot 2022-01-05 at 16-42-42 Online Resources](https://user-images.githubusercontent.com/332812/148246219-5d7b828e-039e-4fb5-8f42-878976a4d136.png)

We moved it to a new page at https://docs.scala-lang.org/online-courses.html:

![Screenshot 2022-01-05 at 16-32-53 Online Courses from The Scala Center](https://user-images.githubusercontent.com/332812/148246337-acc39737-e468-4267-940d-9870c34d298e.png)

Note that the new page uses the Scala 3 colors since the courses mainly use Scala 3.

The page /learn.html now contains a link to /online-courses.html:
![Screenshot 2022-01-05 at 16-31-51 Online Resources](https://user-images.githubusercontent.com/332812/148246697-14ae6179-2902-4337-b7a1-2e07fad0bfd5.png)

(also note that the layout of the page is different and now shows the table of contents on the right)

We have also added entries to the navigation menus:

![Screenshot from 2022-01-05 16-31-01](https://user-images.githubusercontent.com/332812/148246876-79bb4c10-a3df-48e6-b895-3c2363bdc6ae.png)
![Screenshot from 2022-01-05 16-31-27](https://user-images.githubusercontent.com/332812/148246877-10685620-2c6c-44f5-b728-bfc2d8009679.png)

In the /online-courses.html page, we have moved the section “Learning Paths” up to the beginning, and we have included a general video about Scala Center MOOCs (the video is not available yet) :

![Screenshot 2022-01-05 at 16-32-53 Online Courses from The Scala Center](https://user-images.githubusercontent.com/332812/148247151-51f44f9d-7c81-44b2-812d-2efab4088027.png)

---

This PR requires one more action from visitors to see the Scala Center courses. Indeed, the path used to be index.html -> learn.html. It is now index.html -> learn.html -> online-courses.html. We could address this issue by putting a link to the online courses on the index.html page.

Update: I pushed a commit that includes back a link to /online-courses.html from the landing page:

![Screenshot from 2022-01-05 17-40-00](https://user-images.githubusercontent.com/332812/148255020-300076ad-7fd9-4f4b-991c-35a5c8e47c0c.png)

However, I am not very happy with it because before the commit the whole gray rectangle was a link, whereas with the commit users now have to click exactly on the item title.