### PR TITLE
navigation-menu: fix wrong style

### DIFF
--- a/_sass/layout/doc-navigation.scss
+++ b/_sass/layout/doc-navigation.scss
@@ -65,7 +65,7 @@ $nav-height: 46px;
               position: absolute;
               margin-top: 10px;
               display: none;
-              z-index: 1;
+              z-index: 40;
               box-shadow: 0 3px 12px rgba(0, 0, 0, 0.15);
 
               @include bp(medium) {


### PR DESCRIPTION
the search icon covers the menu, and i fix it by adjust the z-index

before:
![before](https://s3.bmp.ovh/imgs/2022/05/29/25a20c7efc566f2e.png)

after:
![after](https://s3.bmp.ovh/imgs/2022/05/29/d258bee7718475b3.png)