### PR TITLE
restore mdoc checking to higher order fns

### DIFF
--- a/_tour/higher-order-functions.md
+++ b/_tour/higher-order-functions.md
@@ -24,7 +24,7 @@ function `map` which is available for collections in Scala.
 {% tabs map_example_1 class=tabs-scala-version %}
 
 {% tab 'Scala 2 and 3' for=map_example_1 %}
-```scala mdoc
+```scala mdoc:nest
 val salaries = Seq(20_000, 70_000, 40_000)
 val doubleSalary = (x: Int) => x * 2
 val newSalaries = salaries.map(doubleSalary) // List(40000, 140000, 80000)
@@ -42,7 +42,7 @@ an argument to map:
 {% tabs map_example_2 class=tabs-scala-version %}
 
 {% tab 'Scala 2 and 3' for=map_example_2 %}
-```scala mdoc
+```scala mdoc:nest
 val salaries = Seq(20_000, 70_000, 40_000)
 val newSalaries = salaries.map(x => x * 2) // List(40000, 140000, 80000)
 ```
@@ -56,7 +56,7 @@ compiler can infer the type based on the type of function map expects (see [Curr
 {% tabs map_example_3 class=tabs-scala-version %}
 
 {% tab 'Scala 2 and 3' for=map_example_3 %}
-```scala mdoc
+```scala mdoc:nest
 val salaries = Seq(20_000, 70_000, 40_000)
 val newSalaries = salaries.map(_ * 2)
 ```

--- a/_tour/higher-order-functions.md
+++ b/_tour/higher-order-functions.md
@@ -24,7 +24,7 @@ function `map` which is available for collections in Scala.
 {% tabs map_example_1 class=tabs-scala-version %}
 
 {% tab 'Scala 2 and 3' for=map_example_1 %}
-```scala
+```scala mdoc
 val salaries = Seq(20_000, 70_000, 40_000)
 val doubleSalary = (x: Int) => x * 2
 val newSalaries = salaries.map(doubleSalary) // List(40000, 140000, 80000)
@@ -42,7 +42,7 @@ an argument to map:
 {% tabs map_example_2 class=tabs-scala-version %}
 
 {% tab 'Scala 2 and 3' for=map_example_2 %}
-```scala
+```scala mdoc
 val salaries = Seq(20_000, 70_000, 40_000)
 val newSalaries = salaries.map(x => x * 2) // List(40000, 140000, 80000)
 ```
@@ -56,7 +56,7 @@ compiler can infer the type based on the type of function map expects (see [Curr
 {% tabs map_example_3 class=tabs-scala-version %}
 
 {% tab 'Scala 2 and 3' for=map_example_3 %}
-```scala
+```scala mdoc
 val salaries = Seq(20_000, 70_000, 40_000)
 val newSalaries = salaries.map(_ * 2)
 ```


### PR DESCRIPTION
now that the syntax for mdoc is 2.13, restore checking on numeric literals with underscore