### PR TITLE
Add links to debugger in inspection article

### DIFF
--- a/_overviews/scala3-contribution/procedures-inspection.md
+++ b/_overviews/scala3-contribution/procedures-inspection.md
@@ -13,7 +13,9 @@ while the compiler is running, and inspect produced artifacts of the compiler.
 ## Inspecting variables in-place
 
 Frequently you will need to inspect the content of a particular variable.
-Often, it is sufficient to use `println`.
+You can either use `println`s or the debugger, more info on how to setup the latter [here](https://docs.scala-lang.org/scala3/guides/contribution/procedures-debugging.html).
+
+In the remeainder of this article we'll use `println(<someUsefulExpression>)` inserted in the code, but the same effect can be accomplished by stopping at a breakpoint, and typing `<someUsefulExpression>` in the [debug console](https://docs.scala-lang.org/scala3/guides/contribution/procedures-debugging.html#the-debug-console) of the debugger.
 
 When printing a variable, it's always a good idea to call `show` on that variable: `println(x.show)`.
 Many objects of the compiler define `show`, returning a human-readable string.

--- a/_overviews/scala3-contribution/procedures-inspection.md
+++ b/_overviews/scala3-contribution/procedures-inspection.md
@@ -13,9 +13,9 @@ while the compiler is running, and inspect produced artifacts of the compiler.
 ## Inspecting variables in-place
 
 Frequently you will need to inspect the content of a particular variable.
-You can either use `println`s or the debugger, more info on how to setup the latter [here](https://docs.scala-lang.org/scala3/guides/contribution/procedures-debugging.html).
+You can either use `println`s or the debugger, more info on how to setup the latter [here]({% link _overviews/scala3-contribution/procedures-debugging.md %}).
 
-In the remeainder of this article we'll use `println(<someUsefulExpression>)` inserted in the code, but the same effect can be accomplished by stopping at a breakpoint, and typing `<someUsefulExpression>` in the [debug console](https://docs.scala-lang.org/scala3/guides/contribution/procedures-debugging.html#the-debug-console) of the debugger.
+In the remeainder of this article we'll use `println(<someUsefulExpression>)` inserted in the code, but the same effect can be accomplished by stopping at a breakpoint, and typing `<someUsefulExpression>` in the [debug console]({% link _overviews/scala3-contribution/procedures-debugging.md %}#the-debug-console) of the debugger.
 
 When printing a variable, it's always a good idea to call `show` on that variable: `println(x.show)`.
 Many objects of the compiler define `show`, returning a human-readable string.


### PR DESCRIPTION
Makes the new debugger article more visible by linking from a page that benefits from it, "How to Inspect Values"