### PR TITLE
list scala 3 releases in api/all

### DIFF
--- a/api/all.md
+++ b/api/all.md
@@ -6,6 +6,8 @@ includeTOC: true
 
 ## Latest releases
 
+* Scala 3.1.1
+  * [Library API](https://www.scala-lang.org/api/3.1.1/)
 * Scala 2.13.8
   * [Library API](https://www.scala-lang.org/api/2.13.8/)
   * [Compiler API](https://www.scala-lang.org/api/2.13.8/scala-compiler/scala/)
@@ -58,6 +60,14 @@ https://scala-ci.typesafe.com/artifactory/scala-integration/org/scala-lang/
 
 ## Previous releases
 
+* Scala 3.1.0
+  * [Library API](https://www.scala-lang.org/api/3.1.0/)
+* Scala 3.0.2
+  * [Library API](https://www.scala-lang.org/api/3.0.2/)
+* Scala 3.0.1
+  * [Library API](https://www.scala-lang.org/api/3.0.1/)
+* Scala 3.0.0
+  * [Library API](https://www.scala-lang.org/api/3.0.0/)
 * Scala 2.13.7
   * [Library API](https://www.scala-lang.org/api/2.13.7/)
   * [Compiler API](https://www.scala-lang.org/api/2.13.7/scala-compiler/scala/)


### PR DESCRIPTION
I propose that we also list the scala 3 APIs in this documentation page for new releases.

paging @SethTisue @Kordyjan 

The plan is to then link to this from the scala-lang homepage where it currently says "API Docs (All Releases)"