### PR TITLE
Fix actual label for the translated pages

### DIFF
--- a/_includes/sidebar-toc-multipage-overview.html
+++ b/_includes/sidebar-toc-multipage-overview.html
@@ -22,9 +22,9 @@
               {% for lpg in site.[page.language] %}
                 {% if lpg.id == localizedId %}
                   {% if pg.type %} <!-- if a type is set in a document, we add it as a class. Used in Scala book to diff between chapter and section -->
-                  <li class="type-{{ pg.type }}"><a {% if page.title == lpg.title %}class="active"{% endif %} href="{{ site.baseurl }}{{ pg.url }}">{{ lpg.title }}</a>{{ toc }}</li>
+                  <li class="type-{{ pg.type }}"><a {% if page.num == pg.num %}class="active"{% endif %} href="{{ site.baseurl }}{{ pg.url }}">{{ lpg.title }}</a>{{ toc }}</li>
                   {% else %}
-                  <li><a {% if page.title == lpg.title %}class="active"{% endif %} href="{{ site.baseurl }}{{ pg.url }}">{{ lpg.title }}</a>{{ toc }}</li>
+                  <li><a {% if page.num == pg.num %}class="active"{% endif %} href="{{ site.baseurl }}{{ pg.url }}">{{ lpg.title }}</a>{{ toc }}</li>
                   {% endif %}
                 {% endif %}
               {% endfor %}


### PR DESCRIPTION
[This commit](https://github.com/artemkorsakov/docs.scala-lang/commit/5a01937a15e806c3e2b832994d0bd13302f3ff69) fixed the following:

```
Fix multiple highlighted headlines in TOC
Previously, multiple equally named headlines were highlighted as the
current page, if the name was the same as on the actually current page.
This issued showed up in the book, where for instance "Summary" was used
more than once. Instead, here I am using the page ordinal instead of the
title.

It should be safe to assume that the page has a number, since otherwise
it would not show up in the TOC, IIUC.
```

But unfortunately only the English versions of the pages were corrected.

The bug remained in the other versions:
![Screenshot_1](https://user-images.githubusercontent.com/19820864/203710402-5830c1ee-cf75-4091-9187-56dd54288696.png)

Fixed for the translated pages.
