### PR TITLE
Fix difficult to read value name in example.

### DIFF
--- a/_overviews/scala3-book/types-opaque-types.md
+++ b/_overviews/scala3-book/types-opaque-types.md
@@ -124,12 +124,12 @@ However, outside of the module the type `Logarithm` is completely encapsulated, 
 
 ```scala
 import Logarithms.*
-val l2 = Logarithm(2.0)
-val l3 = Logarithm(3.0)
-println((l2 * l3).toDouble) // prints 6.0
-println((l2 + l3).toDouble) // prints 4.999...
+val log2 = Logarithm(2.0)
+val log3 = Logarithm(3.0)
+println((log2 * log3).toDouble) // prints 6.0
+println((log2 + log3).toDouble) // prints 4.999...
 
-val d: Double = l2 // ERROR: Found Logarithm required Double
+val d: Double = log2 // ERROR: Found Logarithm required Double
 ```
 
 Even though we abstracted over `Logarithm`, the abstraction comes for free:


### PR DESCRIPTION
In my font (default for Firefox I think) the old name `l2` (i.e. _<lowercase L>_2) looks a lot like `12` (i.e. twelve). This changes the name to `log2` (and same for `l3` → `log3`) since that's a lot easier to parse. I was very confused thinking I was reading
 
```scala
val d: Double = 12 // ERROR: Found Logarithm required Double
```
and wondering "how did the compiler decide that twelve was a `Logarithm`???"

Great book overall, thanks for putting it together!