### PR TITLE
correct valueOrError to valueOrAbort

### DIFF
--- a/_overviews/scala3-macros/faq.md
+++ b/_overviews/scala3-macros/faq.md
@@ -13,7 +13,7 @@ All quotes containing a value of a primitive type is optimised to an `Expr.apply
 Choose one in your project and stick with a single notation to avoid confusion.
 
 ## How do I get a value out of an `Expr`?
-If the expression represents a value, you can use `.value`, `.valueOrError` or `Expr.unapply`
+If the expression represents a value, you can use `.value`, `.valueOrAbort` or `Expr.unapply`
 
 ## How can I get the precise type of an `Expr`?
 We can get the precise type (`Type`) of an `Expr` using the following pattern match:

--- a/_overviews/scala3-macros/tutorial/quotes.md
+++ b/_overviews/scala3-macros/tutorial/quotes.md
@@ -367,7 +367,7 @@ As with expression quote patterns, type variables are represented using lower ca
 
 ## FromExpr
 
-The `Expr.value`, `Expr.valueOrError`, and `Expr.unapply` methods uses intances of `FromExpr` to extract the value if possible.
+The `Expr.value`, `Expr.valueOrAbort`, and `Expr.unapply` methods uses intances of `FromExpr` to extract the value if possible.
 ```scala
 extension [T](expr: Expr[T]):
   def value(using Quotes)(using fromExpr: FromExpr[T]): Option[T] =


### PR DESCRIPTION
In some places the docs mention `valueOrError` which is deprecated in favor of `valueOrAbort`.

The missing `import quotes.reflect.*` made it hard to figure out where the `report` comes from, I think it's worth including it if someone wants to follow along with the code in their IDE.