### PR TITLE
Update scalatest to 3.2.11

### DIFF
--- a/_getting-started/intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/_getting-started/intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -20,15 +20,15 @@ This assumes you know [how to build a project in IntelliJ](building-a-scala-proj
 1. Add the ScalaTest dependency:
     1. Add the ScalaTest dependency to your `build.sbt` file:
         ```
-        libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % Test
+        libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.11" % Test
         ```
     1. If you get a notification "build.sbt was changed", select **auto-import**.
     1. These two actions will cause `sbt` to download the ScalaTest library.
-    1. Wait for the `sbt` sync to finish; otherwise, `FunSuite` and `test()` will be
+    1. Wait for the `sbt` sync to finish; otherwise, `AnyFunSuite` and `test()` will be
         unrecognized.
 1. On the project pane on the left, expand `src` => `main`.
 1. Right-click on `scala` and select **New** => **Scala class**.
-1. Call it `CubeCalculator`, change the **Kind** to `object`, and click **OK**.
+1. Call it `CubeCalculator`, change the **Kind** to `object`, and hit enter or double click on `object`.
 1. Replace the code with the following:
     ```
     object CubeCalculator extends App {
@@ -41,12 +41,12 @@ This assumes you know [how to build a project in IntelliJ](building-a-scala-proj
 ## Creating a test
 1. On the project pane on the left, expand `src` => `test`.
 1. Right-click on `scala` and select **New** => **Scala class**.
-1. Name the class `CubeCalculatorTest` and click **OK**.
+1. Name the class `CubeCalculatorTest` and hit enter or double click on `class`.
 1. Replace the code with the following:
     ```
-    import org.scalatest.FunSuite
+    import org.scalatest.funsuite.AnyFunSuite
     
-    class CubeCalculatorTest extends FunSuite {
+    class CubeCalculatorTest extends AnyFunSuite {
       test("CubeCalculator.cube") {
         assert(CubeCalculator.cube(3) === 27)
       }
@@ -60,9 +60,9 @@ This assumes you know [how to build a project in IntelliJ](building-a-scala-proj
 Let's go over this line by line:
 
 * `class CubeCalculatorTest` means we are testing the object `CubeCalculator`
-* `extends FunSuite` lets us use functionality of ScalaTest's FunSuite class
+* `extends AnyFunSuite` lets us use functionality of ScalaTest's AnyFunSuite class
 such as the `test` function
-* `test` is function that comes from the FunSuite library that collects
+* `test` is a function that comes from the FunSuite library that collects
 results from assertions within the function body.
 * `"CubeCalculator.cube"` is a name for the test. You can call it anything but
 one convention is "ClassName.methodName".

--- a/_overviews/scala-book/sbt-scalatest-bdd.md
+++ b/_overviews/scala-book/sbt-scalatest-bdd.md
@@ -70,7 +70,7 @@ class MathUtilsSpec extends FunSpec {
 
 As you can see, this is a very different-looking style than the TDD tests in the previous lesson. If you’ve never used a BDD style of testing before, a main idea is that the tests should be relatively easy to read for one of the “domain experts” who work with the programmers to create the application. A few notes about this code:
 
-- It uses the `FunSpec` class where the TDD tests used `FunSuite`
+- It uses the `AnyFunSpec` class where the TDD tests used `AnyFunSuite`
 - A set of tests begins with `describe`
 - Each test begins with `it`. The idea is that the test should read like, “It should do XYZ...,” where “it” is the `double` function
 - This example also shows how to mark a test as “pending”
@@ -96,7 +96,7 @@ With those files in place you can again run `sbt test`. The important part of th
 [info] Suites: completed 2, aborted 0
 [info] Tests: succeeded 4, failed 0, canceled 0, ignored 0, pending 1
 [info] All tests passed.
-[success] Total time: 4 s, completed Jan 6, 2018 4:58:23 PM
+[success] Total time: 4 s
 ````
 
 A few notes about that output:

--- a/_overviews/scala-book/sbt-scalatest-tdd.md
+++ b/_overviews/scala-book/sbt-scalatest-tdd.md
@@ -39,7 +39,7 @@ version := "1.0"
 scalaVersion := "{{site.scala-version}}"
 
 libraryDependencies +=
-    "org.scalatest" %% "scalatest" % "3.0.8" % Test
+    "org.scalatest" %% "scalatest" % "3.2.11" % Test
 
 ```
 
@@ -47,7 +47,7 @@ The first three lines of this file are essentially the same as the first example
 
 ```scala
 libraryDependencies +=
-    "org.scalatest" %% "scalatest" % "3.0.8" % Test
+    "org.scalatest" %% "scalatest" % "3.2.11" % Test
 ```
 
 >The ScalaTest documentation has always been good, and you can always find the up to date information on what those lines should look like on the [Installing ScalaTest](http://www.scalatest.org/install) page.
@@ -85,8 +85,8 @@ There isn’t much that can go wrong with that source code, but it provides a si
 [warn]   consider launching sbt without any commands, or explicitly passing 'shell'
 ...
 ...
-[info] Compiling 1 Scala source to /Users/al/Projects/Scala/HelloScalaTest/target/scala-2.12/classes...
-[info] Running simpletest.Hello 
+[info] compiling 1 Scala source to /Users/al/Projects/Scala/HelloScalaTest/target/scala-2.13/classes...
+[info] running simpletest.Hello 
 Hello Alvin Alexander
 [success] Total time: 4 s
 ````
@@ -108,9 +108,9 @@ Next, create a file named *HelloTests.scala* in that directory with the followin
 ```scala
 package simpletest
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class HelloTests extends FunSuite {
+class HelloTests extends AnyFunSuite {
 
     // test 1
     test("the name is set correctly in constructor") {
@@ -130,7 +130,7 @@ class HelloTests extends FunSuite {
 
 This file demonstrates the ScalaTest `FunSuite` approach. A few important points:
 
-- Your class should extend `FunSuite`
+- Your class should extend `AnyFunSuite`
 - You create tests as shown, by giving each `test` a unique name
 - At the end of each test you should call `assert` to test that a condition has been satisfied
 
@@ -140,7 +140,7 @@ Now you can run these tests with the `sbt test` command. Skipping the first few 
 
 ````
 > sbt test
-[info] Set current project to HelloScalaTest (in build file:/Users/al/Projects/Scala/HelloScalaTest/)
+[info] set current project to HelloScalaTest (in build file:/Users/al/Projects/Scala/HelloScalaTest/)
 [info] HelloTests:
 [info] - the name is set correctly in constructor
 [info] - a Person's name can be changed


### PR DESCRIPTION
Applying this PR will update scalatest to 3.2.11 in the scala book and in the IntelliJ test example. I also fixed a few things along the way while going through the example step-by-step.

Fixes #2376.