### PR TITLE
Update default jekyll tab

### DIFF
--- a/_layouts/multipage-overview.html
+++ b/_layouts/multipage-overview.html
@@ -17,6 +17,12 @@ includeCollectionTOC: true
 						{% endif %}
 						{% include version-specific-notice.html language=versionSpecificLang %}
 					{% endif %}
+					<noscript>
+						<blockquote>
+							<span style="font-weight: bold;">Info:</span> JavaScript is currently disabled, code tabs will still work,
+							but preferences will not be remembered.
+						</blockquote>
+					</noscript>
 					{{content}}
 				</div>
 

--- a/_layouts/singlepage-overview.html
+++ b/_layouts/singlepage-overview.html
@@ -16,6 +16,12 @@ includeTOC: true
 						{% endif %}
 						{% include version-specific-notice.html language=versionSpecificLang %}
 					{% endif %}
+					<noscript>
+						<blockquote>
+							<span style="font-weight: bold;">Info:</span> JavaScript is currently disabled, code tabs will still work,
+							but preferences will not be remembered.
+						</blockquote>
+					</noscript>
 					{{content}}
 				</div>
 

--- a/_overviews/scala3-book/taste-hello-world.md
+++ b/_overviews/scala3-book/taste-hello-world.md
@@ -9,7 +9,6 @@ next-page: taste-repl
 ---
 
 > **Hint**: in the following examples try picking your preferred Scala version.
-> <noscript><span style="font-weight: bold;">Info</span>: JavaScript is currently disabled, code tabs will still work, but preferences will not be remembered.</noscript>
 
 ## Your First Scala Program
 
@@ -149,7 +148,7 @@ import scala.io.StdIn.readLine
 <!-- End tabs -->
 
 In this code we save the result of `readLine` to a variable called `name`, we then
-use the `+` operator on strings to join `"Hello, "` with `name` and `"!"`, making one single string value. 
+use the `+` operator on strings to join `"Hello, "` with `name` and `"!"`, making one single string value.
 
 > You can learn more about using `val` by reading [Variables and Data Types](/scala3/book/taste-vars-data-types.html).
 

--- a/_plugins/jekyll-tabs-lib/jekyll-tabs-4scala.rb
+++ b/_plugins/jekyll-tabs-lib/jekyll-tabs-4scala.rb
@@ -67,8 +67,8 @@ module Jekyll
                 end
 
                 if !foundDefault and allTabs.length > 0
-                    # set last tab to default
-                    allTabs[-1].defaultTab = true
+                    # set first tab to default
+                    allTabs[0].defaultTab = true
                 end
 
                 if @is_scala_tabs

--- a/_plugins/jekyll-tabs-lib/jekyll-tabs-4scala.rb
+++ b/_plugins/jekyll-tabs-lib/jekyll-tabs-4scala.rb
@@ -3,7 +3,7 @@ require 'erb'
 module Jekyll
     module Tabs
 
-        ScalaVersions = Set.new ['Scala 2', 'Scala 3']
+        ScalaVersions = ['Scala 2', 'Scala 3']
 
         def self.unquote(string)
             string.gsub(/^['"]|['"]$/, '')
@@ -54,32 +54,55 @@ module Jekyll
 
                 allTabs = environment["tabs-#{@name}"]
 
-                seenTabs = Set.new
+                seenTabs = []
+
+                def joinScalaVersions()
+                    Tabs::ScalaVersions.to_a.map{|item| "'#{item}'"}.join(", ")
+                end
+
+                def errorNonScalaVersion(tab)
+                    SyntaxError.new(
+                        "Scala version tab label '#{tab.label}' is not valid for tabs '#{@name}' with " +
+                        "class=tabs-scala-version. Valid tab labels are: #{joinScalaVersions()}")
+                end
+
+                def errorScalaVersionWithoutClass(tab)
+                    SyntaxError.new(
+                        "Scala version tab label '#{tab.label}' is not valid for tabs '#{@name}' without " +
+                        "class=tabs-scala-version")
+                end
+
+                def errorMissingScalaVersion()
+                    SyntaxError.new(
+                        "Tabs '#{@name}' with class=tabs-scala-version must have exactly the following " +
+                        "tab labels: #{joinScalaVersions()}")
+                end
 
                 allTabs.each do | tab |
                     if seenTabs.include? tab.label
                         raise SyntaxError.new("Duplicate tab label '#{tab.label}' in tabs '#{@name}'")
                     end
-                    seenTabs.add tab.label
+                    seenTabs.push tab.label
                     if tab.defaultTab
                         foundDefault = true
                     end
+
+                    isScalaTab = Tabs::ScalaVersions.include? tab.label
+
+                    if @is_scala_tabs and !isScalaTab
+                        raise errorNonScalaVersion(tab)
+                    elsif !@is_scala_tabs and isScalaTab
+                        raise errorScalaVersionWithoutClass(tab)
+                    end
+                end
+
+                if @is_scala_tabs and seenTabs != Tabs::ScalaVersions
+                    raise errorMissingScalaVersion()
                 end
 
                 if !foundDefault and allTabs.length > 0
                     # set first tab to default
                     allTabs[0].defaultTab = true
-                end
-
-                if @is_scala_tabs
-                    allTabs.each do | tab |
-                        if !Tabs::ScalaVersions.include?(tab.label)
-                            joined_versions = Tabs::ScalaVersions.to_a.map{|item| "'#{item}'"}.join(", ")
-                            raise SyntaxError.new(
-                                "Scala version tab label '#{tab.label}' is not valid for tabs '#{@name}' with " +
-                                "class=tabs-scala-version. Valid tab labels are: #{joined_versions}")
-                        end
-                    end
                 end
 
                 currentDirectory = File.dirname(__FILE__)


### PR DESCRIPTION
- sets the initial tab to be the default (unless specified, or class=tabs-scala-version)
- add notice to all overviews that code tabs still work when javascript is disabled
- validate that `class=tabs-scala-version` implies exactly `'Scala 2'`, `'Scala 3'` tabs in that order

fixes https://github.com/scalacenter/docs.scala-lang/issues/12