### PR TITLE
Fix: Increase the number of search results

### DIFF
--- a/resources/js/functions.js
+++ b/resources/js/functions.js
@@ -338,7 +338,7 @@ $(document).ready(function() {
       resultsContainer: document.getElementById('result-container'),
       json: '/resources/json/search.json',
       searchResultTemplate: '<li><a href="{url}">{title}</a></li>',
-      limit: 5,
+      limit: 7,
     });
 
     $("#blog-search-bar").on("change paste keyup", function() {


### PR DESCRIPTION
As the Scala documentation grows (the new Scala3 version, earlier versions, etc.) the search areas become more diverse, and a search should be as comprehensive as possible so that even the most novice user can easily find what they are looking for. 
This is why in this PR, I have increased the number of search results.



Fixes #2715