### PR TITLE
Fix error in `given` definition

### DIFF
--- a/_overviews/scala3-book/packaging-imports.md
+++ b/_overviews/scala3-book/packaging-imports.md
@@ -354,20 +354,19 @@ object MonthConversions:
   trait MonthConverter[A]:
     def convert(a: A): String
 
-  given intMonthConverter as MonthConverter[Int]:
+  given intMonthConverter: MonthConverter[Int] with
     def convert(i: Int): String = 
       i match
         case 1 =>  "January"
         case 2 =>  "February"
         // more cases here ...
 
-  given stringMonthConverter as MonthConverter[String]:
+  given stringMonthConverter: MonthConverter[String] with
     def convert(s: String): String = 
       s match
         case "jan" => "January"
         case "feb" => "February"
         // more cases here ...
-}
 ```
 
 To import those givens into the current scope, use these two `import` statements:


### PR DESCRIPTION
We can see in the [reference](https://docs.scala-lang.org/scala3/reference/contextual/givens.html) that the right `given` definition is:
```
given intMonthConverter: MonthConverter[Int] with
```