### PR TITLE
Correct complex number toString implementation

### DIFF
--- a/_overviews/tutorials/scala-for-java-programmers.md
+++ b/_overviews/tutorials/scala-for-java-programmers.md
@@ -572,7 +572,7 @@ class Complex(real: Double, imaginary: Double) {
   def re = real
   def im = imaginary
   override def toString() =
-    "" + re + (if (im >= 0) "+" else "") + im + "i"
+    "" + re + (if (im >= 0) "+" else "-") + im + "i"
 }
 ```
 {% endtab %}
@@ -583,7 +583,7 @@ class Complex(real: Double, imaginary: Double):
   def re = real
   def im = imaginary
   override def toString() =
-    "" + re + (if im >= 0 then "+" else "") + im + "i"
+    "" + re + (if im >= 0 then "+" else "-") + im + "i"
 ```
 {% endtab %}
 


### PR DESCRIPTION
For Complex numbers with negative imaginary parts, existing representation doesn't include "-" and shows real and imaginary parts conjoined