### PR TITLE
Refactor: Add documentation for the Scastie configuration

### DIFF
--- a/_overviews/scala3-scaladoc/settings.md
+++ b/_overviews/scala3-scaladoc/settings.md
@@ -172,6 +172,14 @@ Which means:
 - all snippets in files under directory `my/path/f` should fail during compilation
 - all other snippets should compile successfully
 
+#### -scastie-configuration
+
+Define the additional sbt configuration for your Scastie snippets. For example, when you import external libraries into your snippets, you need to add the related dependencies.
+
+```
+"-scastie-configuration", """libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.12.0""""
+```
+
 ##### -Ysnippet-compiler-debug
 
 Setting this option makes snippet compiler print the snippet as it is compiled (after wrapping).


### PR DESCRIPTION
I have noticed that in most Scala projects using Scaladoc with snippets. When snippets were using external libraries, these did not work. Example:
<img width="600" alt="Screenshot 2023-05-23 at 16 02 45" src="https://github.com/scala/docs.scala-lang/assets/44496264/c34294bd-8aed-47f8-880d-e163313799e0">

Planned or just lack of interest to look into it further, the question remains "How to fix it?".
So I noticed that a -scastie-configuration flag was present but as discussed in [Issue #16220](https://github.com/lampepfl/dotty/issues/16220) on Dotty, nothing explains how to use it or anything.
So when testing some things, I noticed that it was behaving like the "Add Extra Sbt Configuration" input of the Scastie web application. 

<img width="500" alt="Screenshot 2023-05-23 at 16 06 32" src="https://github.com/scala/docs.scala-lang/assets/44496264/e13eba99-6c9c-49f7-90ed-1efde625f43d">

And as soon as I added the following piece of code, the snippet worked as it should.

<img width="500" alt="Screenshot 2023-05-23 at 16 10 04" src="https://github.com/scala/docs.scala-lang/assets/44496264/423bce22-0da8-40e3-a54b-7a147f6ece50">
<img width="500" alt="Screenshot 2023-05-23 at 16 13 26" src="https://github.com/scala/docs.scala-lang/assets/44496264/df224999-30d5-4812-a152-1574345a940d">

So the goal to this PR is to add some documentation about `-scastie-configuration` flag so the users can make the best use of Scastie.

Fixes: https://github.com/lampepfl/dotty/issues/16220