### PR TITLE
JDK compat page: add JDK 20 (early access)

### DIFF
--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -12,10 +12,11 @@ Sometimes new JVM and JDK (Java Development Kit) versions require us to update S
 
 | JDK version | Minimum Scala versions                                       |
 |:-----------:|:-------------------------------------------------------------|
+| 20 (ea)     | 3.2.2 (forthcoming), 2.13.11 (forthcoming), 2.12.18 (forthcoming) |
 | 19          | 3.2.0, 2.13.9, 2.12.16                                       |
 | 18          | 3.1.3, 2.13.7, 2.12.15                                       |
-| 17          | 3.0.0, 2.13.6, 2.12.15                                       |
-| 11          | 3.0.0, 2.13.0, 2.12.4, 2.11.12                               |
+| 17 (LTS)    | 3.0.0, 2.13.6, 2.12.15                                       |
+| 11 (LTS)    | 3.0.0, 2.13.0, 2.12.4, 2.11.12                               |
 | 8           | 3.0.0, 2.13.0, 2.12.0, 2.11.0                                |
 
 **Using latest patch version is always recommended**
@@ -91,14 +92,13 @@ JDK 19, a non-LTS release, came out in September 2022.
 
 Support for JDK 19 was included in Scala 2.13.9 and 2.12.16.
 
-<!--
 ## JDK 20 compatibility notes
 
 Early access builds of JDK 20, a non-LTS release, are already available.
 
-Initial support for JDK 20 was included in Scala 2.12.???, Scala 2.13.???,
-and Scala 3.2.???.
--->
+Initial support for JDK 20 has been merged and is already available in
+nightly builds of Scala 2.12, 2.13, and 3.  (The support will be
+included in forthcoming Scala releases: 2.12.18, 2.13.11, and 3.2.2.)
 
 ## GraalVM Native Image compatibility notes
 

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -17,7 +17,7 @@ Sometimes new JVM and JDK (Java Development Kit) versions require us to update S
 | 18          | 3.1.3, 2.13.7, 2.12.15                                       |
 | 17 (LTS)    | 3.0.0, 2.13.6, 2.12.15                                       |
 | 11 (LTS)    | 3.0.0, 2.13.0, 2.12.4, 2.11.12                               |
-| 8           | 3.0.0, 2.13.0, 2.12.0, 2.11.0                                |
+| 8 (LTS)     | 3.0.0, 2.13.0, 2.12.0, 2.11.0                                |
 
 **Using latest patch version is always recommended**
 

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -12,7 +12,7 @@ Sometimes new JVM and JDK (Java Development Kit) versions require us to update S
 
 | JDK version | Minimum Scala versions                                       |
 |:-----------:|:-------------------------------------------------------------|
-| 20 (ea)     | 3.2.2 (forthcoming), 2.13.11 (forthcoming), 2.12.18 (forthcoming) |
+| 20 (ea)     | 3.3.0 (forthcoming), 2.13.11 (forthcoming), 2.12.18 (forthcoming) |
 | 19          | 3.2.0, 2.13.9, 2.12.16                                       |
 | 18          | 3.1.3, 2.13.7, 2.12.15                                       |
 | 17 (LTS)    | 3.0.0, 2.13.6, 2.12.15                                       |
@@ -98,7 +98,7 @@ Early access builds of JDK 20, a non-LTS release, are already available.
 
 Initial support for JDK 20 has been merged and is already available in
 nightly builds of Scala 2.12, 2.13, and 3.  (The support will be
-included in forthcoming Scala releases: 2.12.18, 2.13.11, and 3.2.2.)
+included in forthcoming Scala releases: 2.12.18, 2.13.11, and 3.3.0.)
 
 ## GraalVM Native Image compatibility notes
 


### PR DESCRIPTION
Marking as draft for now until we hear from Paweł (at https://github.com/lampepfl/dotty/pull/16155) about whether the ASM 9.4 upgrade could make 3.2.2 or must wait for 3.2.3.

If that remains unclear for more than a few days, we could merge this anyway and then change it later. :-)