### PR TITLE
Update comment in example code

### DIFF
--- a/_tour/classes.md
+++ b/_tour/classes.md
@@ -111,7 +111,7 @@ println(point1)           // prints (1, 0)
 class Point(var x: Int = 0, var y: Int = 0)
 
 val origin = Point()  // x and y are both set to 0
-val point1 = Point(1) // y is set to 0
+val point1 = Point(1) // x is set to 1 and y is set to 0
 println(point1)       // prints (1, 0)
 ```
 {% endtab %}

--- a/_tour/classes.md
+++ b/_tour/classes.md
@@ -101,7 +101,7 @@ Constructors can have optional parameters by providing a default value like so:
 class Point(var x: Int = 0, var y: Int = 0)
 
 val origin = new Point    // x and y are both set to 0
-val point1 = new Point(1) // y is set to 0
+val point1 = new Point(1) // x is set to 1 and y is set to 0
 println(point1)           // prints (1, 0)
 ```
 {% endtab %}


### PR DESCRIPTION
Help clarify that x is set to 1, and y is set to default value. This comment is more explicit in what x and y are set to. 

The reason why I proposed this change was it's easy to misread, especially as x and y look visually similar on smaller screens.