### PR TITLE
fix: needs `var` for Dog extends abstract class

### DIFF
--- a/_overviews/scala3-book/domain-modeling-tools.md
+++ b/_overviews/scala3-book/domain-modeling-tools.md
@@ -415,7 +415,7 @@ abstract class Pet(name: String):
   def age: Int
   override def toString = s"My name is $name, I say $greeting, and I’m $age"
 
-class Dog(name: String, age: Int) extends Pet(name):
+class Dog(name: String, var age: Int) extends Pet(name):
   val greeting = "Woof"
 
 val d = Dog("Fido", 1)


### PR DESCRIPTION
In the _Dog extends abstract class_ (aka Scala 2 way) `var` keyword is missing in the class defition
```
class Dog(name: String, age: Int) extends Pet(name):
...
```
As a result the `Dog` class fails to compile with the following error
`class Dog needs to be abstract, since def age: Int in class Pet is not defined`

adding `var` to the definition solves to problem
```
class Dog(name: String, var age: Int) extends Pet(name):
...
```