### PR TITLE
Scala 2.13.11

### DIFF
--- a/_ba/tour/implicit-conversions.md
+++ b/_ba/tour/implicit-conversions.md
@@ -46,8 +46,8 @@ Možete, zato što `Predef` uključuje slj. implicitnu konverziju:
 ```scala mdoc
 import scala.language.implicitConversions
 
-implicit def int2Integer(x: Int) =
-  java.lang.Integer.valueOf(x)
+implicit def int2Integer(x: Int): Integer =
+  Integer.valueOf(x)
 ```
 
 Pošto su implicitne konverzije opasne ako se koriste pogrešno, kompajler upozorava kada kompajlira definiciju implicitne konverzije.

--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ keywords:
 - Document
 - Guide
 
-scala-version: 2.13.10
+scala-version: 2.13.11
 scala-212-version: 2.12.17
 scala-3-version: 3.3.0
 

--- a/_ja/tour/implicit-conversions.md
+++ b/_ja/tour/implicit-conversions.md
@@ -42,8 +42,8 @@ implicit def list2ordered[A](x: List[A])
 ```scala mdoc
 import scala.language.implicitConversions
 
-implicit def int2Integer(x: Int) =
-  java.lang.Integer.valueOf(x)
+implicit def int2Integer(x: Int): Integer =
+  Integer.valueOf(x)
 ```
 
 暗黙の変換は見境なく使われると落とし穴になり得るため、暗黙の変換の定義をコンパイルしている時にコンパイラは警告を出します。

--- a/_ko/tour/implicit-conversions.md
+++ b/_ko/tour/implicit-conversions.md
@@ -43,8 +43,8 @@ previous-page: implicit-parameters
 ```scala mdoc
 import scala.language.implicitConversions
 
-implicit def int2Integer(x: Int) =
-  java.lang.Integer.valueOf(x)
+implicit def int2Integer(x: Int): Integer =
+  Integer.valueOf(x)
 ```
 
 암시적 변환이 무분별하게 사용될 경우 잠재적인 위험을 가질 수 있기 때문에, 컴파일러는 암시적 변환의 선언을 컴파일할 시 이를 경고한다.

--- a/_overviews/FAQ/index.md
+++ b/_overviews/FAQ/index.md
@@ -124,7 +124,7 @@ Welcome to Scala 3.2.0 (17.0.3, Java OpenJDK 64-Bit Server VM).
 Type in expressions for evaluation. Or try :help.
 
 scala> util.Properties.versionNumberString
