### PR TITLE
Update scala-features.md

### DIFF
--- a/_overviews/scala3-book/scala-features.md
+++ b/_overviews/scala3-book/scala-features.md
@@ -537,7 +537,7 @@ Serialization:
 
 ### AI, machine learning
 
-- [BigDL](https://github.com/intel-analytics/BigDL) (Distributed Deep Learning Framework for Apache Spark) for Apache Spark
+- [BigDL](https://github.com/intel-analytics/BigDL) (Distributed Deep Learning Framework for Apache Spark)
 - [TensorFlow Scala](https://github.com/eaplatanios/tensorflow_scala)
 
 


### PR DESCRIPTION
We can see 'for Apache Spark' twice on the page
https://docs.scala-lang.org/scala3/book/scala-features.html#ai-machine-learning

May be it's a typo?

