### PR TITLE
Renamed deprecated annotation in the doc

### DIFF
--- a/_overviews/scala3-book/interacting-with-java.md
+++ b/_overviews/scala3-book/interacting-with-java.md
@@ -341,10 +341,10 @@ def +(a: Int, b: Int) = a + b
 That method name won’t work well in Java, but what you can do in Scala 3 is provide an “alternate” name for the method---an alias---that will work in Java:
 
 ```scala
-import scala.annotation.alpha
+import scala.annotation.targetName
 
 class Adder:
-  @alpha("add") def +(a: Int, b: Int) = a + b
+  @targetName("add") def +(a: Int, b: Int) = a + b
 ```
 
 Now in your Java code you can use the aliased method name `add`:


### PR DESCRIPTION
[scala.annotation.alpha is deprecated](https://scala-lang.org/api/3.x/scala/annotation/alpha.html)

It'll be good to use `@targetName` instead