### PR TITLE
Revert "Scope of name"

### DIFF
--- a/_overviews/FAQ/index.md
+++ b/_overviews/FAQ/index.md
@@ -321,27 +321,7 @@ In many cases one should instead write:
 
     ThisBuild / scalaVersion := "2.13.10"
 
-Conversely, you should not write:
-
-    ThisBuild / name := "sample"
-
-which will result in a warning:
-
-    [warn] there's a key that's not used by any other settings/tasks:
-    [warn]
-    [warn] * ThisBuild / name
-    [warn]   +- sample-project/build.sbt:11
-
-For your quick single-project build with bare settings, the minimal settings are:
-
-    scalaVersion := "2.13.10"
-    organization := "sampler"
-    version := "0.1"
-    name := "sample"          // must not be scoped to ThisBuild
-
-    scalacOptions ++= Seq("-Werror", "-Xlint")  // append to options
-
-Other possible solutions to provide a setting everywhere include:
+Other possibilities include:
 
 * the common settings pattern, where you put shared settings
   in a `val`, typically named `commonSettings`, and then


### PR DESCRIPTION
This reverts commit f19728cccca2d94782c2cd044aca4546815e2aab.

For context, see my remarks about the scope of the FAQ at https://github.com/scala/docs.scala-lang/pull/2657 .