### PR TITLE
show language dropdown when english is only option

### DIFF
--- a/resources/js/functions.js
+++ b/resources/js/functions.js
@@ -147,7 +147,7 @@ $(document).ready(function() {
   old.empty();
 
   // if there are no translations, hide language dropdown box
-  if (items.length <= 1) {
+  if (items.length === 0) {
     $("#dd").hide();
   }
 });


### PR DESCRIPTION
Will show the language picker on a translated page when there is only one option - go back to the English page.

currently, if the page has only one translation, going to the translated page will hide the language picker.

This still hides the language picker on pages where there are no translations available