### PR TITLE
Fix localized contents

### DIFF
--- a/_includes/sidebar-toc-multipage-overview.html
+++ b/_includes/sidebar-toc-multipage-overview.html
@@ -18,11 +18,10 @@
 
           {% if pg.num and (page.partof == pg.partof) %}
             {% if page.language %} <!-- if page is a translation, get the translated title -->
-              {% assign prefix = page.language | prepend: '/' %}
-              {% assign localizedId = pg.id | prepend: prefix %}
+              {% assign localizedId = pg.id %}
               {% for lpg in site.[page.language] %}
                 {% if lpg.id == localizedId %}
-                  <li><a {% if page.title == lpg.title %}class="active"{% endif %} href="/{{ site.baseurl }}{{ page.language }}{{ pg.url }}">{{ lpg.title }}</a>
+                  <li><a {% if page.title == lpg.title %}class="active"{% endif %} href="{{ site.baseurl }}{{ pg.url }}">{{ lpg.title }}</a>
                   {{ toc }}</li>
                 {% endif %}
               {% endfor %}


### PR DESCRIPTION
As you can see all localized pages that extend the template `layout: multipage-overview` have empty content.
For example:
https://docs.scala-lang.org/ja/overviews/parallel-collections/concrete-parallel-collections.html
https://docs.scala-lang.org/es/overviews/parallel-collections/concrete-parallel-collections.html
https://docs.scala-lang.org/ru/overviews/collections-2.13/introduction.html
...

It's because `pg.id` and `pg.url` already have localized values. And if we add `page.language`, we'll get the wrong value - `/ru/ru/scala3/book/introduction`

Fixed!

