### PR TITLE
Remove deprecated methods in ArrayBuffer

### DIFF
--- a/_overviews/scala-book/arraybuffer-examples.md
+++ b/_overviews/scala-book/arraybuffer-examples.md
@@ -114,24 +114,22 @@ As a brief overview, here are several methods you can use with an `ArrayBuffer`:
 ```scala
 val a = ArrayBuffer(1, 2, 3)         // ArrayBuffer(1, 2, 3)
 a.append(4)                          // ArrayBuffer(1, 2, 3, 4)
-a.append(5, 6)                       // ArrayBuffer(1, 2, 3, 4, 5, 6)
-a.appendAll(Seq(7,8))                // ArrayBuffer(1, 2, 3, 4, 5, 6, 7, 8)
+a.appendAll(Seq(5, 6))               // ArrayBuffer(1, 2, 3, 4, 5, 6)
 a.clear                              // ArrayBuffer()
 
 val a = ArrayBuffer(9, 10)           // ArrayBuffer(9, 10)
 a.insert(0, 8)                       // ArrayBuffer(8, 9, 10)
 a.insertAll(0, Vector(4, 5, 6, 7))   // ArrayBuffer(4, 5, 6, 7, 8, 9, 10)
 a.prepend(3)                         // ArrayBuffer(3, 4, 5, 6, 7, 8, 9, 10)
-a.prepend(1, 2)                      // ArrayBuffer(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-a.prependAll(Array(0))               // ArrayBuffer(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+a.prependAll(Array(0, 1, 2))         // ArrayBuffer(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 
 val a = ArrayBuffer.range('a', 'h')  // ArrayBuffer(a, b, c, d, e, f, g)
 a.remove(0)                          // ArrayBuffer(b, c, d, e, f, g)
 a.remove(2, 3)                       // ArrayBuffer(b, c, g)
 
 val a = ArrayBuffer.range('a', 'h')  // ArrayBuffer(a, b, c, d, e, f, g)
-a.trimStart(2)                       // ArrayBuffer(c, d, e, f, g)
-a.trimEnd(2)                         // ArrayBuffer(c, d, e)
+a.dropInPlace(2)                     // ArrayBuffer(c, d, e, f, g)
+a.dropRightInPlace(2)                // ArrayBuffer(c, d, e)
 ```
 
 


### PR DESCRIPTION
As of 2.13.4, the following ArrayBuffer methods have been deprecated:

- append(elems: A*): ArrayBuffer.this.type
- prepend(elems: A*): ArrayBuffer.this.type
- trimStart(n: Int): Unit
- trimEnd(n: Int): Unit

Affected examples are updated in this pr.