### PR TITLE
Fix orphan translation

### DIFF
--- a/_includes/sidebar-toc-multipage-overview.html
+++ b/_includes/sidebar-toc-multipage-overview.html
@@ -40,6 +40,7 @@
         {% endfor %}
       </ul>
 
+      {% assign orphanTranslation = page.orphanTranslation | default: false %}
       {% if page.languages %}
         <ul id="available-languages" style="display: none;">
           <li><a href="{{ site.baseurl }}{{ page.url }}">English</a></li>
@@ -50,7 +51,7 @@
             <li><a href="{{ site.baseurl }}/{{ l }}/{{ rootTutorialURL }}" class="lang">{{ lang.name }}</a></li>
           {% endfor %}
         </ul>
-      {% elsif page.language and page.orphanTranslation == false %}
+      {% elsif page.language and orphanTranslation == false %}
         <!-- i.e. some pages like '/zh-cn/thanks.html' have no english version -->
         {% assign engPath = page.id | remove_first: "/" | remove_first: page.language | append: '.html' %}
         {% assign engPg = site.overviews | where: 'partof', page.partof | first %}

--- a/_includes/sidebar-toc-singlepage-overview.html
+++ b/_includes/sidebar-toc-singlepage-overview.html
@@ -3,6 +3,7 @@
 		<h5 class="contents">Contents</h5>
 		<div class="inner-toc" id="sidebar-toc">
       <div id="toc"></div>
+      {% assign orphanTranslation = page.orphanTranslation | default: false %}
       {% if page.languages %}
         <ul id="available-languages" style="display: none;">
           <li><a href="{{ site.baseurl }}{{ page.url }}">English</a></li>
@@ -13,7 +14,7 @@
             <li><a href="{{ site.baseurl }}/{{ l }}/{{ rootTutorialURL }}" class="lang">{{ lang.name }}</a></li>
           {% endfor %}
         </ul>
-      {% elsif page.language and page.orphanTranslation == false %}
+      {% elsif page.language and orphanTranslation == false %}
         <!-- i.e. some pages like '/zh-cn/thanks.html' have no english version -->
         {% assign engPath = page.id | remove_first: "/" | remove_first: page.language | append: '.html' %}
         {% assign engPg = site.overviews | where: 'partof', page.partof | first %}


### PR DESCRIPTION
List of languages are missed on all translated pages.
For example: https://docs.scala-lang.org/ru/scala3/book/first-look-at-types.html

Maybe it's because of this commit:
https://github.com/scala/docs.scala-lang/pull/2634/commits/b6f198bf8d33bb3369efd17327bed0d4106e2b06

Fixed! Please, check it!