### PR TITLE
Document the pattern for evolving case classes in a compatible manner

### DIFF
--- a/_overviews/scala3-book/domain-modeling-tools.md
+++ b/_overviews/scala3-book/domain-modeling-tools.md
@@ -1111,7 +1111,7 @@ As mentioned, case classes support functional programming (FP):
 
 Sometimes it is desirable to be able to change the definition of a case class (adding and/or removing fields) while still staying compatible with the users of the case class, i.e. not breaking the so called _binary compatibility_.
 
-To achieve that, use this pattern:
+To achieve that, follow this pattern:
  * make the constructor `private`
  * define `private` `unapply` function in the companion object
  * define `withXXX` methods on the case class that create a new instance with the respective field changed
@@ -1153,7 +1153,7 @@ object Person:
 {% endtab %}
 {% endtabs %}
 
-The original users can use the case class `Person` as before, all the methods that existed before are present after this change, thus the compatibility with them is maintained.
+The original users can use the case class `Person` as before, all the methods that existed before are present unmodified after this change, thus the compatibility with the users is maintained.
 
 A regular case class not following this pattern would break its users, because by adding a new field some methods (which could be used by somebody else) change, for example `copy` or the constructor itself.
 

--- a/_overviews/scala3-book/domain-modeling-tools.md
+++ b/_overviews/scala3-book/domain-modeling-tools.md
@@ -1107,56 +1107,6 @@ As mentioned, case classes support functional programming (FP):
   This process can be referred to as “update as you copy.”
 - Having an `unapply` method auto-generated for you also lets case classes be used in advanced ways with pattern matching.
 
-### Changing case class definition in a compatible manner
-
-Sometimes it is desirable to be able to change the definition of a case class (adding and/or removing fields) while still staying compatible with the users of the case class, i.e. not breaking the so called _binary compatibility_.
-
-To achieve that, follow this pattern:
- * make the constructor `private`
- * define `private` `unapply` function in the companion object
- * define `withXXX` methods on the case class that create a new instance with the respective field changed
- * define custom `apply` factory method(s) in the companion object (these can use the private constructor)
-
-Example:
-
-{% tabs case_class_compat_1 %}
-{% tab 'Scala 3 Only' %}
-
-```scala
-case class Person private (name: String, age: Int):
-  def withName(name: String) = copy(name = name)
-  def withAge(age: Int) = copy(age = age)
-
-object Person:
-  def apply(name: String, age: Int) = new Person(name, age)
-  private def unapply(p: Person) = p
-```
-{% endtab %}
-{% endtabs %}
-
-Later in time, you can ammend the original case class definition. You
- * add a new field `address`,
- * add a custom `withAddress` method and
- * add an `apply` factory method to the companion.
-
-{% tabs case_class_compat_2 %}
-{% tab 'Scala 3 Only' %}
-```scala
-case class Person private (name: String, age: Int, address: String = ""):
-  ...
-  def withAddress(address: String) = copy(address = address)
-
-object Person:
-  ...
-  def apply(name: String, age: Int, address: String) = new Person(name, age, address)
-```
-{% endtab %}
-{% endtabs %}
-
-The original users can use the case class `Person` as before, all the methods that existed before are present unmodified after this change, thus the compatibility with the users is maintained.
-
-A regular case class not following this pattern would break its users, because by adding a new field some methods (which could be used by somebody else) change, for example `copy` or the constructor itself.
-
 {% comment %}
 NOTE: We can use this following text, if desired. If it’s used, it needs to be updated a little bit.
 

--- a/_overviews/scala3-book/domain-modeling-tools.md
+++ b/_overviews/scala3-book/domain-modeling-tools.md
@@ -1107,6 +1107,56 @@ As mentioned, case classes support functional programming (FP):
   This process can be referred to as “update as you copy.”
 - Having an `unapply` method auto-generated for you also lets case classes be used in advanced ways with pattern matching.
 
