### PR TITLE
Make sure SIP numbers are used exactly once, and proposals use exactly one number

### DIFF
--- a/_sips/sips/2016-09-09-inline-meta.md
+++ b/_sips/sips/2016-09-09-inline-meta.md
@@ -1,6 +1,6 @@
 ---
 layout: sip
-title: SIP-28 and SIP-29 - Inline meta
+title: SIP-28 - Inline meta
 vote-status: dormant
 vote-text: This proposal needs an owner.
 permalink: /sips/:title.html

--- a/_sips/sips/2017-07-12-right-associative-by-name-operators.md
+++ b/_sips/sips/2017-07-12-right-associative-by-name-operators.md
@@ -1,6 +1,6 @@
 ---
 layout: sip
-title: SIP-34 - Right-Associative By-Name Operators
+title: SIP-39 - Right-Associative By-Name Operators
 vote-status: complete
 vote-text: This SIP has been implemented in Scala 2.13.0 and Scala 3.0.0
 permalink: /sips/:title.html

--- a/_sips/sips/2017-11-20-byname-implicits.md
+++ b/_sips/sips/2017-11-20-byname-implicits.md
@@ -1,6 +1,6 @@
 ---
 layout: sip
-title: SIP-36 - Byname implicit arguments
+title: SIP-31 - Byname implicit arguments
 vote-status: complete
 vote-text: This SIP has been implemented in Scala 2.13.0 and Scala 3.0.0
 permalink: /sips/:title.html


### PR DESCRIPTION
In #2389 I assigned the number 34 to a SIP although that number was already used by another one. I noticed that a couple of other proposals were using the number 36, and that another proposal was using two numbers.

I propose these changes so that numbers are used at most once, and proposals use at most one number.