### PR TITLE
Fix: Prevent the code text from sticking out of the div in Settings page documentation

### DIFF
--- a/_sass/layout/documentation.scss
+++ b/_sass/layout/documentation.scss
@@ -46,6 +46,7 @@
 
   p {
     line-height: 1.5;
+    overflow: scroll;
   }
 
   ol {

--- a/_sass/layout/type-md.scss
+++ b/_sass/layout/type-md.scss
@@ -172,6 +172,7 @@
             color: #859900;
             @include border-radius($border-radius-medium);
             padding: 2px 6px;
+            word-wrap: break-word;
         }
     }
 

--- a/_sass/layout/type-md.scss
+++ b/_sass/layout/type-md.scss
@@ -172,7 +172,6 @@
             color: #859900;
             @include border-radius($border-radius-medium);
             padding: 2px 6px;
-            word-wrap: break-word;
         }
     }
 


### PR DESCRIPTION
On the settings page, the code for the -social-links flag is sticking out.
On this PR, I just added a overflow scroll to the p elements with code.
Before:
<img width="1233" alt="Screenshot 2023-03-01 at 16 11 04" src="https://user-images.githubusercontent.com/44496264/222181952-f6a5ac9f-8bc0-4f33-9edb-36c1c3c14fa6.png">

After:
<img width="921" alt="Screenshot 2023-03-02 at 16 24 15" src="https://user-images.githubusercontent.com/44496264/222687000-620ad367-7a13-4c1e-998c-f0432b5d060f.png">


Reviewed-by: @ckipp01 