### PR TITLE
Update implicit casting example

### DIFF
--- a/_overviews/scala3-book/first-look-at-types.md
+++ b/_overviews/scala3-book/first-look-at-types.md
@@ -249,7 +249,7 @@ You can only cast to a type if there is no loss of information. Otherwise, you n
 
 ```scala
 val x: Long = 987654321
-val y: Float = x.toFloat  // 9.8765434E8 (note that `.toFloat` is required because it results in percision loss)
+val y: Float = x.toFloat  // 9.8765434E8 (note that `.toFloat` is required because the cast results in percision loss)
 val z: Long = y  // Error
 ```
 

--- a/_overviews/scala3-book/first-look-at-types.md
+++ b/_overviews/scala3-book/first-look-at-types.md
@@ -239,7 +239,7 @@ For example:
 
 ```scala
 val x: Long = 987654321
-val y: Float = x  // 9.8765434E8 (note that some precision is lost in this case)
+val y: Float = x.toFloat  // 9.8765434E8 (note implicit conversion is depreciated since 2.13.1 when it would result in percision loss)
 
 val face: Char = '☺'
 val number: Int = face  // 9786

--- a/_overviews/scala3-book/first-look-at-types.md
+++ b/_overviews/scala3-book/first-look-at-types.md
@@ -246,7 +246,6 @@ val number: Int = face  // 9786
 ```
 
 You can only cast to a type if there is no loss of information. Otherwise, you need to be explicit about the cast:
-This will not compile:
 
 ```scala
 val x: Long = 987654321

--- a/_overviews/scala3-book/first-look-at-types.md
+++ b/_overviews/scala3-book/first-look-at-types.md
@@ -238,8 +238,8 @@ Value types can be cast in the following way:
 For example:
 
 ```scala
-val x: Long = 987654321
-val y: Float = x.toFloat  // 9.8765434E8 (note implicit conversion is depreciated since 2.13.1 when it would result in percision loss)
+val b: Byte = 127
+val i: Int = b  // 127
 
 val face: Char = '☺'
 val number: Int = face  // 9786
@@ -248,9 +248,9 @@ val number: Int = face  // 9786
 Casting is unidirectional.
 This will not compile:
 
-```
+```scala
 val x: Long = 987654321
-val y: Float = x  // 9.8765434E8
+val y: Float = x.toFloat  // 9.8765434E8 (note implicit conversion is deprecated since 2.13.1, when it would result in percision loss)
 val z: Long = y  // Does not conform
 ```
 

--- a/_overviews/scala3-book/first-look-at-types.md
+++ b/_overviews/scala3-book/first-look-at-types.md
@@ -245,13 +245,13 @@ val face: Char = '☺'
 val number: Int = face  // 9786
 ```
 
-Casting is unidirectional.
+You can only cast to a type if there is no loss of information. Otherwise, you need to be explicit about the cast:
 This will not compile:
 
 ```scala
 val x: Long = 987654321
-val y: Float = x.toFloat  // 9.8765434E8 (note implicit conversion is deprecated since 2.13.1, when it would result in percision loss)
-val z: Long = y  // Does not conform
+val y: Float = x.toFloat  // 9.8765434E8 (note that `.toFloat` is required because it results in percision loss)
+val z: Long = y  // Error
 ```
 
 You can also cast a reference type to a subtype.


### PR DESCRIPTION
Addresses the following issue https://github.com/scala/docs.scala-lang/issues/2369

Example of implicit casting uses depreciated example.