+### Changing case class definition in a compatible manner
+
+Sometimes it is desirable to be able to change the definition of a case class (adding and/or removing fields) while still staying compatible with the users of the case class, i.e. not breaking the so called _binary compatibility_.
+
+To achieve that, use this pattern:
+ * make the constructor `private`
+ * define `private` `unapply` function in the companion object
+ * define `withXXX` methods on the case class that create a new instance with the respective field changed
+ * define custom `apply` factory method(s) in the companion object (these can use the private constructor)
+
+Example:
+
+{% tabs case_class_compat_1 %}
+{% tab 'Scala 3 Only' %}
+
+```scala
+case class Person private (name: String, age: Int):
+  def withName(name: String) = copy(name = name)
+  def withAge(age: Int) = copy(age = age)
+
+object Person:
+  def apply(name: String, age: Int) = new Person(name, age)
+  private def unapply(p: Person) = p
+```
+{% endtab %}
+{% endtabs %}
+
+Later in time, you can ammend the original case class definition. You
+ * add a new field `address`,
+ * add a custom `withAddress` method and
+ * add an `apply` factory method to the companion.
+
+{% tabs case_class_compat_2 %}
+{% tab 'Scala 3 Only' %}
+```scala
+case class Person private (name: String, age: Int, address: String = ""):
+  ...
+  def withAddress(address: String) = copy(address = address)
+
+object Person:
+  ...
+  def apply(name: String, age: Int, address: String) = new Person(name, age, address)
+```
+{% endtab %}
+{% endtabs %}
+
+The original users can use the case class `Person` as before, all the methods that existed before are present after this change, thus the compatibility with them is maintained.
+
+A regular case class not following this pattern would break its users, because by adding a new field some methods (which could be used by somebody else) change, for example `copy` or the constructor itself.
+
 {% comment %}
 NOTE: We can use this following text, if desired. If it’s used, it needs to be updated a little bit.
 

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -180,7 +180,7 @@ Sometimes, it is desirable to change the definition of a case class (adding and/
 To achieve that, follow this pattern:
  * make the constructor private (this also makes private the `copy` method of the class)
  * define a private `unapply` function in the companion object (note that by doing that the case class loses the ability to be used in an extractor pattern match)
- * define `withXXX` methods on the case class that create a new instance with the respective field changed
+ * for all the fields, define `withXXX` methods on the case class that create a new instance with the respective field changed
  * define custom `apply` factory method(s) in the companion object (these can use the private constructor)
 
 Example:

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -219,7 +219,7 @@ alice match
 ~~~
 Later in time, you can amend the original case class definition to, say, add an optional `address` field. You
  * add a new field `address` and a custom `withAddress` method,
- * add the former constructor signature as a secondary constructor, private to the companion object. This step is necessary because the public `apply` method in the companion object calls the former constructor, which was effectively public in the bytecode produced by the compiler.
+ * add the former constructor signature as a secondary constructor, private to the companion object. This step is necessary because the compilers currently emit the private constructors as public constructors in the bytecode (see [#12711](https://github.com/scala/bug/issues/12711) and [#16651](https://github.com/lampepfl/dotty/issues/16651)).
 
 {% tabs case_class_compat_2 %}
 {% tab 'Scala 3 Only' %}

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -227,7 +227,7 @@ Later in time, you can amend the original case class definition to, say, add an 
 case class Person private (name: String, age: Int, address: Option[String]):
   ...
   // Add back the former primary constructor signature
-  private[Person] def this(name: String, age: Int): Person = this(name, age, None)
+  private[Person] def this(name: String, age: Int) = this(name, age, None)
   def withAddress(address: Option[String]) = copy(address = address)
 ```
 {% endtab %}

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -199,7 +199,7 @@ object Person:
 {% endtab %}
 {% endtabs %}
 
-Later in time, you can ammend the original case class definition. You
+Later in time, you can amend the original case class definition. You
  * add a new field `address`,
  * add a custom `withAddress` method and
  * add an `apply` factory method to the companion.

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -179,7 +179,7 @@ Sometimes it is desirable to be able to change the definition of a case class (a
 
 To achieve that, follow this pattern:
  * make the constructor `private`
- * define `private` `unapply` function in the companion object (note that by doing that the case class looses the ability to be used in a pattern match)
+ * define a private `unapply` function in the companion object (note that by doing that the case class loses the ability to be used in a pattern match)
  * define `withXXX` methods on the case class that create a new instance with the respective field changed
  * define custom `apply` factory method(s) in the companion object (these can use the private constructor)
 

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -201,7 +201,7 @@ object Person:
 
 Later in time, you can amend the original case class definition. You
  * add a new field `address`,
- * add a private constructor with the original fields
+ * add a new constructor, private to the companion object, with the original fields
  * add a custom `withAddress` method and
  * add an `apply` factory method to the companion.
 

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -191,7 +191,7 @@ Example:
 ```scala
 case class Person private (name: String, age: Int):
   def withName(name: String): Person = copy(name = name)
-  def withAge(age: Int) = copy(age = age)
+  def withAge(age: Int): Person = copy(age = age)
 object Person:
   def apply(name: String, age: Int) = new Person(name, age)
   private def unapply(p: Person) = p

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -217,7 +217,7 @@ object Person:
 {% endtab %}
 {% endtabs %}
 
-The original users can use the case class `Person` as before, all the methods that existed before are present unmodified after this change, thus the compatibility with the users is maintained.
+The original users can use the case class `Person` as before, all the methods that existed before are present unmodified after this change, thus the compatibility with the existing usage is maintained.
 
 A regular case class not following this pattern would break its usage, because by adding a new field changes some methods (which could be used by somebody else), for example `copy` or the constructor itself.
 

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -178,7 +178,7 @@ Again, we recommend using MiMa to double-check that you have not broken binary c
 Sometimes, it is desirable to change the definition of a case class (adding and/or removing fields) while still staying backwards-compatible with the existing usage of the case class, i.e. not breaking the so-called _binary compatibility_.
 
 To achieve that, follow this pattern:
- * make the constructor private
+ * make the constructor private (this also makes private the `copy` method of the class)
  * define a private `unapply` function in the companion object (note that by doing that the case class loses the ability to be used in an extractor pattern match)
  * define `withXXX` methods on the case class that create a new instance with the respective field changed
  * define custom `apply` factory method(s) in the companion object (these can use the private constructor)

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -178,7 +178,7 @@ Again, we recommend using MiMa to double-check that you have not broken binary c
 Sometimes it is desirable to be able to change the definition of a case class (adding and/or removing fields) while still staying compatible with the users of the case class, i.e. not breaking the so called _binary compatibility_.
 
 To achieve that, follow this pattern:
- * make the constructor `private`
+ * make the constructor private
  * define a private `unapply` function in the companion object (note that by doing that the case class loses the ability to be used in a pattern match)
  * define `withXXX` methods on the case class that create a new instance with the respective field changed
  * define custom `apply` factory method(s) in the companion object (these can use the private constructor)

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -185,27 +185,10 @@ To achieve that, follow this pattern:
 
 Example:
 
-{% tabs case_class_compat_1 class=tabs-scala-version %}
+{% tabs case_class_compat_1 %}
+{% tab 'Scala 3 Only' %}
 
-{% tab 'Scala 2' %}
-~~~ scala
-// Mark the primary constructor as private
-case class Person private (name: String, age: Int) {
-  // Create withXxx methods for every field, implemented by using the copy method
-  def withName(name: String): Person = copy(name = name)
-  def withAge(age: Int): Person = copy(age = age)
-}
-object Person {
-  // Create a public constructor (which uses the primary constructor)
-  def apply(name: String, age: Int) = new Person(name, age)
-  // Make the extractor private
-  private def unapply(p: Person): Some[Person] = Some(p)
-}
-~~~
-{% endtab %}
-
-{% tab 'Scala 3' %}
-~~~ scala
+```scala
 // Mark the primary constructor as private
 case class Person private (name: String, age: Int):
   // Create withXxx methods for every field, implemented by using the copy method
@@ -215,64 +198,38 @@ object Person:
   // Create a public constructor (which uses the primary constructor)
   def apply(name: String, age: Int) = new Person(name, age)
   // Make the extractor private
-  private def unapply(p: Person): Person = p
-~~~
+  private def unapply(p: Person) = p
+```
 {% endtab %}
-
 {% endtabs %}
 This class can be published in a library and used as follows:
 
-{% tabs case_class_compat_1_b %}
-{% tab 'Scala 2 and 3' %}
 ~~~ scala
 // Create a new instance
 val alice = Person("Alice", 42)
 // Transform an instance
 println(alice.withAge(alice.age + 1)) // Person(Alice, 43)
 ~~~
-{% endtab %}
-{% endtabs %}
 
 If you try to use `Person` as an extractor in a match expression, it will fail with a message like “method unapply cannot be accessed as a member of Person.type”. Instead, you can use it as a typed pattern:
 
-{% tabs case_class_compat_1_c class=tabs-scala-version %}
-{% tab 'Scala 2' %}
-~~~ scala
-alice match {
-  case person: Person => person.name
-}
-~~~
-{% endtab %}
-{% tab 'Scala 3' %}
 ~~~ scala
 alice match
   case person: Person => person.name
 ~~~
-{% endtab %}
-{% endtabs %}
 Later in time, you can amend the original case class definition to, say, add an optional `address` field. You
  * add a new field `address` and a custom `withAddress` method,
  * add the former constructor signature as a secondary constructor, private to the companion object. This step is necessary because the compilers currently emit the private constructors as public constructors in the bytecode (see [#12711](https://github.com/scala/bug/issues/12711) and [#16651](https://github.com/lampepfl/dotty/issues/16651)).
 
-{% tabs case_class_compat_2 class=tabs-scala-version %}
-{% tab 'Scala 2' %}
-~~~ scala
-case class Person private (name: String, age: Int, address: Option[String]) {
-  ...
-  // Add back the former primary constructor signature
-  private[Person] def this(name: String, age: Int) = this(name, age, None)
-  def withAddress(address: Option[String]) = copy(address = address)
-}
-~~~
-{% endtab %}
-{% tab 'Scala 3' %}
-~~~ scala
+{% tabs case_class_compat_2 %}
+{% tab 'Scala 3 Only' %}
+```scala
 case class Person private (name: String, age: Int, address: Option[String]):
   ...
   // Add back the former primary constructor signature
   private[Person] def this(name: String, age: Int) = this(name, age, None)
   def withAddress(address: Option[String]) = copy(address = address)
-~~~
+```
 {% endtab %}
 {% endtabs %}
 
@@ -286,16 +243,12 @@ The original users can use the case class `Person` as before, all the methods th
 
 The new field `address` can be used as follows:
 
-{% tabs case_class_compat_3 %}
-{% tab 'Scala 2 and 3' %}
 ~~~ scala
 // The public constructor sets the address to None by default.
 // To set the address, we call withAddress:
 val bob = Person("Bob", 21).withAddress(Some("Atlantic ocean"))
 println(bob.address)
 ~~~
-{% endtab %}
-{% endtabs %}
 
 A regular case class not following this pattern would break its usage, because by adding a new field changes some methods (which could be used by somebody else), for example `copy` or the constructor itself.
 

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -179,7 +179,7 @@ Sometimes it is desirable to be able to change the definition of a case class (a
 
 To achieve that, follow this pattern:
  * make the constructor private
- * define a private `unapply` function in the companion object (note that by doing that the case class loses the ability to be used in a pattern match)
+ * define a private `unapply` function in the companion object (note that by doing that the case class loses the ability to be used in an extractor pattern match)
  * define `withXXX` methods on the case class that create a new instance with the respective field changed
  * define custom `apply` factory method(s) in the companion object (these can use the private constructor)
 
@@ -219,7 +219,7 @@ object Person:
 
 The original users can use the case class `Person` as before, all the methods that existed before are present unmodified after this change, thus the compatibility with the users is maintained.
 
-A regular case class not following this pattern would break its users, because by adding a new field some methods (which could be used by somebody else) change, for example `copy` or the constructor itself.
+A regular case class not following this pattern would break its usage, because by adding a new field changes some methods (which could be used by somebody else), for example `copy` or the constructor itself.
 
 ## Versioning Scheme - Communicating compatibility breakages
 

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -190,7 +190,7 @@ Example:
 
 ```scala
 case class Person private (name: String, age: Int):
-  def withName(name: String) = copy(name = name)
+  def withName(name: String): Person = copy(name = name)
   def withAge(age: Int) = copy(age = age)
 object Person:
   def apply(name: String, age: Int) = new Person(name, age)

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -175,7 +175,7 @@ Again, we recommend using MiMa to double-check that you have not broken binary c
 
 ### Changing a case class definition in a backwards-compatible manner
 
-Sometimes it is desirable to be able to change the definition of a case class (adding and/or removing fields) while still staying compatible with the users of the case class, i.e. not breaking the so called _binary compatibility_.
+Sometimes, it is desirable to change the definition of a case class (adding and/or removing fields) while still staying backwards-compatible with the existing usage of the case class, i.e. not breaking the so-called _binary compatibility_.
 
 To achieve that, follow this pattern:
  * make the constructor private

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -173,7 +173,7 @@ You can find detailed explanations, runnable examples and tips to maintain binar
 
 Again, we recommend using MiMa to double-check that you have not broken binary compatibility after making changes.
 
-### Changing case class definition in a compatible manner
+### Changing a case class definition in a backwards-compatible manner
 
 Sometimes it is desirable to be able to change the definition of a case class (adding and/or removing fields) while still staying compatible with the users of the case class, i.e. not breaking the so called _binary compatibility_.
 

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -178,7 +178,7 @@ Again, we recommend using MiMa to double-check that you have not broken binary c
 Sometimes, it is desirable to change the definition of a case class (adding and/or removing fields) while still staying backwards-compatible with the existing usage of the case class, i.e. not breaking the so-called _binary compatibility_.
 
 To achieve that, follow this pattern:
- * make the constructor private (this also makes private the `copy` method of the class)
+ * make the constructor private (this makes private the `copy` method of the class)
  * define a private `unapply` function in the companion object (note that by doing that the case class loses the ability to be used in an extractor pattern match)
  * for all the fields, define `withXXX` methods on the case class that create a new instance with the respective field changed
  * define custom `apply` factory method(s) in the companion object (these can use the private constructor)
@@ -201,18 +201,20 @@ object Person:
 
 Later in time, you can amend the original case class definition. You
  * add a new field `address`,
+ * add a private constructor with the original fields
  * add a custom `withAddress` method and
  * add an `apply` factory method to the companion.
 
 {% tabs case_class_compat_2 %}
 {% tab 'Scala 3 Only' %}
 ```scala
-case class Person private (name: String, age: Int, address: String = ""):
+case class Person private (name: String, age: Int, address: Option[String]):
   ...
+  private[Person] def this(name: String, age: Int): Person = this(name, age, None)
   def withAddress(address: String) = copy(address = address)
 object Person:
   ...
-  def apply(name: String, age: Int, address: String) = new Person(name, age, address)
+  def apply(name: String, age: Int, address: String) = new Person(name, age, Some(address))
 ```
 {% endtab %}
 {% endtabs %}

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -179,7 +179,7 @@ Sometimes it is desirable to be able to change the definition of a case class (a
 
 To achieve that, follow this pattern:
  * make the constructor `private`
- * define `private` `unapply` function in the companion object (note that by doing so you loose the ability to use the case class in a pattern match)
+ * define `private` `unapply` function in the companion object (note that by doing that the case class looses the ability to be used in a pattern match)
  * define `withXXX` methods on the case class that create a new instance with the respective field changed
  * define custom `apply` factory method(s) in the companion object (these can use the private constructor)
 

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -167,7 +167,7 @@ For example, the use of these language features are a common source of binary co
 in library releases:
 
 * Default parameter values for methods or classes
-* Case classes
+* Case classes (work around the issue with [this pattern]({{ site.baseurl }}/scala3/book/domain-modeling-tools.html#changing-case-class-definition-in-a-compatible-manner))
 
 You can find detailed explanations, runnable examples and tips to maintain binary compatibility in [Binary Compatibility Code Examples & Explanation](https://github.com/jatcwang/binary-compatibility-guide).
 


### PR DESCRIPTION
Documenting the patter coming from _SIP-50 - Struct Classes_ https://github.com/scala/improvement-proposals/pull/50#issuecomment-1361474980
English is not my first language, so I'd be very grateful for suggestions on how to improve the wording, etc.

Rendered:
https://github.com/sideeffffect/docs.scala-lang/blob/patch-1/_overviews/tutorials/binary-compatibility-for-library-authors.md#evolving-code-without-breaking-binary-compatibility