-val res0: String = 2.13.10
+val res0: String = 2.13.11
 ```
 
 Note that Scala 3 offers
@@ -312,14 +312,14 @@ setting in a multi-project build.
 
 For example, if you add this to your `build.sbt`:
 
-    scalaVersion := "2.13.10"
+    scalaVersion := "2.13.11"
 
 that's a "bare" setting, and you might expect it to apply build-wide.
 But it doesn't. _It only applies to the root project._
 
 In many cases one should instead write:
 
-    ThisBuild / scalaVersion := "2.13.10"
+    ThisBuild / scalaVersion := "2.13.11"
 
 Other possibilities include:
 

--- a/_overviews/contribute/bug-reporting-guide.md
+++ b/_overviews/contribute/bug-reporting-guide.md
@@ -65,7 +65,7 @@ If you cannot find your issue in the issue tracker, create a new bug. The detail
 
 Please make sure to fill in as many fields as possible. Make sure you've indicated the following:
 
- 1. **Exact Scala version** that you are using. For example, `2.13.10` or `3.2.0`. If the bug happens in multiple versions indicate all of them.
+ 1. **Exact Scala version** that you are using. For example, `2.13.11` or `3.3.0`. If the bug happens in multiple versions indicate all of them.
  2. **The component** that is affected by the bug. For example, the Standard Library, Scaladoc, etc.
  3. **Labels** related to your issue. For example, if you think your issue is related to the typechecker, and if you have successfully minimized your issue, label your bug as "typechecker" and "minimized". Issue tracker will suggest names for existing labels as you type them so try not to create duplicates.
  4. **Running environment**. Are you running on Linux? Windows? What JVM version are you using?

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -12,8 +12,8 @@ Sometimes new JVM and JDK (Java Development Kit) versions require us to update S
 
 | JDK version | Minimum Scala versions                                       |
 |:-----------:|:-------------------------------------------------------------|
-| 21 (ea)     | 3.3.1 (soon), 2.13.11 (soon), 2.12.18                        |
-| 20          | 3.3.0, 2.13.11 (soon), 2.12.18                               |
+| 21 (ea)     | 3.3.1 (soon), 2.13.11, 2.12.18                               |
+| 20          | 3.3.0, 2.13.11, 2.12.18                                      |
 | 19          | 3.2.0, 2.13.9, 2.12.16                                       |
 | 18          | 3.1.3, 2.13.7, 2.12.15                                       |
 | 17 (LTS)    | 3.0.0, 2.13.6, 2.12.15                                       |
@@ -97,14 +97,7 @@ Support for JDK 19 was included in Scala 2.13.9 and 2.12.16.
 
 JDK 20, a non-LTS release, came out in March 2023.
 
-Support for JDK 20 was included in Scala 3.3.0 and 2.12.18.
-
-Support for JDK 20 has already been merged and is available in
-[nightly builds](https://stackoverflow.com/questions/40622878/how-do-i-tell-sbt-or-scala-cli-to-use-a-nightly-build-of-scala-2-12-or-2-13)
-of 2.13.
-
-The support will be included in the forthcoming Scala release
-2.13.11.  We expect to release it in June 2023.
+Support for JDK 20 was included in Scala 3.3.0, 2.13.11, and 2.12.18.
 
 ## JDK 21 compatibility notes
 
@@ -112,10 +105,9 @@ Early access builds of JDK 21 are already available. JDK 21 will
 be an LTS release.
 
 Initial support for JDK 21 has been merged and is already available in
-Scala 2.12.18 and in nightly builds of Scala 2.13 and Scala 3.
+Scala 2.13.11 and 2.12.18 and in nightly builds of Scala 3.
 
-The support will be included in the forthcoming Scala releases
-2.13.11 and 3.3.1.
+The support will be included in the forthcoming Scala 3.3.1 release.
 
 ## GraalVM Native Image compatibility notes
 

--- a/_pl/tour/implicit-conversions.md
+++ b/_pl/tour/implicit-conversions.md
@@ -43,8 +43,8 @@ Przykładowo, kiedy wywołujemy metodę Javy, która wymaga typu `java.lang.Inte
 ```scala mdoc
 import scala.language.implicitConversions
 
-implicit def int2Integer(x: Int) =
-  java.lang.Integer.valueOf(x)
+implicit def int2Integer(x: Int): Integer =
+  Integer.valueOf(x)
 ```
 
 Aby zdefiniować własne konwersje niejawne, należy zaimportować `scala.language.implicitConversions` (albo uruchomić kompilator z opcją `-language:implicitConversions`). Ta funkcjonalność musi być włączona jawnie ze względu na problemy, jakie mogą się wiązać z ich nadmiernym stosowaniem.

--- a/_pt-br/tour/implicit-conversions.md
+++ b/_pt-br/tour/implicit-conversions.md
@@ -44,8 +44,8 @@ Por exemplo, ao chamar um método Java que espera um `java.lang.Integer`, você 
 ```scala mdoc
 import scala.language.implicitConversions
 
-implicit def int2Integer(x: Int) =
-  java.lang.Integer.valueOf(x)
+implicit def int2Integer(x: Int): Integer =
+  Integer.valueOf(x)
 ```
 
 Para definir suas próprias conversões implícitas, primeiro você deve importar `scala.language.implicitConversions` (ou invocar o compilador com a opção `-language: implicitConversions`). Tal recurso deve ser explicitamente habilitado porque pode se tornar complexo se usado indiscriminadamente.

