### PR TITLE
inline sticky should be below nav bar menus

### DIFF
--- a/_sass/base/helper.scss
+++ b/_sass/base/helper.scss
@@ -20,7 +20,7 @@
     -webkit-box-shadow: 0 0 18px 20px #fff;
     -moz-box-shadow: 0 0 18px 20px #fff;
     box-shadow: 0 0 18px 20px #fff;
-    z-index: 999;
+    z-index: 5;
 }
 
 .wrap-inline {


### PR DESCRIPTION
previously the white shadow appeared above both the language drop-down (z-index 10) and the nav-bar submenus (z-index 40)