### PR TITLE
Fix compiling warnings in a code example of tour/classes

### DIFF
--- a/_tour/classes.md
+++ b/_tour/classes.md
@@ -86,7 +86,7 @@ class Point {
     if (newValue < bound) _y = newValue else printWarning()
   }
 
-  private def printWarning(): Unit = println("WARNING: Out of bounds")
+  private def printWarning() = println("WARNING: Out of bounds")
 }
 
 val point1 = new Point

--- a/_tour/classes.md
+++ b/_tour/classes.md
@@ -76,17 +76,17 @@ class Point {
   private var _y = 0
   private val bound = 100
 
-  def x = _x
+  def x: Int = _x
   def x_= (newValue: Int): Unit = {
-    if (newValue < bound) _x = newValue else printWarning
+    if (newValue < bound) _x = newValue else printWarning()
   }
 
-  def y = _y
+  def y: Int = _y
   def y_= (newValue: Int): Unit = {
-    if (newValue < bound) _y = newValue else printWarning
+    if (newValue < bound) _y = newValue else printWarning()
   }
 
-  private def printWarning = println("WARNING: Out of bounds")
+  private def printWarning(): Unit = println("WARNING: Out of bounds")
 }
 
 val point1 = new Point


### PR DESCRIPTION
Hi,

While following the code examples in Classes (Tour of Scala) in IDE, I noticed some compile warnings as follows:
* Type annotation required for public member (`x` and `y`)
* Method with Unit result type is parameterless (`printWarning`)
* Type annotation required for Unit definition (`printWarning`)

I tried to fix them in this PR :)

Thanks!