### PR TITLE
New Scaladoc static site gen - Add a mention to the provided Liquid variables

### DIFF
--- a/_overviews/scala3-scaladoc/static-site.md
+++ b/_overviews/scala3-scaladoc/static-site.md
@@ -51,6 +51,12 @@ Scaladoc uses the [Liquid](https://shopify.github.io/liquid/) templating engine
 and provides several custom filters and tags specific to Scala
 documentation.
 
+The following project related variables are available and can be accessed using
+double curly braces (e.g. `{{ projectTitle }}`):
+
+- **projectTitle** the project title defined with the `-project` flag.
+- **projectVersion** the project version defined with the `-project-version` flag.
+
 In Scaladoc, all templates can contain YAML front-matter. The front-matter
 is parsed and put into the `page` variable available in templates via Liquid.
 


### PR DESCRIPTION
I think it's a bit odd that the documentation specifies "[...] several custom filters and tags specific to Scala[...]" and then doesn't mention anything about that.

From what I can tell from the [source code](https://github.com/lampepfl/dotty/blob/0632405ae487233709c9c6af6d83ff03db7f7bce/scaladoc/src/dotty/tools/scaladoc/site/StaticSiteContext.scala#L113-L115), the only Scala specific things being provided are the `projectTitle` and `projectVersion`.

I think it's useful to document the existence of this variables. Especially `projectVersion`, which can be used to automatically generate `sbt`/`mill`/`maven`/... coordinates.