### PR TITLE
Fix a broken link

### DIFF
--- a/online-courses.md
+++ b/online-courses.md
@@ -103,7 +103,7 @@ the (legacy) Scala 2 version of our courses here:
 - [Functional Programming Principles in Scala (Scala 2 version)](https://www.coursera.org/learn/scala2-functional-programming)
 - [Functional Program Design (Scala 2 version)](https://www.coursera.org/learn/scala2-functional-program-design)
 - [Parallel Programming (Scala 2 version)](https://www.coursera.org/learn/scala2-parallel-programming)
-- [Big Data Analysis with Scala and Spark (Scala 2 version)](https://www.coursera.org/learn/scala2-spark-big-data)
+- [Big Data Analysis with Scala and Spark](https://www.coursera.org/learn/scala-spark-big-data)
 - [Programming Reactive Systems (Scala 2 version)](https://www.coursera.org/learn/scala2-akka-reactive)
 
 ## Testimonials


### PR DESCRIPTION
"Big Data Analysis with Scala and Spark (Scala 2 version)" doesn't exist and the link to this page has been already invalid.

Currently, It seems that "Big Data Analysis with Scala and Spark" exists instead of "Big Data Analysis with Scala and Spark (Scala 2 version)" on Coursera.

In addition, the test on GitHub Actions is failing by the link to "Big Data Analysis with Scala and Spark (Scala 2 version)" is invalid.
