### PR TITLE
Fix import that changed with the update to scalatest 3.2.11

### DIFF
--- a/_overviews/scala-book/sbt-scalatest-bdd.md
+++ b/_overviews/scala-book/sbt-scalatest-bdd.md
@@ -45,9 +45,9 @@ Next, create a file named *MathUtilsTests.scala* in the *src/test/scala/simplete
 ```scala
 package simpletest
 
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class MathUtilsSpec extends FunSpec {
+class MathUtilsSpec extends AnyFunSpec {
   
     describe("MathUtils::double") {
 


### PR DESCRIPTION
Similar to #2377, this PR fixes where the Scala 2 book is still based on scalatest 3.0.8