### PR TITLE
removed wrong variable(languages) from result

### DIFF
--- a/_overviews/scala3-book/taste-collections.md
+++ b/_overviews/scala3-book/taste-collections.md
@@ -103,8 +103,7 @@ You can also use this _extractor_ approach to assign the tuple fields to variabl
 val (num, str, person) = t
 
 // result:
-// val languages: [zh-cn]
-num: Int = 11
+// val num: Int = 11
 // val str: String = eleven
 // val person: Person = Person(Eleven)
 ```


### PR DESCRIPTION
The result of code section `val(num,str,person) = t` will give out only num,str and person. There is no `languages` val in Person class as well as the tuple, so removed it to prevent confusion.