### PR TITLE
Update quotes.md

### DIFF
--- a/_overviews/scala3-macros/tutorial/quotes.md
+++ b/_overviews/scala3-macros/tutorial/quotes.md
@@ -154,7 +154,7 @@ given ToExpr[Boolean] with {
 }
 
 given ToExpr[StringContext] with {
-  def apply(x: StringContext)(using Quotes) =
+  def apply(stringContext: StringContext)(using Quotes) =
     val parts = Varargs(stringContext.parts.map(Expr(_)))
     '{ StringContext($parts: _*) }
 }


### PR DESCRIPTION
There is a typo in the **ToExpr** section [Quoted Code documentation](https://docs.scala-lang.org/scala3/guides/macros/quotes.html#toexpr).

We use `stringContext` parameter in the body of the method - not `x`.

The error example:
https://scastie.scala-lang.org/R1zL474TTvmQqZjtAB0FXQ
