### PR TITLE
Fix: Improve documentation for Built-in Blog doc

### DIFF
--- a/_overviews/scala3-scaladoc/blog.md
+++ b/_overviews/scala3-scaladoc/blog.md
@@ -49,17 +49,7 @@ authorImg: <Link to the author's image>
 <Content of your page>
 ```
 
-## Special characters for the content
-Keep in mind that the writing of your blog is done with classic markdown. So here are some useful examples:
+You can also find more details about the front matter on the [Jekyll documentation site](https://jekyllrb.com/docs/front-matter/).
 
-` ```<content>``` ` : Multiline code block.
-
-You can also specify a language type, ` ```scala <content>``` `.
-
-`# Title` : For titles.
-
-`## Subtitle` : For subtitles.
-
-`word` : For inline code.
-
-`[name](Link to a website)`: If you want to put a link in the word.
+## Syntax of the content
+Keep in mind that the writing of your blog is done with Markdown. You can find more information about the syntax in [Markdown Guide](https://www.markdownguide.org/basic-syntax/).

--- a/_overviews/scala3-scaladoc/blog.md
+++ b/_overviews/scala3-scaladoc/blog.md
@@ -50,14 +50,16 @@ authorImg: <Link to the author's image>
 ```
 
 ## Special characters for the content
+Keep in mind that the writing of your blog `<content>` is done with regular markdowns but here are some useful examples:
 
-` ```<content>``` ` : Multiline code block
-You can also specify a language type, ` ```scala <content>``` `
+` ```<content>``` ` : Multiline code block.
 
-`# Title` : For titles
+You can also specify a language type, ` ```scala <content>``` `.
 
-`## Subtitle` : For subtitles
+`# Title` : For titles.
+
+`## Subtitle` : For subtitles.
 
 `word` : For inline code.
 
-`[word](Link to a website)`: If you want to put a link in a word
+`[name](Link to a website)`: If you want to put a link in the word.

--- a/_overviews/scala3-scaladoc/blog.md
+++ b/_overviews/scala3-scaladoc/blog.md
@@ -50,7 +50,7 @@ authorImg: <Link to the author's image>
 ```
 
 ## Special characters for the content
-Keep in mind that the writing of your blog `<content>` is done with regular markdowns but here are some useful examples:
+Keep in mind that the writing of your blog is done with classic markdown. So here are some useful examples:
 
 ` ```<content>``` ` : Multiline code block.
 

--- a/_overviews/scala3-scaladoc/blog.md
+++ b/_overviews/scala3-scaladoc/blog.md
@@ -33,4 +33,28 @@ Scaladoc loads blog if the `_blog` directory exists.
 All the blogpost filenames should start with date in numeric format matching `YYYY-MM-DD`.
 Example name is `2015-10-23-dotty-compiler-bootstraps.md`.
 
+## Structure
 
+```
+---
+layout: A reference to the layout for the blog page
+author: Name of the author of the page
+title: Name of the author of the page
+subTitle: Subtitle of the page
+excerpt_separator: <!--more-->
+date: Date of creation of the page
+authorImg: Image of the author of the page
+---
+<Content>
+```
+Keep in mind that with the exception of the author's name and title, the fields are optional.
+
+## Special characters for structures
+
+````<content>```` : For code
+
+`##Subtitle` : For subtitles
+
+`word` : To highlight
+
+`[word](Link to a website)`: If you want to put a link in a word

--- a/_overviews/scala3-scaladoc/blog.md
+++ b/_overviews/scala3-scaladoc/blog.md
@@ -55,8 +55,7 @@ authorImg: <Link to the author's image>
 ## Special characters for the content
 
 ` ```<content>``` ` : Multiline code block
-You can also specify a language type.
-` ```scala <content>``` `
+You can also specify a language type, ` ```scala <content>``` `
 
 `# Title` : For titles
 

--- a/_overviews/scala3-scaladoc/blog.md
+++ b/_overviews/scala3-scaladoc/blog.md
@@ -35,25 +35,26 @@ Example name is `2015-10-23-dotty-compiler-bootstraps.md`.
 
 ## Structure
 
+When creating a blog page, you will have a first part to fill in with different fields. See the following example:
+
 ```
 ---
-layout: A reference to the layout for the blog page
-author: Name of the author of the page
-title: Name of the author of the page
-subTitle: Subtitle of the page
+layout: <A reference to the layout page for the blog page>
+author: <Name of the author of the page>
+title: <Title of the page>
+subTitle: <Subtitle of the page>
 excerpt_separator: <!--more-->
-date: Date of creation of the page
-authorImg: Image of the author of the page
+date: <Date of the creation of the page>
+authorImg: <Link to the author's image>
 ---
 <Content>
 ```
-Keep in mind that with the exception of the author's name and title, the fields are optional.
 
-## Special characters for structures
+## Special characters for the content
 
-````<content>```` : For code
+` ```<content>``` ` : For code
 
-`##Subtitle` : For subtitles
+`## Subtitle` : For subtitles
 
 `word` : To highlight
 

--- a/_overviews/scala3-scaladoc/blog.md
+++ b/_overviews/scala3-scaladoc/blog.md
@@ -33,9 +33,9 @@ Scaladoc loads blog if the `_blog` directory exists.
 All the blogpost filenames should start with date in numeric format matching `YYYY-MM-DD`.
 Example name is `2015-10-23-dotty-compiler-bootstraps.md`.
 
-## Structure
+## Page metadata
 
-When creating a blog page, you will have a first part to fill in with different fields. See the following example:
+The blog pages in scaladoc support [Yaml Frontmatter](https://assemble.io/docs/YAML-front-matter.html) which allows you to specify different values which will be used for metadata in your page. Here are the possible fields:
 
 ```
 ---
@@ -43,19 +43,25 @@ layout: <A reference to the layout page for the blog page>
 author: <Name of the author of the page>
 title: <Title of the page>
 subTitle: <Subtitle of the page>
-excerpt_separator: <!--more-->
-date: <Date of the creation of the page>
+date: <Date of the creation of the page>, e.g. 2016-12-05
 authorImg: <Link to the author's image>
 ---
-<Content>
+<Content of your page>
 ```
+
+<!-- Here is an example of a blogpost page with the fields:
+![Blog page](https://assets.digitalocean.com/articles/alligator/boo.svg "Scaladoc blog page") -->
 
 ## Special characters for the content
 
-` ```<content>``` ` : For code
+` ```<content>``` ` : Multiline code block
+You can also specify a language type.
+` ```scala <content>``` `
+
+`# Title` : For titles
 
 `## Subtitle` : For subtitles
 
-`word` : To highlight
+`word` : For inline code.
 
 `[word](Link to a website)`: If you want to put a link in a word

--- a/_overviews/scala3-scaladoc/blog.md
+++ b/_overviews/scala3-scaladoc/blog.md
@@ -49,9 +49,6 @@ authorImg: <Link to the author's image>
 <Content of your page>
 ```
 
-<!-- Here is an example of a blogpost page with the fields:
-![Blog page](https://assets.digitalocean.com/articles/alligator/boo.svg "Scaladoc blog page") -->
-
 ## Special characters for the content
 
 ` ```<content>``` ` : Multiline code block


### PR DESCRIPTION
First proposal to improve the "Built-in blog" page
Add parts : 
- Page metadata
- Special characters for the content

## Result
<img width="539" alt="Screenshot 2023-03-13 at 17 40 57" src="https://user-images.githubusercontent.com/44496264/224768303-972cb291-3738-4f24-81fc-26e537c87af0.png">
