### PR TITLE
fix imperative code snippet in scala-features.md

### DIFF
--- a/_overviews/scala3-book/scala-features.md
+++ b/_overviews/scala3-book/scala-features.md
@@ -51,6 +51,8 @@ As the functional programming saying goes, in Scala you write _what_ you want, n
 That is, we don’t write imperative code like this:
 
 ```scala
+import scala.collection.mutable.ListBuffer
+
 def double(ints: List[Int]): List[Int] = {
   val buffer = new ListBuffer[Int]()
   for (i <- ints) {
@@ -59,6 +61,7 @@ def double(ints: List[Int]): List[Int] = {
   buffer.toList
 }
 
+val oldNumbers = List(1, 2, 3)
 val newNumbers = double(oldNumbers)
 ```
 


### PR DESCRIPTION
This minor PR slightly modifies the imperative code snippet such that it is executable. More precisely, its previous version was returning the error ``Not found: type ListBuffer``. While I see that this is just a toy example to show beginners what _not to do_ in Scala, I'd think it would be helpful if the code snippet was executable nonetheless.

This patch also makes the next line of code, i.e., ``val newNumbers = oldNumbers.map(_ * 2)``, executable.