### PR TITLE
Update package-objects.md

### DIFF
--- a/_tour/package-objects.md
+++ b/_tour/package-objects.md
@@ -7,7 +7,7 @@ num: 36
 previous-page: packages-and-imports
 ---
 
-Often, it is convenient to have definitions accessible accross an entire package, and not need to invent a
+Often, it is convenient to have definitions accessible across an entire package, and not need to invent a
 name for a wrapper `object` to contain them.
 
 {% tabs pkg-obj-vs-top-lvl_1 class=tabs-scala-version %}


### PR DESCRIPTION
fix: update typo

`accross` -> `across`