### PR TITLE
Update implicit-conversions.md

### DIFF
--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -87,7 +87,7 @@ The following imports would bring the `Conversion[String, Student]` into scope:
 
 If the implicit conversion is in the companion object of the argument type, (e.g. `Student` in this case), then no import is necessary.
 
-```scala mdoc
+```scala
 import Conversions.given
 object Usage:
   @main def run =

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -42,11 +42,12 @@ An example is to compare two strings `"foo" < "bar"`. In this case, `String` has
 
 {% tabs implicit-conversion-scope class=tabs-scala-version %}
 {% tab 'Scala 2' %}
-In Scala 2, an implicit conversion is brought into scope by importing from the object that defined it, (e.g. `Conversions` in this case).
+In Scala 2, an implicit conversion is brought into scope by importing from the object that defined it, (e.g. `Conversions` in this case). If the implicit conversion is in the companion object of the argument type, (e.g. `Student` in this case), then no import is necessary.
 
 ```scala mdoc
-case class Student(name: String) {
-  def printName: Unit = println(name)
+case class Student(name: String)
+object Student {
+  implicit def fromStudentToInt(student: Student): Int = student.name.length
 }
   
 object Conversions {
@@ -54,8 +55,12 @@ object Conversions {
 }
 
 import Conversions._
-object Usage:
-  def main(args: Array[String]) = "Reginald".printName
+object Usage {
+  def main(args: Array[String]) = {
+    val reginald: Student = "Reginald" // applies the conversion Conversions.fromStringToStudent
+    println(reginald + 2)              // applies the conversion Student.fromStudentToInt
+  }
+}
 ```
 {% endtab %}
 {% tab 'Scala 3' %}

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -70,7 +70,7 @@ Note that as of Scala 3, implicit conversions cannot be brought into scope anymo
 
 Given the example:
 
-```scala mdoc
+```scala
 case class Student(name: String):
   def printName: Unit = println(name)
 object Student:

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -38,6 +38,45 @@ In the second case, a conversion `c` is searched for, which is applicable to `e`
 
 An example is to compare two strings `"foo" < "bar"`. In this case, `String` has no member `<`, so the implicit conversion `Predef.augmentString("foo") < "bar"` is inserted. (`scala.Predef` is automatically imported into all Scala programs.)
 
