### PR TITLE
Potential Semantic Clarity

### DIFF
--- a/_tour/lower-type-bounds.md
+++ b/_tour/lower-type-bounds.md
@@ -61,7 +61,7 @@ case class EuropeanSwallow() extends Bird
 
 
 val africanSwallowList = ListNode[AfricanSwallow](AfricanSwallow(), Nil())
-val birdList: Node[Bird] = africanSwallowList
+val birdList: ListNode[Bird] = africanSwallowList
 birdList.prepend(EuropeanSwallow())
 ```
-The `Node[Bird]` can be assigned the `africanSwallowList` but then accept `EuropeanSwallow`s.
+The `ListNode[Bird]` can be assigned the `africanSwallowList` but then accept `EuropeanSwallow`s.


### PR DESCRIPTION
Hello! Firstly, I would like to thank all the contributors for the awesome tour of Scala Lang. While going through the example, the usage of `Node[Bird]` type for birdList threw me in a loop for a moment. The location of usage has been proposed as a change for both demonstration purposes and as a potential change.

I understand traits can be used to describe a type, but in this instance wouldn't it be clearer to say `ListNode[Bird]` instead? Seeing that the value name –birdList– indicates we are going for a list. From what I can surmise, the Node trait can be implemented by say, a GraphNode which uses the prepend method in some way (one might argue it to be a convoluted use case). For the sake of clarity and consistency with the semantic meaning of the example, I believe `ListNode[Bird]` would be a better choice.