### PR TITLE
fix typo in scala-features.md

### DIFF
--- a/_overviews/scala3-book/scala-features.md
+++ b/_overviews/scala3-book/scala-features.md
@@ -117,7 +117,7 @@ All of these expressions look like a dynamically-typed language like Python or R
 ```scala
 val s = "Hello"
 val p = Person("Al", "Pacino")
-val sum = ints.reduceLeft(_ + _)
+val sum = nums.reduceLeft(_ + _)
 val y = for i <- nums yield i * 2
 val z = nums.filter(_ > 100)
             .filter(_ < 10_000)


### PR DESCRIPTION
This PR fix a minor typo where ``nums`` was mostly likely intended to be used in place of ``ints``.