### PR TITLE
add sticky help message to get started

### DIFF
--- a/_includes/getting-started.md
+++ b/_includes/getting-started.md
@@ -2,7 +2,8 @@ The instructions below cover both Scala 2 and Scala 3.
 
 <div class="inline-sticky-top">
 {% altDetails need-help-info-box 'Need Help?' class=help-info %}
-*If you are having trouble with setting up Scala, feel free to ask for help in the [#scala-users](https://discord.com/channels/632150470000902164/632150470000902166) channel of our Discord.*
+*If you are having trouble with setting up Scala, feel free to ask for help in the `#scala-users` channel of
+[our Discord](https://discord.com/invite/scala).*
 {% endaltDetails %}
 </div>
 

--- a/_includes/getting-started.md
+++ b/_includes/getting-started.md
@@ -1,5 +1,11 @@
 The instructions below cover both Scala 2 and Scala 3.
 
+<div class="inline-sticky-top">
+{% altDetails need-help-info-box 'Need Help?' class=help-info %}
+*If you are having trouble with setting up Scala, feel free to ask for help in the [#scala-users](https://discord.com/channels/632150470000902164/632150470000902166) channel of our Discord.*
+{% endaltDetails %}
+</div>
+
 ## Try Scala without installing anything
 
 To start experimenting with Scala right away, use <a href="https://scastie.scala-lang.org/pEBYc5VMT02wAGaDrfLnyw" target="_blank">“Scastie” in your browser</a>.

--- a/_plugins/alt-details-lib/alt-details.rb
+++ b/_plugins/alt-details-lib/alt-details.rb
@@ -3,7 +3,7 @@ require 'erb'
 module Jekyll
     module AltDetails
         class AltDetailsBlock < Liquid::Block
-            SYNTAX = /^\s*(#{Liquid::QuotedFragment})\s+(#{Liquid::QuotedFragment})/o
+            SYNTAX = /^\s*(#{Liquid::QuotedFragment})\s+(#{Liquid::QuotedFragment})(?=\s+class=(#{Liquid::QuotedFragment}))?/o
             Syntax = SYNTAX
 
             alias_method :render_block, :render
@@ -18,6 +18,11 @@ module Jekyll
                 if markup =~ SYNTAX
                     @name = unquote($1)
                     @title = unquote($2)
+                    @css_classes = ""
+                    if $3
+                        # append $3 to @css_classes
+                        @css_classes = "#{@css_classes} #{unquote($3)}"
+                    end
                 else
                     raise SyntaxError.new("Block #{block_name} requires an id and a title")
                 end

--- a/_plugins/alt-details-lib/template.erb
+++ b/_plugins/alt-details-lib/template.erb
@@ -1,5 +1,5 @@
 <div class="place-inline">
-  <div id="<%= @name %>" class="alt-details">
+  <div id="<%= @name %>" class="alt-details<%= @css_classes %>">
     <input class="alt-details-control" type="checkbox" id="<%= @name %>__control" hidden aria-hidden="true">
     <label class="alt-details-toggle" for="<%= @name %>__control"><%= @title %></label>
     <div class="alt-details-detail">

--- a/_sass/base/helper.scss
+++ b/_sass/base/helper.scss
@@ -3,35 +3,45 @@
 //------------------------------------------------
 
 .wrap {
-	@include outer-container;
-	@include padding(0 20px);
+    @include outer-container;
+    @include padding(0 20px);
 }
 
 .place-inline {
-	// add vertical margin
-	@include outer-container;
-	@include margin(20px 0);
+    // add vertical margin
+    @include outer-container;
+    @include margin(20px 0);
+}
+
+.inline-sticky-top {
+    position: sticky;
+    top: 15px;
+    background: #fff;
+    -webkit-box-shadow: 0 0 18px 20px #fff;
+    -moz-box-shadow: 0 0 18px 20px #fff;
+    box-shadow: 0 0 18px 20px #fff;
+    z-index: 999;
 }
 
 .wrap-inline {
-	// add vertical padding
-	@include outer-container;
-	@include padding(20px 0);
+    // add vertical padding
+    @include outer-container;
+    @include padding(20px 0);
 }
 
 .wrap-tab {
-	@extend .wrap-narrow;
-	margin-top: 20px;
-	margin-bottom: 20px;
+    @extend .wrap-narrow;
+    margin-top: 20px;
+    margin-bottom: 20px;
 }
 
 .wrap-narrow {
-	@include outer-container;
-	@include padding(0 10px);
+    @include outer-container;
+    @include padding(0 10px);
 }
 
 .dot {
-	font-size: 10px;
-	color: rgba($base-font-color-light, 0.6);
-	margin: 0 3px;
+    font-size: 10px;
+    color: rgba($base-font-color-light, 0.6);
+    margin: 0 3px;
 }

--- a/_sass/components/alt-details.scss
+++ b/_sass/components/alt-details.scss
@@ -2,6 +2,21 @@
 //------------------------------------------------
 //------------------------------------------------
 
+.alt-details.help-info {
+    .alt-details-toggle {
+        background-color: $brand-primary;
+        color: white;
+
+        &:hover {
+            background-color: darken($brand-primary, 15%);
+        }
+    }
+
+    .alt-details-detail {
+        background: #fae6e6
+    }
+}
+
 .alt-details {
     @include span-columns(12);
 
@@ -33,6 +48,10 @@
             margin-top: 2px;
         }
 
+    }
+
+    .alt-details-control {
+        margin: 0;
     }
 
     .alt-details-control+.alt-details-toggle+.alt-details-detail {

--- a/_sass/layout/footer.scss
+++ b/_sass/layout/footer.scss
@@ -84,7 +84,7 @@
       text-align: center;
       z-index: 2;
       color: #f0f3f3;
-      background-color: #dc322f;
+      background-color: $brand-primary;
       border-radius: 50%;
       display: none;
      


### PR DESCRIPTION
Add a toggle details to point users to Discord if they have problems with set up. The details will stick at the top of the screen as you scroll. It also has a more red theme to match its importance level. Also toggle works without JS.

first screenshot shows page at load:

![Screenshot 2022-06-08 at 15 55 40](https://user-images.githubusercontent.com/13436592/172634657-7f6f34c4-d643-42be-8df6-4f275abe0fa7.png)


next screenshot demonstrates what it looks like when expanded and sticky while scrolling:

![Screenshot 2022-06-08 at 15 53 39](https://user-images.githubusercontent.com/13436592/172634155-a813faf1-92e0-4823-baba-563ba1bd88fd.png)