--- a/_ru/tour/implicit-conversions.md
+++ b/_ru/tour/implicit-conversions.md
@@ -44,8 +44,8 @@ implicit def list2ordered[A](x: List[A])
 ```scala mdoc
 import scala.language.implicitConversions
 
-implicit def int2Integer(x: Int) =
-  java.lang.Integer.valueOf(x)
+implicit def int2Integer(x: Int): Integer =
+  Integer.valueOf(x)
 ```
 
 Компилятор предупреждает при компиляции об обнаружении неявных преобразований, т.к. неявные преобразования могут иметь разные подводные камни (особенно если использовать их без разбора).

--- a/_zh-cn/tour/implicit-conversions.md
+++ b/_zh-cn/tour/implicit-conversions.md
@@ -47,8 +47,8 @@ implicit def list2ordered[A](x: List[A])
 ```scala mdoc
 import scala.language.implicitConversions
 
-implicit def int2Integer(x: Int) =
-  java.lang.Integer.valueOf(x)
+implicit def int2Integer(x: Int): Integer =
+  Integer.valueOf(x)
 ```
 
 因为如果不加选择地使用隐式转换可能会导致陷阱，编译器会在编译隐式转换定义时发出警告。

--- a/api/all.md
+++ b/api/all.md
@@ -10,10 +10,10 @@ redirect_from:
 
 * Scala 3.3.0 LTS
   * [Library API](https://www.scala-lang.org/api/3.3.0/)
-* Scala 2.13.10
-  * [Library API](https://www.scala-lang.org/api/2.13.10/)
-  * [Compiler API](https://www.scala-lang.org/api/2.13.10/scala-compiler/scala/)
-  * [Reflection API](https://www.scala-lang.org/api/2.13.10/scala-reflect/scala/reflect/)
+* Scala 2.13.11
+  * [Library API](https://www.scala-lang.org/api/2.13.11/)
+  * [Compiler API](https://www.scala-lang.org/api/2.13.11/scala-compiler/scala/)
+  * [Reflection API](https://www.scala-lang.org/api/2.13.11/scala-reflect/scala/reflect/)
 * Scala 2.12.17
   * [Library API](https://www.scala-lang.org/api/2.12.17/)
   * [Compiler API](https://www.scala-lang.org/api/2.12.17/scala-compiler/scala/)
@@ -82,6 +82,10 @@ https://scala-ci.typesafe.com/artifactory/scala-integration/org/scala-lang/
   * [Library API](https://www.scala-lang.org/api/3.0.1/)
 * Scala 3.0.0
   * [Library API](https://www.scala-lang.org/api/3.0.0/)
+* Scala 2.13.10
+  * [Library API](https://www.scala-lang.org/api/2.13.10/)
+  * [Compiler API](https://www.scala-lang.org/api/2.13.10/scala-compiler/scala/)
+  * [Reflection API](https://www.scala-lang.org/api/2.13.10/scala-reflect/scala/reflect/)
 * Scala 2.13.9
   * [Library API](https://www.scala-lang.org/api/2.13.9/)
   * [Compiler API](https://www.scala-lang.org/api/2.13.9/scala-compiler/scala/)

--- a/scripts/run-mdoc.sh
+++ b/scripts/run-mdoc.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -eux
 
-cs launch --scala-version 2.13.10 org.scalameta::mdoc:2.3.3 -- \
+cs launch --scala-version 2.13.11 org.scalameta::mdoc:2.3.3 -- \
   --in . \
   --out /tmp/mdoc-out/ \
   --classpath \
-  $(cs fetch --scala-version 2.13.10 -p \
+  $(cs fetch --scala-version 2.13.11 -p \
     com.chuusai::shapeless:2.3.10 \
     org.scala-lang::toolkit:0.1.7 \
     org.scala-lang::toolkit-test:0.1.7 \


### PR DESCRIPTION
reference: https://contributors.scala-lang.org/t/scala-2-13-11-release-planning/6088

before merge, I should rebase on top of the merged 2.12.18 PR, then update `_overviews/jdk-compatibility/overview.md`