### PR TITLE
Update Scala 3 contributing guide and fix dead links

### DIFF
--- a/_overviews/contribute/scala3.md
+++ b/_overviews/contribute/scala3.md
@@ -11,11 +11,3 @@ Dotty is an open-source project, and as such, we welcome contributions from the 
 If you are interested in contributing to Scala 3, please visit the project [developer website](https://dotty.epfl.ch/docs/contributing/index.html), where you will find all the information you need to get started. We encourage everyone, regardless of their level of expertise, to contribute to Scala 3, as there are many ways to help, from fixing bugs and implementing new features to improving documentation and testing.
 
 If you have any questions, please feel free to ask them on the [Contributors Forum](https://contributors.scala-lang.org/c/scala-3/scala-3-contributors/9).
-
-Summary of the contribution guide on Scala 3:
-
-- [Getting-Started](https://dotty.epfl.ch/docs/contributing/getting-started.html)
-- [Workflow](https://dotty.epfl.ch/docs/contributing/workflow/index.html)
-- [IDEs and Tools](https://dotty.epfl.ch/docs/contributing/tools/index.html)
-- [Procedures](https://dotty.epfl.ch/docs/contributing/procedures/index.html)
-- [High Level Architecture](https://dotty.epfl.ch/docs/contributing/architecture/index.html)

--- a/_overviews/scala3-contribution/procedures-cheatsheet.md
+++ b/_overviews/scala3-contribution/procedures-cheatsheet.md
@@ -1,5 +1,5 @@
 ---
 title: Cheatsheets
 description: This page describes a cheatsheet for working with the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/index.html#sbt-commands-cheat-sheet-1
+redirect_to: https://dotty.epfl.ch/docs/contributing/cheatsheet.html
 ---

--- a/_overviews/scala3-contribution/procedures-efficiency.md
+++ b/_overviews/scala3-contribution/procedures-efficiency.md
@@ -1,5 +1,0 @@
----
-title: Improving Your Workflow
-description: This page describes improving efficiency of debugging the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/efficiency.html
----

--- a/_overviews/scala3-contribution/procedures-intro.md
+++ b/_overviews/scala3-contribution/procedures-intro.md
@@ -1,5 +1,5 @@
 ---
 title: Contributing to Scala 3
 description: This page introduces the compiler procedures for the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/index.html
+redirect_to: https://dotty.epfl.ch/docs/contributing/procedures/index.html
 ---


### PR DESCRIPTION
Should fix the CI after https://github.com/lampepfl/dotty/pull/17912 is merged and the website updated.