### PR TITLE
Remover border for code lines in comparison page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,8 +219,6 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.17.0)
-    nokogiri (1.14.2-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -265,7 +263,6 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
-  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,8 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.17.0)
+    nokogiri (1.14.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -263,6 +265,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/_overviews/scala3-book/scala4x.css
+++ b/_overviews/scala3-book/scala4x.css
@@ -10,8 +10,7 @@
   background: #fdfdf7;
   border-collapse: collapse;
 }
-.content-primary .scala3-comparison-page th,
-.content-primary .scala3-comparison-page td
+.content-primary .scala3-comparison-page li
 {
   border-top: 1px solid #E5EAEA;
   border-bottom: 1px solid #E5EAEA;

--- a/_overviews/scala3-book/scala4x.css
+++ b/_overviews/scala3-book/scala4x.css
@@ -10,11 +10,7 @@
   background: #fdfdf7;
   border-collapse: collapse;
 }
-.content-primary .scala3-comparison-page li
-{
-  border-top: 1px solid #E5EAEA;
-  border-bottom: 1px solid #E5EAEA;
-}
+
 .content-primary .scala3-comparison-page table td.python-block,
 .content-primary .scala3-comparison-page table td.java-block,
 .content-primary .scala3-comparison-page table td.javascript-block,

--- a/_sass/layout/type-md.scss
+++ b/_sass/layout/type-md.scss
@@ -162,8 +162,6 @@
 
     li,
     p,
-    tr,
-    td,
     dt,
     dd {
         code {

--- a/_sass/layout/type-md.scss
+++ b/_sass/layout/type-md.scss
@@ -149,8 +149,6 @@
 
     li,
     p,
-    tr,
-    td,
     dt,
     dd,
     pre {
@@ -173,6 +171,16 @@
         }
     }
 
+    tr,
+    td{
+        code {
+            font-family: 'Consolas';
+            font-size: 0.9375rem;
+        }
+    }
+
+
+
     pre {
         code {
             overflow-x: auto;
@@ -193,8 +201,8 @@
 
         td,
         th {
-            border-bottom: $base-border-gray;
-            padding: 6px 0;
+            border: $base-border-gray;
+            padding: 6px;
         }
     }
 


### PR DESCRIPTION
In this PR, I changed the CSS files to remove the border in comparison page.
Before:
<img width="400" alt="Screenshot 2023-03-07 at 16 32 36" src="https://user-images.githubusercontent.com/44496264/223471404-60a05de5-1a3f-43e1-a91a-a9dbeb84cd6f.png">


After:
<img width="400" alt="Screenshot 2023-03-07 at 16 32 42" src="https://user-images.githubusercontent.com/44496264/223471458-dc9905cc-c851-47a0-a07a-fe0ce1a820fc.png">

Fixes: #2415