### PR TITLE
fix typo in `scala-for-java-devs.md`

### DIFF
--- a/_overviews/scala3-book/scala-for-java-devs.md
+++ b/_overviews/scala3-book/scala-for-java-devs.md
@@ -813,7 +813,7 @@ Called a _ternary operator_ in Java:
         <code>val monthAsString = day match
         <br>&nbsp; case 1 =&gt; "January"
         <br>&nbsp; case 2 =&gt; "February"
-        <br>&nbsp; _ =&gt; "Other"
+        <br>&nbsp; case _ =&gt; "Other"
         </code>
       </td>
     </tr>


### PR DESCRIPTION
I am new to scala who came from java, and was practicing with the doc.
I found the typo while I was coding following the doc.

## previous

![image](https://github.com/scala/docs.scala-lang/assets/71590696/4e55eee0-6f1a-47b1-a0b0-a5e910e0150d)


## should be

![image](https://github.com/scala/docs.scala-lang/assets/71590696/0d295a93-84fc-42a3-90dd-346e41e3aa8d)