### PR TITLE
Fix setup instructions

### DIFF
--- a/_data/setup-scala.yml
+++ b/_data/setup-scala.yml
@@ -1,4 +1,6 @@
-linux: curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup
-macOS-default: curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-apple-darwin.gz | gzip -d > cs && chmod +x cs && (xattr -d com.apple.quarantine cs || true) && ./cs setup
+linux-x86-64: curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup
+linux-arm64: curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup
+macOS-x86-64: curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-apple-darwin.gz | gzip -d > cs && chmod +x cs && (xattr -d com.apple.quarantine cs || true) && ./cs setup
+macOS-arm64: curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-apple-darwin.gz | gzip -d > cs && chmod +x cs && (xattr -d com.apple.quarantine cs || true) && ./cs setup
 macOS-brew: brew install coursier/formulas/coursier && cs setup
 windows-link: https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-win32.zip

--- a/_fr/getting-started/index.md
+++ b/_fr/getting-started/index.md
@@ -34,14 +34,14 @@ Installez-le sur votre système avec les instructions suivantes.
 {% tab macOS for=install-cs-setup-tabs %}
 {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-brew %}
 {% altDetails cs-setup-macos-nobrew  "Alternativement, si vous n'utilisez pas Homebrew:" %}
-  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-default %}
+  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-x86-64 %}
 {% endaltDetails %}
 {% endtab %}
 <!-- end macOS -->
 
 <!-- Linux -->
 {% tab Linux for=install-cs-setup-tabs %}
-  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.linux %}
+  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.linux-x86-64 %}
 {% endtab %}
 <!-- end Linux -->
 

--- a/_ja/getting-started/index.md
+++ b/_ja/getting-started/index.md
@@ -34,14 +34,14 @@ Scala のインストーラーは[Coursier](https://get-coursier.io/docs/cli-ove
 {% tab macOS for=install-cs-setup-tabs %}
 {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-brew %}
 {% altDetails cs-setup-macos-nobrew  "または、Homebrewを使用しない場合は" %}
-  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-default %}
+  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-x86-64 %}
 {% endaltDetails %}
 {% endtab %}
 <!-- end macOS -->
 
 <!-- Linux -->
 {% tab Linux for=install-cs-setup-tabs %}
-  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.linux %}
+  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.linux-x86-64 %}
 {% endtab %}
 <!-- end Linux -->
 

--- a/_overviews/getting-started/index.md
+++ b/_overviews/getting-started/index.md
@@ -51,7 +51,7 @@ Install it on your system with the following instructions.
 {% tab macOS for=install-cs-setup-tabs %}
 Run the following command in your terminal, following the on-screen instructions:
 {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-brew %}
-{% altDetails cs-setup-macos-nobrew  "Alternatively, if you don't use Homebrew:" %}
+{% altDetails cs-setup-macos-nobrew  "Alternatively for Apple Silicon, or if you don't use Homebrew:" %}
   On the Apple Silicon (M1, M2, …) architecture:
   {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-arm64 %}
   Otherwise, on the x86-64 architecture:

--- a/_overviews/getting-started/index.md
+++ b/_overviews/getting-started/index.md
@@ -52,15 +52,22 @@ Install it on your system with the following instructions.
 Run the following command in your terminal, following the on-screen instructions:
 {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-brew %}
 {% altDetails cs-setup-macos-nobrew  "Alternatively, if you don't use Homebrew:" %}
-  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-default %}
+  On the Apple Silicon (M1, M2, …) architecture:
+  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-arm64 %}
+  Otherwise, on the x86-64 architecture:
+  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-x86-64 %}
 {% endaltDetails %}
 {% endtab %}
 <!-- end macOS -->
 
 <!-- Linux -->
 {% tab Linux for=install-cs-setup-tabs %}
-  Run the following command in your terminal, following the on-screen instructions:
-  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.linux %}
+  Run the following command in your terminal, following the on-screen instructions.
+
+  On the x86-64 architecture:
+  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.linux-x86-64 %}
+  Otherwise, on the ARM64 architecture:
+  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.linux-arm64 %}
 {% endtab %}
 <!-- end Linux -->
 

--- a/_ru/getting-started/index.md
+++ b/_ru/getting-started/index.md
@@ -53,7 +53,7 @@ newcomer_resources:
 Запустите в терминале следующую команду, следуя инструкциям на экране:
 {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-brew %}
 {% altDetails cs-setup-macos-nobrew  "В качестве альтернативы, если вы не используете Homebrew:" %}
-  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-default %}
+  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-x86-64 %}
 {% endaltDetails %}
 {% endtab %}
 <!-- end macOS -->
@@ -61,7 +61,7 @@ newcomer_resources:
 <!-- Linux -->
 {% tab Linux for=install-cs-setup-tabs %}
   Запустите в терминале следующую команду, следуя инструкциям на экране:
-  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.linux %}
+  {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.linux-x86-64 %}
 {% endtab %}
 <!-- end Linux -->
 

--- a/_uk/getting-started/index.md
+++ b/_uk/getting-started/index.md
@@ -38,7 +38,7 @@ _Scastie_ це онлайн “пісочниця”, де ви можете е�
 Виконайте наступну команду в терміналі, виконуючи всі спливаючі інструкції:
 {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-brew %}
 {% altDetails cs-setup-macos-nobrew "Якщо ви не використовуєте Homebrew:" %}
-{% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-default %}
+{% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-x86-64 %}
 {% endaltDetails %}
 {% endtab %}
 <!-- end macOS -->
@@ -46,7 +46,7 @@ _Scastie_ це онлайн “пісочниця”, де ви можете е�
 <!-- Linux -->
 {% tab Linux for=install-cs-setup-tabs %}
 Виконайте наступну команду в терміналі, виконуючи всі спливаючі інструкції:
-{% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.linux %}
+{% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.linux-x86-64 %}
 {% endtab %}
 <!-- end Linux -->
 


### PR DESCRIPTION
I think these setup instructions are too complicated but we need to fix them so that they work with the current state of things.

Ideally, we should have a single script that would download the correct binary based on the user OS and architecture.

![Screenshot 2023-02-14 at 10-19-27 Getting Started](https://user-images.githubusercontent.com/332812/218693054-d076676c-f7a1-4085-b519-ba382de19556.png)

![Screenshot 2023-02-14 at 10-19-44 Getting Started](https://user-images.githubusercontent.com/332812/218693087-3c981ceb-fe11-4515-8746-07298866f441.png)
