### PR TITLE
repaired links to now dead `scalamacros.org`

### DIFF
--- a/_overviews/macros/paradise.md
+++ b/_overviews/macros/paradise.md
@@ -20,7 +20,7 @@ Macro paradise is a plugin for several versions of Scala compilers.
 It is designed to reliably work with production releases of <code>scalac</code>,
 making latest macro developments available way before they end up in future versions Scala.
 Refer to the roadmap for [the list of supported features and versions](roadmap.html)
-and visit [the paradise announcement](https://scalamacros.org/news/2013/08/07/roadmap-for-macro-paradise.html)
+and visit [the paradise announcement](https://github.com/scalamacros/scalamacros.github.com/blob/5904f7ef88a439c668204b4bf262835e89fb13cb/news/_posts/2013-08-07-roadmap-for-macro-paradise.html)
 to learn more about our support guarantees.
 
     ~/210x $ scalac -Xplugin:paradise_*.jar -Xshow-phases

--- a/_overviews/macros/typemacros.md
+++ b/_overviews/macros/typemacros.md
@@ -12,7 +12,7 @@ permalink: /overviews/macros/:title.html
 
 Type macros used to be available in previous versions of ["Macro Paradise"](paradise.html),
 but are not supported anymore in macro paradise 2.0.
-Visit [the paradise 2.0 announcement](https://scalamacros.org/news/2013/08/05/macro-paradise-2.0.0-snapshot.html)
+Visit [the paradise 2.0 announcement](https://github.com/scalamacros/scalamacros.github.com/blob/5904f7ef88a439c668204b4bf262835e89fb13cb/news/_posts/2013-08-05-macro-paradise-2.0.0-snapshot.html)
 for an explanation and suggested migration strategy.
 
 ## Intuition

--- a/_overviews/macros/untypedmacros.md
+++ b/_overviews/macros/untypedmacros.md
@@ -12,7 +12,7 @@ permalink: /overviews/macros/:title.html
 
 Untyped macros used to be available in previous versions of ["Macro Paradise"](paradise.html),
 but are not supported anymore in macro paradise 2.0.
-Visit [the paradise 2.0 announcement](https://scalamacros.org/news/2013/08/05/macro-paradise-2.0.0-snapshot.html)
+Visit [the paradise 2.0 announcement](https://github.com/scalamacros/scalamacros.github.com/blob/5904f7ef88a439c668204b4bf262835e89fb13cb/news/_posts/2013-08-05-macro-paradise-2.0.0-snapshot.html)
 for an explanation and suggested migration strategy.
 
 ## Intuition

--- a/_overviews/macros/usecases.md
+++ b/_overviews/macros/usecases.md
@@ -19,12 +19,12 @@ to the realm of possible. Both commercial and research users of Scala use macros
 At EPFL we are leveraging macros to power our research. Lightbend also employs macros in a number of projects.
 Macros are also popular in the community and have already given rise to a number of interesting applications.
 
-The recent talk ["What Are Macros Good For?"](https://scalamacros.org/paperstalks/2014-02-04-WhatAreMacrosGoodFor.pdf)
+The recent talk ["What Are Macros Good For?"](https://github.com/scalamacros/scalamacros.github.com/blob/5904f7ef88a439c668204b4bf262835e89fb13cb/paperstalks/2014-02-04-WhatAreMacrosGoodFor.pdf)
 describes and systemizes uses that macros found among Scala 2.10 users. The thesis of the talk is that macros are good for
 code generation, static checking and DSLs, illustrated with a number of examples from research and industry.
 
 We have also published a paper in the Scala'13 workshop,
-["Scala Macros: Let Our Powers Combine!"](https://scalamacros.org/paperstalks/2013-04-22-LetOurPowersCombine.pdf),
+["Scala Macros: Let Our Powers Combine!"](https://github.com/scalamacros/scalamacros.github.com/blob/5904f7ef88a439c668204b4bf262835e89fb13cb/paperstalks/2013-04-22-LetOurPowersCombine.pdf),
 covering the state of the art of macrology in Scala 2.10 from a more academic point of view.
 In the paper we show how the rich syntax and static types of Scala synergize with macros and
 explore how macros enable new and unique ways to use pre-existing language features.


### PR DESCRIPTION
closes #2840

the website `scalamacros.org` is no longer being used for what it was originally intended for when this documentation was written, so I have linked to the github repository which contains the original data.

It may be worth it to look into `archive.org` for this purpose, if it is felt that the repository used is not sufficient.
In the event the repository disapears, I have
created a fork, and plan use it for archival purposes. This fork is welcome to use by the scala project in such an event. [https://github.com/bicknrown/scalamacros.github.com/](https://github.com/bicknrown/scalamacros.github.com/)