### PR TITLE
Add redirect link to scala 3 / contribution-intro

### DIFF
--- a/_overviews/scala3-contribution/contribution-intro.md
+++ b/_overviews/scala3-contribution/contribution-intro.md
@@ -1,4 +1,5 @@
 ---
 title: Contribute to Scala 3
 description: This page describes the format of the contribution guide for the Scala 3 compiler.
+redirect_to: https://dotty.epfl.ch/docs/contributing/index.html
 ---


### PR DESCRIPTION
This will fix the scala 3 contribution link at https://docs.scala-lang.org/contribute/