### PR TITLE
Fix: Increase the number of results of the doc search bar

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -106,7 +106,7 @@ if ($("#doc-search-bar").length) {
     apiKey: 'fbc439670f5d4e3730cdcb715c359391',
     indexName: 'scala-lang',
     inputSelector: '#doc-search-bar',
-    algoliaOptions: { 'facetFilters': ["language:en"] },
+    algoliaOptions: { 'facetFilters': ["language:en"], 'hitsPerPage': 7 },
     debug: false // Set debug to true if you want to inspect the dropdown
   });
 }

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -106,7 +106,7 @@ if ($("#doc-search-bar").length) {
     apiKey: 'fbc439670f5d4e3730cdcb715c359391',
     indexName: 'scala-lang',
     inputSelector: '#doc-search-bar',
-    algoliaOptions: { 'facetFilters': ["language:en"], 'hitsPerPage': 7 },
+    algoliaOptions: { 'facetFilters': ["language:en"], 'hitsPerPage': 6, 'distinct': 1},
     debug: false // Set debug to true if you want to inspect the dropdown
   });
 }

--- a/resources/js/functions.js
+++ b/resources/js/functions.js
@@ -338,7 +338,7 @@ $(document).ready(function() {
       resultsContainer: document.getElementById('result-container'),
       json: '/resources/json/search.json',
       searchResultTemplate: '<li><a href="{url}">{title}</a></li>',
-      limit: 7,
+      limit: 5,
     });
 
     $("#blog-search-bar").on("change paste keyup", function() {


### PR DESCRIPTION
This PR corrects PR #2716 that I made.
In this one I set the search bar value of the blog to 5 as it was before and I set the search bar value of the documentation to 6 with distinct to true.
See the algolia documentation for:
- [hitsPerPage](https://www.algolia.com/doc/api-reference/api-parameters/hitsPerPage/)
- [distinct](https://www.algolia.com/doc/api-reference/api-parameters/distinct/?client=javascript)
### Before:
<img width="300" alt="Screenshot 2023-03-07 at 10 02 42" src="https://user-images.githubusercontent.com/44496264/223374336-42456e7d-2d4c-4b25-b9e6-aa11f134ad4a.png">

### After:
<img width="300" alt="Screenshot 2023-03-14 at 16 01 03" src="https://user-images.githubusercontent.com/44496264/225043192-d5a08e00-82f3-4925-9cd6-2445fff8fbe9.png">

Also for the idea of having a paging system to be able to see other results. I've just seen that there is an open issue for this for DocSearch.
https://github.com/algolia/docsearch/issues/883