### PR TITLE
Add newest version for scala-parser-combinators

### DIFF
--- a/_overviews/getting-started/sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.md
+++ b/_overviews/getting-started/sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.md
@@ -88,7 +88,7 @@ extra functionality to our apps.
 1. Open up `build.sbt` and add the following line:
 
 ```
-libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1"
 ```
 Here, `libraryDependencies` is a set of dependencies, and by using `+=`,
 we're adding the [scala-parser-combinators](https://github.com/scala/scala-parser-combinators) dependency to the set of dependencies that sbt will go


### PR DESCRIPTION
The previous version suggested was causing compilation issues.