### PR TITLE
fix typo in `start-intro.md`

### DIFF
--- a/_overviews/scala3-contribution/start-intro.md
+++ b/_overviews/scala3-contribution/start-intro.md
@@ -11,7 +11,7 @@ next-page: procedures-intro
 
 ### Scala CLA
 
-Sometime before submitting you're pull request you'll want to make sure you have
+Sometime before submitting your pull request you'll want to make sure you have
 signed the [Scala CLA][scala-cla]. You can read more about why we require a CLA
 and what exactly is included in it [here][scala-cla].
 
@@ -21,7 +21,7 @@ Before digging into an issue or starting on a new feature it's a good idea to
 make sure an [issue][dotty-issue] or a [discussion][dotty-discussion] has been
 created outlining what you plan to work on. This is both for your and the team's
 benefit. It ensures you get the help you need, and also gives the compiler team
-a heads up that someone is working on an issue.
+a heads-up that someone is working on an issue.
 
 For some small changes like documentation, this isn't always necessary, but it's
 never a bad idea to check.


### PR DESCRIPTION
I found a typo while familiarizing myself with the contribution process. This is my first contribution to this repo so please let me know if there is anything else that I need to do.