### PR TITLE
Add assertions for formatting of code tabs

### DIFF
--- a/_overviews/contribute/add-guides.md
+++ b/_overviews/contribute/add-guides.md
@@ -111,7 +111,7 @@ can generate the same tabs in markdown with the `tabs` directive and class `tabs
 ~~~liquid
 {% tabs hello-world-demo class=tabs-scala-version %}
 
-{% tab 'Scala 2' for=hello-world-demo %}
+{% tab 'Scala 2' %}
 ```scala
 object hello extends App {
   println("Hello, World!")
@@ -119,7 +119,7 @@ object hello extends App {
 ```
 {% endtab %}
 
-{% tab 'Scala 3' for=hello-world-demo %}
+{% tab 'Scala 3' %}
 ```scala
 @main def hello() = println("Hello, World!")
 ```
@@ -134,17 +134,30 @@ It is crucial that you use the `tabs-scala-version` class to benefit from some c
 - the tab picked will be remembered across the site, and when the user returns to the page after some time.
 
 For code snippets that are valid in both Scala 2 and Scala 3, please use a single tab labelled
-“Scala 2 and 3” (please note that the `tabs-scala-version` class is also dropped):
+`'Scala 2 and 3'` (please note that the `tabs-scala-version` class is also dropped):
 
 <!-- {% raw  %} -->
 ~~~liquid
 {% tabs scala-2-and-3-demo %}
-{% tab 'Scala 2 and 3' for=scala-2-and-3-demo %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 List(1, 2, 3).map(x => x + 1).sum
 ```
 {% endtab %}
 {% endtabs %}
+~~~
+<!-- {% endraw  %} -->
+
+For examples that only apply to either one of Scala 2 or 3, use the tabs `'Scala 2 Only'` and `'Scala 3 Only'`.
+
+If you have a particularly long tab, for readability you can indicate which tab group it belongs to with
+a parameter `for=tab-group` as in this example:
+<!-- {% raw  %} -->
+~~~liquid
+{% tabs my-tab-group class=tabs-scala-version %}
+...
+{% tab 'Scala 3' for=my-tab-group %}
+...
 ~~~
 <!-- {% endraw  %} -->
 

--- a/_overviews/scala3-book/taste-vars-data-types.md
+++ b/_overviews/scala3-book/taste-vars-data-types.md
@@ -37,7 +37,7 @@ When you create a new variable in Scala, you declare whether the variable is imm
 These examples show how to create `val` and `var` variables:
 
 {% tabs var-express-1 %}
-{% tab 'Scala 2 and 3' for=var-express-1 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 // immutable
@@ -53,7 +53,7 @@ In an application, a `val` can’t be reassigned.
 You’ll cause a compiler error if you try to reassign one:
 
 {% tabs var-express-2 %}
-{% tab 'Scala 2 and 3' for=var-express-2 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 val msg = "Hello, world"
@@ -65,7 +65,7 @@ msg = "Aloha"   // "reassignment to val" error; this won’t compile
 Conversely, a `var` can be reassigned:
 
 {% tabs var-express-3 %}
-{% tab 'Scala 2 and 3' for=var-express-3 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 var msg = "Hello, world"
@@ -79,7 +79,7 @@ msg = "Aloha"   // this compiles because a var can be reassigned
 When you create a variable you can explicitly declare its type, or let the compiler infer the type:
 
 {% tabs var-express-4 %}
-{% tab 'Scala 2 and 3' for=var-express-4 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 val x: Int = 1   // explicit
@@ -92,7 +92,7 @@ The second form is known as _type inference_, and it’s a great way to help kee
 The Scala compiler can usually infer the data type for you, as shown in the output of these REPL examples:
 
 {% tabs var-express-5 %}
-{% tab 'Scala 2 and 3' for=var-express-5 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 scala> val x = 1
@@ -110,7 +110,7 @@ val nums: List[Int] = List(1, 2, 3)
 You can always explicitly declare a variable’s type if you prefer, but in simple assignments like these it isn’t necessary:
 
 {% tabs var-express-6 %}
-{% tab 'Scala 2 and 3' for=var-express-6 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 val x: Int = 1
@@ -134,7 +134,7 @@ In Scala, everything is an object.
 These examples show how to declare variables of the numeric types:
 
 {% tabs var-express-7 %}
-{% tab 'Scala 2 and 3' for=var-express-7 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 val b: Byte = 1
@@ -150,7 +150,7 @@ val f: Float = 3.0
 Because `Int` and `Double` are the default numeric types, you typically create them without explicitly declaring the data type:
 
 {% tabs var-express-8 %}
-{% tab 'Scala 2 and 3' for=var-express-8 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 val i = 123   // defaults to Int
@@ -162,7 +162,7 @@ val j = 1.0   // defaults to Double
 In your code you can also append the characters `L`, `D`, and `F` (and their lowercase equivalents) to numbers to specify that they are `Long`, `Double`, or `Float` values:
 
 {% tabs var-express-9 %}
-{% tab 'Scala 2 and 3' for=var-express-9 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 val x = 1_000L   // val x: Long = 1000
@@ -175,7 +175,7 @@ val z = 3.3F     // val z: Float = 3.3
 When you need really large numbers, use the `BigInt` and `BigDecimal` types:
 
 {% tabs var-express-10 %}
-{% tab 'Scala 2 and 3' for=var-express-10 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 var a = BigInt(1_234_567_890_987_654_321L)
@@ -189,7 +189,7 @@ Where `Double` and `Float` are approximate decimal numbers, `BigDecimal` is used
 Scala also has `String` and `Char` data types:
 
 {% tabs var-express-11 %}
-{% tab 'Scala 2 and 3' for=var-express-11 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 val name = "Bill"   // String
@@ -211,7 +211,7 @@ String interpolation provides a very readable way to use variables inside string
 For instance, given these three variables:
 
 {% tabs var-express-12 %}
-{% tab 'Scala 2 and 3' for=var-express-12 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 val firstName = "John"
@@ -224,7 +224,7 @@ val lastName = "Doe"
 You can combine those variables in a string like this:
 
 {% tabs var-express-13 %}
-{% tab 'Scala 2 and 3' for=var-express-13 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 println(s"Name: $firstName $mi $lastName")   // "Name: John C Doe"
@@ -237,7 +237,7 @@ Just precede the string with the letter `s`, and then put a `$` symbol before yo
 To embed arbitrary expressions inside a string, enclose them in curly braces:
 
 {% tabs var-express-14 %}
-{% tab 'Scala 2 and 3' for=var-express-14 %}
+{% tab 'Scala 2 and 3' %}
 
 ``` scala
 println(s"2 + 2 = ${2 + 2}")   // prints "2 + 2 = 4"
@@ -258,7 +258,7 @@ For instance, some database libraries define the very powerful `sql` interpolato
 Multiline strings are created by including the string inside three double-quotes:
 
 {% tabs var-express-15 %}
-{% tab 'Scala 2 and 3' for=var-express-15 %}
+{% tab 'Scala 2 and 3' %}
 
 ```scala
 val quote = """The essence of Scala:

--- a/_overviews/scala3-book/taste-vars-data-types.md
+++ b/_overviews/scala3-book/taste-vars-data-types.md
@@ -36,7 +36,7 @@ When you create a new variable in Scala, you declare whether the variable is imm
 
 These examples show how to create `val` and `var` variables:
 
-{% tabs var-express-1 class=tabs-scala-version %}
+{% tabs var-express-1 %}
 {% tab 'Scala 2 and 3' for=var-express-1 %}
 
 ```scala
@@ -52,7 +52,7 @@ var b = 1
 In an application, a `val` can’t be reassigned.
 You’ll cause a compiler error if you try to reassign one:
 
-{% tabs var-express-2 class=tabs-scala-version %}
+{% tabs var-express-2 %}
 {% tab 'Scala 2 and 3' for=var-express-2 %}
 
 ```scala
@@ -64,7 +64,7 @@ msg = "Aloha"   // "reassignment to val" error; this won’t compile
 
 Conversely, a `var` can be reassigned:
 
-{% tabs var-express-3 class=tabs-scala-version %}
+{% tabs var-express-3 %}
 {% tab 'Scala 2 and 3' for=var-express-3 %}
 
 ```scala
@@ -78,7 +78,7 @@ msg = "Aloha"   // this compiles because a var can be reassigned
 
 When you create a variable you can explicitly declare its type, or let the compiler infer the type:
 
-{% tabs var-express-4 class=tabs-scala-version %}
+{% tabs var-express-4 %}
 {% tab 'Scala 2 and 3' for=var-express-4 %}
 
 ```scala
@@ -91,7 +91,7 @@ val x = 1        // implicit; the compiler infers the type
 The second form is known as _type inference_, and it’s a great way to help keep this type of code concise.
 The Scala compiler can usually infer the data type for you, as shown in the output of these REPL examples:
 
-{% tabs var-express-5 class=tabs-scala-version %}
+{% tabs var-express-5 %}
 {% tab 'Scala 2 and 3' for=var-express-5 %}
 
 ```scala
@@ -109,7 +109,7 @@ val nums: List[Int] = List(1, 2, 3)
 
 You can always explicitly declare a variable’s type if you prefer, but in simple assignments like these it isn’t necessary:
 
-{% tabs var-express-6 class=tabs-scala-version %}
+{% tabs var-express-6 %}
 {% tab 'Scala 2 and 3' for=var-express-6 %}
 
 ```scala
@@ -133,7 +133,7 @@ In Scala, everything is an object.
 
 These examples show how to declare variables of the numeric types:
 
-{% tabs var-express-7 class=tabs-scala-version %}
+{% tabs var-express-7 %}
 {% tab 'Scala 2 and 3' for=var-express-7 %}
 
 ```scala
@@ -149,7 +149,7 @@ val f: Float = 3.0
 
 Because `Int` and `Double` are the default numeric types, you typically create them without explicitly declaring the data type:
 
-{% tabs var-express-8 class=tabs-scala-version %}
+{% tabs var-express-8 %}
 {% tab 'Scala 2 and 3' for=var-express-8 %}
 
 ```scala
@@ -161,7 +161,7 @@ val j = 1.0   // defaults to Double
 
 In your code you can also append the characters `L`, `D`, and `F` (and their lowercase equivalents) to numbers to specify that they are `Long`, `Double`, or `Float` values:
 
-{% tabs var-express-9 class=tabs-scala-version %}
+{% tabs var-express-9 %}
 {% tab 'Scala 2 and 3' for=var-express-9 %}
 
 ```scala
@@ -174,7 +174,7 @@ val z = 3.3F     // val z: Float = 3.3
 
 When you need really large numbers, use the `BigInt` and `BigDecimal` types:
 
-{% tabs var-express-10 class=tabs-scala-version %}
+{% tabs var-express-10 %}
 {% tab 'Scala 2 and 3' for=var-express-10 %}
 
 ```scala
@@ -188,7 +188,7 @@ Where `Double` and `Float` are approximate decimal numbers, `BigDecimal` is used
 
 Scala also has `String` and `Char` data types:
 
-{% tabs var-express-11 class=tabs-scala-version %}
+{% tabs var-express-11 %}
 {% tab 'Scala 2 and 3' for=var-express-11 %}
 
 ```scala
@@ -210,7 +210,7 @@ Scala strings are similar to Java strings, but they have two great additional fe
 String interpolation provides a very readable way to use variables inside strings.
 For instance, given these three variables:
 
-{% tabs var-express-12 class=tabs-scala-version %}
+{% tabs var-express-12 %}
 {% tab 'Scala 2 and 3' for=var-express-12 %}
 
 ```scala
@@ -223,7 +223,7 @@ val lastName = "Doe"
 
 You can combine those variables in a string like this:
 
-{% tabs var-express-13 class=tabs-scala-version %}
+{% tabs var-express-13 %}
 {% tab 'Scala 2 and 3' for=var-express-13 %}
 
 ```scala
@@ -236,7 +236,7 @@ Just precede the string with the letter `s`, and then put a `$` symbol before yo
 
 To embed arbitrary expressions inside a string, enclose them in curly braces:
 
-{% tabs var-express-14 class=tabs-scala-version %}
+{% tabs var-express-14 %}
 {% tab 'Scala 2 and 3' for=var-express-14 %}
 
 ``` scala
@@ -257,7 +257,7 @@ For instance, some database libraries define the very powerful `sql` interpolato
 
 Multiline strings are created by including the string inside three double-quotes:
 
-{% tabs var-express-15 class=tabs-scala-version %}
+{% tabs var-express-15 %}
 {% tab 'Scala 2 and 3' for=var-express-15 %}
 
 ```scala

--- a/_plugins/jekyll-tabs-lib/jekyll-tabs-4scala.rb
+++ b/_plugins/jekyll-tabs-lib/jekyll-tabs-4scala.rb
@@ -43,8 +43,13 @@ module Jekyll
             def render(context)
                 environment = context.environments.first
                 environment["tabs-#{@name}"] = [] # reset every time (so page translations can use the same name)
-                super
-
+                if environment["CURRENT_TABS_ENV"].nil?
+                    environment["CURRENT_TABS_ENV"] = @name
+                else
+                    raise SyntaxError.new("Nested tabs are not supported")
+                end
+                super # super call renders the internal content
+                environment["CURRENT_TABS_ENV"] = nil # reset after rendering
                 foundDefault = false
 
                 allTabs = environment["tabs-#{@name}"]
@@ -87,7 +92,7 @@ module Jekyll
         class TabBlock < Liquid::Block
             alias_method :render_block, :render
 
-            SYNTAX = /^\s*(#{Liquid::QuotedFragment})\s+(?:for=(#{Liquid::QuotedFragment}))(?:\s+(defaultTab))?/o
+            SYNTAX = /^\s*(#{Liquid::QuotedFragment})\s+(?:for=(#{Liquid::QuotedFragment}))?(?:\s+(defaultTab))?/o
             Syntax = SYNTAX
 
             def initialize(block_name, markup, tokens)
@@ -95,7 +100,9 @@ module Jekyll
 
                 if markup =~ SYNTAX
                     @tab = Tabs::unquote($1)
-                    @name = Tabs::unquote($2)
+                    if $2
+                        @name = Tabs::unquote($2)
+                    end
                     @anchor = Tabs::asAnchor(@tab)
                     if $3
                         @defaultTab = true
@@ -113,8 +120,16 @@ module Jekyll
                 content = converter.convert(pre_content)
                 tabcontent = TabDetails.new(label: @tab, anchor: @anchor, defaultTab: @defaultTab, content: content)
                 environment = context.environments.first
-                environment["tabs-#{@name}"] ||= []
-                environment["tabs-#{@name}"] << tabcontent
+                tab_env = environment["CURRENT_TABS_ENV"]
+                if tab_env.nil?
+                    raise SyntaxError.new("Tab block '#{tabcontent.label}' must be inside a tabs block")
+                end
+                if !@name.nil? && tab_env != @name
+                    raise SyntaxError.new(
+                        "Tab block '#{@tab}' for=#{@name} does not match its enclosing tabs block #{tab_env}")
+                end
+                environment["tabs-#{tab_env}"] ||= []
+                environment["tabs-#{tab_env}"] << tabcontent
             end
         end
     end

--- a/_tour/higher-order-functions.md
+++ b/_tour/higher-order-functions.md
@@ -16,12 +16,12 @@ The terminology can get a bit confusing at this point, and we use the phrase
 "higher order function" for both methods and functions that take functions as parameters
 or that return a function.
 
-In a pure Object Oriented world a good practice is to avoid exposing methods parameterized with functions that might leak object's internal state. Leaking internal state might break the invariants of the object itself thus violating encapsulation. 
+In a pure Object Oriented world a good practice is to avoid exposing methods parameterized with functions that might leak object's internal state. Leaking internal state might break the invariants of the object itself thus violating encapsulation.
 
 One of the most common examples is the higher-order
 function `map` which is available for collections in Scala.
 
-{% tabs map_example_1 class=tabs-scala-version %}
+{% tabs map_example_1 %}
 
 {% tab 'Scala 2 and 3' for=map_example_1 %}
 ```scala mdoc:nest
@@ -39,7 +39,7 @@ list of salaries.
 To shrink the code, we could make the function anonymous and pass it directly as
 an argument to map:
 
-{% tabs map_example_2 class=tabs-scala-version %}
+{% tabs map_example_2 %}
 
 {% tab 'Scala 2 and 3' for=map_example_2 %}
 ```scala mdoc:nest
@@ -53,7 +53,7 @@ val newSalaries = salaries.map(x => x * 2) // List(40000, 140000, 80000)
 Notice how `x` is not declared as an Int in the above example. That's because the
 compiler can infer the type based on the type of function map expects (see [Currying](/tour/multiple-parameter-lists.html)). An even more idiomatic way to write the same piece of code would be:
 
-{% tabs map_example_3 class=tabs-scala-version %}
+{% tabs map_example_3 %}
 
 {% tab 'Scala 2 and 3' for=map_example_3 %}
 ```scala mdoc:nest

--- a/_zh-cn/overviews/scala3-book/why-scala-3.md
+++ b/_zh-cn/overviews/scala3-book/why-scala-3.md
@@ -43,7 +43,7 @@ Scala 比任何其他语言都更支持 FP 和 OOP 范式的融合。
 例如，`List` 被定义为一个类---从技术上讲，它是一个抽象类---并且像这样创建了一个新实例：
 
 {% tabs list %}
-{% tab 'Scala 2 and 3' for=list %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 val x = List(1, 2, 3)
 ```
@@ -55,8 +55,8 @@ val x = List(1, 2, 3)
 
 除了从一系列模块化 traits 构建/cases像 `List` 这样的类型之外，`List` API还包含数十种其他方法，其中许多是高阶函数：
 
-{% tabs list %}
-{% tab 'Scala 2 and 3' for=list-methods %}
+{% tabs list-methods %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 val xs = List(1, 2, 3, 4, 5)
 
@@ -76,8 +76,8 @@ xs.takeWhile(_ < 3)   // List(1, 2)
 Scala的 _类型推断_ 经常使语言感觉是动态类型的，即使它是静态类型的。
 对于变量声明，情况确实如此：
 
-{% tabs list %}
-{% tab 'Scala 2 and 3' for=dynamic %}
+{% tabs dynamic %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 val a = 1
 val b = "Hello, world"
@@ -89,8 +89,8 @@ val stuff = ("fish", 42, 1_234.5)
 
 当把匿名函数传递给高阶函数时，情况也是如此：
 
-{% tabs list %}
-{% tab 'Scala 2 and 3' for=dynamic-hof %}
+{% tabs dynamic-hof %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 list.filter(_ < 4)
 list.map(_ * 2)
@@ -102,8 +102,8 @@ list.filter(_ < 4)
 
 还有定义方法的时候：
 
-{% tabs list %}
-{% tab 'Scala 2 and 3' for=list-method %}
+{% tabs list-method %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 def add(a: Int, b: Int) = a + b
 ```
@@ -113,7 +113,7 @@ def add(a: Int, b: Int) = a + b
 这在Scala 3中比以往任何时候都更加真实，例如在使用[union types][union-types] 时：
 
 {% tabs union %}
-{% tab 'Scala 3 Only' for=union %}
+{% tab 'Scala 3 Only' %}
 ```scala
 // union type parameter
 def help(id: Username | Password) =
@@ -132,8 +132,8 @@ val b: Password | Username = if (true) name else password
 
 Scala是一种 low ceremony，“简洁但仍然可读”的语言。例如，变量声明是简洁的：
 
-{% tabs list %}
-{% tab 'Scala 2 and 3' for=concise %}
+{% tabs concise %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 val a = 1
 val b = "Hello, world"
@@ -145,7 +145,7 @@ val c = List(1,2,3)
 创建类型如traits, 类和枚举都很简洁：
 
 {% tabs enum %}
-{% tab 'Scala 3 Only' for=enum %}
+{% tab 'Scala 3 Only' %}
 ```scala
 trait Tail:
   def wagTail(): Unit
@@ -168,7 +168,7 @@ case class Person(
 简洁的高阶函数：
 
 {% tabs list-hof %}
-{% tab 'Scala 2 and 3' for=list-hof %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 list.filter(_ < 4)
 list.map(_ * 2)
@@ -251,8 +251,8 @@ Scala.js 生态系统 [有几十个库](https://www.scala-js.org/libraries) 让�
 
 这里有些例子：
 
-{% tabs list %}
-{% tab 'Scala 2 and 3' for=list-more %}
+{% tabs list-more %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 List.range(1, 3)                          // List(1, 2)
 List.range(start = 1, end = 6, step = 2)  // List(1, 3, 5)
@@ -299,8 +299,8 @@ nums.sortWith(_ > _)                      // List(10, 8, 7, 5, 1)
 Scala 习语以多种方式鼓励最佳实践。
 对于不可变性，我们鼓励您创建不可变的 `val` 声明：
 
-{% tabs list %}
-{% tab 'Scala 2 and 3' for=val %}
+{% tabs val %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 val a = 1 // 不可变变量
 ```
@@ -309,8 +309,8 @@ val a = 1 // 不可变变量
 
 还鼓励您使用不可变集合类，例如 `List` 和 `Map`：
 
-{% tabs list %}
-{% tab 'Scala 2 and 3' for=list-map %}
+{% tabs list-map  %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 val b = List(1,2,3)       // List 是不可变的
 val c = Map(1 -> "one")   // Map 是不可变的
@@ -320,8 +320,8 @@ val c = Map(1 -> "one")   // Map 是不可变的
 
 样例类主要用于 [领域建模]({% link _zh-cn/overviews/scala3-book/domain-modeling-intro.md %})，它们的参数是不可变的：
 
-{% tabs list %}
-{% tab 'Scala 2 and 3' for=case-class %}
+{% tabs case-class %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 case class Person(name: String)
 val p = Person("Michael Scott")
@@ -333,8 +333,8 @@ p.name = "Joe"  // 编译器错误（重新分配给 val 名称）
 
 如上一节所示，Scala 集合类支持高阶函数，您可以将方法（未显示）和匿名函数传递给它们：
 
-{% tabs list %}
-{% tab 'Scala 2 and 3' for=higher-order %}
+{% tabs higher-order %}
+{% tab 'Scala 2 and 3' %}
 ```scala
 a.dropWhile(_ < 25)
 a.filter(_ < 25)
@@ -349,7 +349,7 @@ nums.sortWith(_ > _)
 `match` 表达式让您可以使用模式匹配，它们确实是返回值的 _表达式_：
 
 {% tabs match class=tabs-scala-version %}
-{% tab 'Scala 2' for=match %}
+{% tab 'Scala 2' %}
 ```scala
 val numAsString = i match {
   case 1 | 3 | 5 | 7 | 9 => "odd"
@@ -359,7 +359,7 @@ val numAsString = i match {
 ```
 {% endtab %}
 
-{% tab 'Scala 3' for=match %}
+{% tab 'Scala 3' %}
 ```scala
 val numAsString = i match
   case 1 | 3 | 5 | 7 | 9 => "odd"
@@ -372,7 +372,7 @@ val numAsString = i match
 因为它们可以返回值，所以它们经常被用作方法的主体：
 
 {% tabs match-body class=tabs-scala-version %}
-{% tab 'Scala 2' for=match-body %}
+{% tab 'Scala 2' %}
 ```scala
 def isTruthy(a: Matchable) = a match {
   case 0 | "" => false
@@ -381,7 +381,7 @@ def isTruthy(a: Matchable) = a match {
 ```
 {% endtab %}
 
-{% tab 'Scala 3' for=match-body %}
+{% tab 'Scala 3' %}
 ```scala
 def isTruthy(a: Matchable) = a match
   case 0 | "" => false
@@ -457,7 +457,7 @@ _安全_ 与几个新的和改变的特性有关：
 _人体工程学_ 的好例子是枚举和扩展方法，它们以非常易读的方式添加到 Scala 3 中：
 
 {% tabs extension %}
-{% tab 'Scala 3 Only' for=extension %}
+{% tab 'Scala 3 Only' %}
 ```scala
 // 枚举
 enum Color:


### PR DESCRIPTION
update the plugin to validate:
- no duplicate tab labels
- when using `class=tabs-scala-version`, validate that only `Scala 2` and `Scala 3` are used as tab labels
- validate that tab with `for=my-tab-group` is in a tab group called `my-tab-group`

I've also made it optional to put `for=my-tab-group` on each tab, now we track the enclosing tab-group.

Adding these assertions exposed some formatting problems with already merged updates to docs - so it would be good to add this asap