### PR TITLE
Scala tour add explanation for Scala 3 class instantiation

### DIFF
--- a/_tour/basics.md
+++ b/_tour/basics.md
@@ -272,7 +272,7 @@ class Greeter(prefix: String, suffix: String):
 
 The return type of the method `greet` is `Unit`, which signifies that there is nothing meaningful to return. It is used similarly to `void` in Java and C. (A difference is that, because every Scala expression must have some value, there is actually a singleton value of type Unit, written (). It carries no information.)
 
-You can make an instance of a class with the `new` keyword:
+In Scala 2 you can make an instance of a class with the `new` keyword. In Scala 3, however, the `new` keyword is not needed:
 
 {% tabs greeter-usage class=tabs-scala-version %}
 

--- a/_tour/basics.md
+++ b/_tour/basics.md
@@ -272,7 +272,7 @@ class Greeter(prefix: String, suffix: String):
 
 The return type of the method `greet` is `Unit`, which signifies that there is nothing meaningful to return. It is used similarly to `void` in Java and C. (A difference is that, because every Scala expression must have some value, there is actually a singleton value of type Unit, written (). It carries no information.)
 
-In Scala 2 you can make an instance of a class with the `new` keyword. In Scala 3, however, the `new` keyword is not needed:
+In Scala 2 you can make an instance of a class with the `new` keyword. In Scala 3, however, the `new` keyword is not needed thanks to [universal apply methods](https://docs.scala-lang.org/scala3/reference/other-new-features/creator-applications.html):
 
 {% tabs greeter-usage class=tabs-scala-version %}
 


### PR DESCRIPTION
The part of Scala tour about basics - classes was confusing for me and I had to search about it. So I changed the corresponding text to explain Scala 3 doesn't need `new` keyword.