### PR TITLE
Add missing parentheses

### DIFF
--- a/_tour/extractor-objects.md
+++ b/_tour/extractor-objects.md
@@ -42,7 +42,7 @@ import scala.util.Random
 
 object CustomerID:
 
-  def apply(name: String) = s"$name--${Random.nextLong}"
+  def apply(name: String) = s"$name--${Random.nextLong()}"
 
   def unapply(customerID: String): Option[String] =
     val stringArray: Array[String] = customerID.split("--")


### PR DESCRIPTION
Random.nextLong() requires parentheses, it was added in the scala 2 code tab