### PR TITLE
Indentation for scala 2 reference made consistent as others

### DIFF
--- a/_overviews/scala3-book/taste-control-structures.md
+++ b/_overviews/scala3-book/taste-control-structures.md
@@ -50,11 +50,11 @@ The `if`/`else` control struture in Scala 2 was constructed differently, with pa
 ```scala
 // Scala 2 syntax
 if (test1) {
-    doX()
+  doX()
 } else if (test2) {
-    doY()
+  doY()
 } else {
-    doZ()
+  doZ()
 }
 ```
 


### PR DESCRIPTION
The other examples made use of 2 indentation, only the reference to scala 2 example used four indentation.