### PR TITLE
Fix extension methods typo

### DIFF
--- a/_ja/overviews/core/value-classes.md
+++ b/_ja/overviews/core/value-classes.md
@@ -51,7 +51,7 @@ language: ja
       def toHexString: String = java.lang.Integer.toHexString(self)
     }
 
-実行時には、この `3.toHexString` という式は、新しくインスタンス化されるオブジェクトへのメソッド呼び出しではなく、静的なオブジェクトへのメソッド呼び出しと同様のコード (`RichInt$.MODULE$.extension$toHexString(3)`) へと最適化される。
+実行時には、この `3.toHexString` という式は、新しくインスタンス化されるオブジェクトへのメソッド呼び出しではなく、静的なオブジェクトへのメソッド呼び出しと同様のコード (`RichInt$.MODULE$.toHexString$extension(3)`) へと最適化される。
 
 ## 正当性
 

--- a/_overviews/core/value-classes.md
+++ b/_overviews/core/value-classes.md
@@ -53,7 +53,7 @@ The following fragment of `RichInt` shows how it extends `Int` to allow the expr
     }
 
 At runtime, this expression `3.toHexString` is optimised to the equivalent of a method call on a static object
-(`RichInt$.MODULE$.extension$toHexString(3)`), rather than a method call on a newly instantiated object.
+(`RichInt$.MODULE$.toHexString$extension(3)`), rather than a method call on a newly instantiated object.
 
 ## Correctness
 

--- a/_zh-cn/overviews/core/value-classes.md
+++ b/_zh-cn/overviews/core/value-classes.md
@@ -43,7 +43,7 @@ Value class只能继承universal traits，但其自身不能再被继承。所�
       def toHexString: String = java.lang.Integer.toHexString(self)
     }
 
-在运行时，表达式3.toHexString 被优化并等价于静态对象的方法调用 （RichInt$.MODULE$.extension$toHexString(3)），而不是创建一个新实例对象，再调用其方法。
+在运行时，表达式3.toHexString 被优化并等价于静态对象的方法调用 （RichInt$.MODULE$.toHexString$extension(3)），而不是创建一个新实例对象，再调用其方法。
 
 ## 正确性
 


### PR DESCRIPTION
Let's say we have`println(42.toHexString)`, and compile it. When we decompile the class file to Java, we get:
```java
.MODULE$.println(scala.runtime.RichInt..MODULE$.toHexString$extension(.MODULE$.intWrapper(42)));
```