### PR TITLE
Add code tabs to contextual abstractions page

### DIFF
--- a/_overviews/scala3-migration/incompat-contextual-abstractions.md
+++ b/_overviews/scala3-migration/incompat-contextual-abstractions.md
@@ -27,25 +27,31 @@ The Scalafix rule named `ExplicitImplicitTypes` in [ohze/scala-rewrites](https:/
 
 Scala 3 does not support implicit conversion from an implicit function value, of the form `implicit val ev: A => B`.
 
-The following piece of code is now invalid:
+{% tabs scala-3-implicit_1 %}
+{% tab 'Scala 3 Only' %}
 
-```scala
+The following piece of code is now invalid:
+~~~ scala
 trait Pretty {
   val print: String
 }
 
 def pretty[A](a: A)(implicit ev: A => Pretty): String =
   a.print // Error: value print is not a member of A
-```
+~~~
+{% endtab %}
+{% endtabs %}
 
 The [Scala 3 migration compilation](tooling-migration-mode.html) can warn you about those cases, but it does not try to fix it.
 
 Be aware that this incompatibility can produce a runtime incompatibility and break your program.
 Indeed the compiler can find another implicit conversion from a broader scope, which would eventually cause an undesired behavior at runtime.
 
-This example illustrates the case:
+{% tabs scala-3-implicit_2 %}
+{% tab 'Scala 3 Only' %}
 
-```scala
+This example illustrates the case:
+~~~ scala
 trait Pretty {
   val print: String
 }
@@ -54,7 +60,7 @@ implicit def anyPretty(any: Any): Pretty = new Pretty { val print = "any" }
 
 def pretty[A](a: A)(implicit ev: A => Pretty): String =
   a.print // always print "any"
-```
+~~~
 
 The resolved conversion depends on the compiler mode:
   - `-source:3.0-migration`: the compiler performs the `ev` conversion
@@ -62,29 +68,34 @@ The resolved conversion depends on the compiler mode:
 
 One simple fix is to supply the right conversion explicitly:
 
-{% highlight diff %}
+~~~ scala
 def pretty[A](a: A)(implicit ev: A => Pretty): String =
--  a.print
-+  ev(a).print
-{% endhighlight %}
+  ev(a).print
+~~~
+{% endtab %}
+{% endtabs %}
 
 ## View Bounds
 
 View bounds have been deprecated for a long time but they are still supported in Scala 2.13.
 They cannot be compiled with Scala 3 anymore.
 
-```scala
+{% tabs scala-3-bounds_1 %}
+{% tab 'Scala 3 Only' %}
+~~~ scala
 def foo[A <% Long](a: A): Long = a
-```
+~~~
 
 In this example we get:
 
-{% highlight text %}
+~~~ text
 -- Error: src/main/scala/view-bound.scala:2:12 
 2 |  def foo[A <% Long](a: A): Long = a
   |            ^
   |          view bounds `<%' are deprecated, use a context bound `:' instead
-{% endhighlight %}
+~~~
+{% endtab %}
+{% endtabs %}
 
 The message suggests to use a context bound instead of a view bound but it would change the signature of the method.
 It is probably easier and safer to preserve the binary compatibility.
@@ -92,28 +103,39 @@ To do so the implicit conversion must be declared and called explicitly.
 
 Be careful not to fall in the runtime incompatibility described above, in [Implicit Views](#implicit-views).
 
-{% highlight diff %}
--def foo[A <% Long](a: A): Long = a
-+def foo[A](a: A)(implicit ev: A => Long): Long = ev(a)
-{% endhighlight %}
+{% tabs runtime_1 class=tabs-scala-version %}
+{% tab 'Scala 2' for=runtime_1 %}
+~~~ scala
+def foo[A <% Long](a: A): Long = a
+~~~
+
+{% endtab %}
+{% tab 'Scala 3' for=runtime_1 %}
+~~~ scala
+def foo[A](a: A)(implicit ev: A => Long): Long = ev(a)
+~~~
+{% endtab %}
+{% endtabs %}
 
 ## Ambiguous Conversion On `A` And `=> A`
 
 In Scala 2.13 the implicit conversion on `A` wins over the implicit conversion on `=> A`.
 It is not the case in Scala 3 anymore, and leads to an ambiguous conversion. 
 
-For instance, in this example:
+{% tabs ambiguous_1 class=tabs-scala-version %}
+{% tab 'Scala 2' for=ambiguous_1 %}
 
-```scala
+For instance, in this example:
+~~~ scala
 implicit def boolFoo(bool: Boolean): Foo = ???
 implicit def lazyBoolFoo(lazyBool:  => Boolean): Foo = ???
 
 true.foo()
-```
+~~~
 
 The Scala 2.13 compiler chooses the `boolFoo` conversion but the Scala 3 compiler fails to compile.
 
-{% highlight text %}
+~~~ text
 -- Error: src/main/scala/ambiguous-conversion.scala:4:19
 9 |  true.foo()
   |  ^^^^
@@ -121,14 +143,17 @@ The Scala 2.13 compiler chooses the `boolFoo` conversion but the Scala 3 compile
   |Required: ?{ foo: ? }
   |Note that implicit extension methods cannot be applied because they are ambiguous;
   |both method boolFoo in object Foo and method lazyBoolFoo in object Foo provide an extension method `foo` on (true : Boolean)
-{% endhighlight %}
+~~~
+{% endtab %}
+{% tab 'Scala 3' for=ambiguous_1 %}
 
 A temporary solution is to write the conversion explicitly.
 
-{% highlight diff %}
+~~~ scala
 implicit def boolFoo(bool: Boolean): Foo = ???
 implicit def lazyBoolFoo(lazyBool:  => Boolean): Foo = ???
 
--true.foo()
-+boolFoo(true).foo()
-{% endhighlight %}
+boolFoo(true).foo()
+~~~
+{% endtab %}
+{% endtabs %}


### PR DESCRIPTION
Here is my PR proposition to add code tabs to the Dropped Features page

### Before:
<img width="400" alt="Screenshot 2023-03-08 at 13 45 26" src="https://user-images.githubusercontent.com/44496264/223716899-f8121903-6dbe-4ee0-b220-9f2b9c723431.png">
<img width="400" alt="Screenshot 2023-03-08 at 13 45 52" src="https://user-images.githubusercontent.com/44496264/223716953-9f8f629c-9473-4c1b-8f51-50169cdae052.png">

### After :
<img width="400" alt="Screenshot 2023-03-08 at 13 45 31" src="https://user-images.githubusercontent.com/44496264/223716917-3c171026-2cc2-458e-82c8-9ef1f15d0a33.png">
<img width="400" alt="Screenshot 2023-03-08 at 13 45 38" src="https://user-images.githubusercontent.com/44496264/223717237-a949595b-c89c-4017-b218-c2f914e9dddd.png">


Ref #2481 