### PR TITLE
Use Coursier release assets rather than coursier/launchers

### DIFF
--- a/_data/setup-scala.yml
+++ b/_data/setup-scala.yml
@@ -1,6 +1,6 @@
-linux-x86-64: curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup
+linux-x86-64: curl -fL https://github.com/coursier/coursier/releases/latest/download/cs-x86_64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup
 linux-arm64: curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-pc-linux.gz | gzip -d > cs && chmod +x cs && ./cs setup
-macOS-x86-64: curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-apple-darwin.gz | gzip -d > cs && chmod +x cs && (xattr -d com.apple.quarantine cs || true) && ./cs setup
+macOS-x86-64: curl -fL https://github.com/coursier/coursier/releases/latest/download/cs-x86_64-apple-darwin.gz | gzip -d > cs && chmod +x cs && (xattr -d com.apple.quarantine cs || true) && ./cs setup
 macOS-arm64: curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-apple-darwin.gz | gzip -d > cs && chmod +x cs && (xattr -d com.apple.quarantine cs || true) && ./cs setup
 macOS-brew: brew install coursier/formulas/coursier && cs setup
-windows-link: https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-win32.zip
+windows-link: https://github.com/coursier/coursier/releases/latest/download/cs-x86_64-pc-win32.zip


### PR DESCRIPTION
The files in coursier/launchers happen to be less up to date than the release assets.