### PR TITLE
update scala-native in Scala 3 migration guide

### DIFF
--- a/_overviews/scala3-migration/tutorial-prerequisites.md
+++ b/_overviews/scala3-migration/tutorial-prerequisites.md
@@ -101,10 +101,9 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.0")
 
 ### Scala Native
 
-Scala 3 does not yet support [Scala Native](https://scala-native.readthedocs.io/en/latest/).
+Scala 3 is now supported in Scala Native starting with [v0.4.3](https://scala-native.readthedocs.io/en/latest/changelog/0.4.3.html)
 
-If you project is cross-built to Scala Native, you can port it to Scala 3.
-But you will not be able to compile for the Native platform.
+The minimal version of Scala 3 supported by Scala Native is 3.1.0, due to fatal blockers in Scala 3.0.x
 
 ### Kind Projector
 


### PR DESCRIPTION
This PR updates the Scala 3 migration guide information related to scala native support.

FIxes #2343 