### PR TITLE
Fix the Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM ruby:2.6
+FROM ruby:2.6.9
 
-RUN gem install bundler jekyll
+RUN gem install rouge -v3.30.0
+RUN gem install bundler:2.3.10 jekyll
 
 WORKDIR /srv/jekyll
 
 COPY Gemfile .
 COPY Gemfile.lock .
 
+RUN echo -n "bundle version: " && bundle --version
+RUN chmod u+s /bin/chown
 RUN bundle install
-

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ For more details, read on.
 
 To build and view site with Docker:
 
-    docker-compose up
+    env UID="$(id -u)" GID="$(id -g)" docker-compose up
 
 It will incrementally build and serve site at `http://localhost:4000`.
+
+In case the Dockerfile changed, re-build it with:
+
+    env UID="$(id -u)" GID="$(id -g)" docker-compose up --build
 
 For more details on the Docker option, see [this issue](https://github.com/scala/docs.scala-lang/issues/1286).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
-version: "2"
+version: '2'
+
 services:
-  scala-lang:
+  jekyll:
+    user: "${UID}:${GID}"
     build: .
-    command: bundle exec jekyll serve --incremental --host=0.0.0.0
+    command: sh -c "chown $UID / && bundle exec jekyll serve --incremental --host=0.0.0.0 "
     ports:
-      - 4000:4000
+      - '4000:4000'
     volumes:
       - .:/srv/jekyll


### PR DESCRIPTION
I found that our previous Docker setup was not good enough and was failing on some machines.

I propose the following changes, based on what has been done on the scala.epfl.ch website. The main “fix” is that we indicate a specific version of Ruby, rouge, and bundler. We also propose a different way to invoke docker-compose up that writes the generated files as a regular user (instead of root).