### PR TITLE
nit: redundant call to `sb.toString` before print

### DIFF
--- a/_overviews/scala3-book/methods-main-methods.md
+++ b/_overviews/scala3-book/methods-main-methods.md
@@ -49,8 +49,7 @@ For example, given this `@main` method that takes an `Int`, a `String`, and a va
 
   val sb = StringBuilder(s"Happy $age$suffix birthday, $name")
   for other <- others do sb.append(" and ").append(other)
-  sb.toString
-  println(sb)
+  println(sb.toString)
 ```
 
 When you compile that code, it creates a main program named `happyBirthday` that’s called like this:


### PR DESCRIPTION
`Command line arguments` chapter ends with the following code snippet:
```
  ...
  sb.toString
  println(sb)
```

and those two lines IMHO should be replaced with one as:
* `sb.toString` performs actual string materialisation from buffer and returns it,
  but nothing is actually using it
* `println(sb)` relies on StringBuilder having properly implemented `toString`
  method (which is obviously the case) and calls it implicitly again and prints
  it to the std out this time

I have proposed to reduce it to `println(sb.toString)` to give clear intent of `toString`
being actually used to produce the content that is outputted but `println(sb)` would
do to, WDYT?