### PR TITLE
use border-collapse on tables

### DIFF
--- a/_sass/layout/type-md.scss
+++ b/_sass/layout/type-md.scss
@@ -194,6 +194,7 @@
     table {
         width: 100%;
         text-align: left;
+        border-collapse: collapse;
 
         thead {
             font-weight: $font-bold;


### PR DESCRIPTION
Restore the original look of tables, where they had no awkward gap between cells

## Before
![Screenshot 2023-05-26 at 13 40 52](https://github.com/scala/docs.scala-lang/assets/13436592/80fcabcc-8e6b-4b40-ac56-619d6c7a176c)
![Screenshot 2023-05-26 at 13 42 21](https://github.com/scala/docs.scala-lang/assets/13436592/c7a5ba6b-2a65-4893-8239-b0e5e88ea41f)



## After

![Screenshot 2023-05-26 at 13 39 32](https://github.com/scala/docs.scala-lang/assets/13436592/524307ba-f9d6-4af9-a93a-8959172c7492)
![Screenshot 2023-05-26 at 13 39 47](https://github.com/scala/docs.scala-lang/assets/13436592/36d889b2-008f-4662-8bb5-ad718563eb88)
![Screenshot 2023-05-26 at 13 40 02](https://github.com/scala/docs.scala-lang/assets/13436592/cc7d7fbb-b72c-428f-a633-cd598aaa24d6)
![Screenshot 2023-05-26 at 13 42 00](https://github.com/scala/docs.scala-lang/assets/13436592/ffc5b14e-474b-4a57-b83a-589ee46029e1)

