### PR TITLE
Fix "Matching types of expression" example in quotes.md

### DIFF
--- a/_overviews/scala3-macros/tutorial/quotes.md
+++ b/_overviews/scala3-macros/tutorial/quotes.md
@@ -207,8 +207,7 @@ Below, we match against `$x` of type `T` and we get out an `x` of type `Expr[T]`
 def exprOfOption[T: Type](x: Expr[Option[T]])(using Quotes): Option[Expr[T]] =
   x match
     case '{ Some($x) } => Some(x) // x: Expr[T]
-    case '{ None } => Some(None)
-    case _ => None
+    case '{ None } => None
 ```
 
 We can also check for the type of an expression:


### PR DESCRIPTION
The definition of exprOfOption seems broken, returning values of a different type than declared. This is an attempt to fix it.

Note that, to get this function to compile in Scala 3.1.1, I had to add an explicit cast:

```scala
import scala.quoted.{Expr, Quotes, Type}

def exprOfOption[T: Type](x: Expr[Option[T]])(using Quotes): Option[Expr[T]] = x match {
  case '{ Some($x) } => Some(x.asInstanceOf[Expr[T]])
  case '{ None } => None
}
```

Otherwise, I get:

```
Found:    (x : scala.quoted.Expr[Any])
Required: quoted.Expr[T]
  case '{ Some($x) } => Some(x)
```