+### How are implicit conversions brought into scope? ###
+
+{% tabs implicit-conversion-scope class=tabs-scala-version %}
+{% tab 'Scala 2' %}
+In Scala 2, an implicit convesion is brought into scope by importing from `ImplicitConversions`.
+
+```scala mdoc
+case class Student(name: String) {
+  def printName: Unit = println(name)
+}
+  
+object Conversions {
+  implicit def fromStringToStudent(name: String): Student = Student(name)
+}
+
+import ImplicitConversions._
+object Usage:
+  def main(args: Array[String]) = "Reginald".printName
+```
+{% endtab %}
+{% tab 'Scala 3' %}
+In Scala 3, an implicit conversion must be explicitly imported in order to be applicable.
+
+```scala mdoc
+case class Student(name: String):
+  def printName: Unit = println(name)
+  
+object Conversions:
+  given fromStringToStudent: Conversion[String, Student] = Student(_)
+  
+import Conversions.fromStringToStudent
+object Usage:
+  @main def run = "Reginald".printName
+```
+
+Note that a wildcard import (`*`) is not enough.
+{% endtab %}
+{% endtabs %}
+
 ### How are implicit conversions selected?
 
 See this [Scala FAQ Answer](https://docs.scala-lang.org/tutorials/FAQ/index.html#where-does-scala-look-for-implicits).

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -53,27 +53,42 @@ object Conversions {
   implicit def fromStringToStudent(name: String): Student = Student(name)
 }
 
-import ImplicitConversions._
+import Conversions._
 object Usage:
   def main(args: Array[String]) = "Reginald".printName
 ```
 {% endtab %}
 {% tab 'Scala 3' %}
-In Scala 3, an implicit conversion must be explicitly imported in order to be applicable.
+In Scala 3, an implicit conversion is brought into scope by either importing `given` or the named conversion from the object that defined it, (e.g. `Conversions` in this case). 
+
+Note that as of Scala 3, implicit conversions cannot be brought into scope anymore by means of a wildcard import (`*`). 
+
+Given the example:
 
 ```scala mdoc
 case class Student(name: String):
   def printName: Unit = println(name)
+object Student:
+  given Conversion[Student, Int] = _.name.length
   
 object Conversions:
   given fromStringToStudent: Conversion[String, Student] = Student(_)
-  
-import Conversions.fromStringToStudent
-object Usage:
-  @main def run = "Reginald".printName
 ```
 
-Note that a wildcard import (`*`) is not enough.
+The following imports would bring the `Conversion[String, Student]` into scope:
+  - `import Conversions.given`
+  - `import Conversions.{given[String, Student]}`
+  - `import Conversions.fromStringToStudent`
+
+If the implicit conversion is in the companion object of the argument type, (e.g. `Student` in this case), then no import is necessary.
+
+```scala mdoc
+import Conversions.given
+object Usage:
+  @main def run =
+    val reginald: Student = "Reginald" // applies the Conversion[String, Student]
+    println(reginald + 2)              // applies the Conversion[Student, Int]
+```
 {% endtab %}
 {% endtabs %}
 

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -99,9 +99,8 @@ object Usage:
 {% endtab %}
 {% endtabs %}
 
-### How are implicit conversions selected?
-
-See this [Scala FAQ Answer](https://docs.scala-lang.org/tutorials/FAQ/index.html#where-does-scala-look-for-implicits).
+Further reading: 
+  - [Where does Scala look for implicits? (on StackOverflow)](https://docs.scala-lang.org/tutorials/FAQ/index.html#where-does-scala-look-for-implicits).
 
 ### Beware the power of implicit conversions
 

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -45,6 +45,8 @@ An example is to compare two strings `"foo" < "bar"`. In this case, `String` has
 In Scala 2, an implicit conversion is brought into scope by importing from the object that defined it, (e.g. `Conversions` in this case). If the implicit conversion is in the companion object of the argument type, (e.g. `Student` in this case), then no import is necessary.
 
 ```scala mdoc
+import scala.language.implicitConversions // required to define an implicit conversion
+
 case class Student(name: String)
 object Student {
   implicit def fromStudentToInt(student: Student): Int = student.name.length

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -44,7 +44,7 @@ An example is to compare two strings `"foo" < "bar"`. In this case, `String` has
 {% tab 'Scala 2' %}
 In Scala 2, an implicit conversion is brought into scope by importing from the object that defined it, (e.g. `Conversions` in this case). If the implicit conversion is in the companion object of the argument type, (e.g. `Student` in this case), then no import is necessary.
 
-```scala mdoc
+```scala
 import scala.language.implicitConversions // required to define an implicit conversion
 
 case class Student(name: String)

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -42,7 +42,7 @@ An example is to compare two strings `"foo" < "bar"`. In this case, `String` has
 
 {% tabs implicit-conversion-scope class=tabs-scala-version %}
 {% tab 'Scala 2' %}
-In Scala 2, an implicit convesion is brought into scope by importing from `ImplicitConversions`.
+In Scala 2, an implicit conversion is brought into scope by importing from the object that defined it, (e.g. `Conversions` in this case).
 
 ```scala mdoc
 case class Student(name: String) {

--- a/_tour/implicit-conversions.md
+++ b/_tour/implicit-conversions.md
@@ -77,7 +77,7 @@ object Conversions:
 
 The following imports would bring the `Conversion[String, Student]` into scope:
   - `import Conversions.given`
-  - `import Conversions.{given[String, Student]}`
+  - `import Conversions.{given Conversion[String, Student]}`
   - `import Conversions.fromStringToStudent`
 
 If the implicit conversion is in the companion object of the argument type, (e.g. `Student` in this case), then no import is necessary.


### PR DESCRIPTION
I'm not sure if it is intentional, but the Tour-of-Scala documentation does not mention how to bring implicit conversions into scope. In fact, that information is a bit hard to find anywhere else, so I thought I'll propose to add it here?