### PR TITLE
Follow up on page renames

### DIFF
--- a/_overviews/contribute/scala3.md
+++ b/_overviews/contribute/scala3.md
@@ -11,11 +11,3 @@ Dotty is an open-source project, and as such, we welcome contributions from the 
 If you are interested in contributing to Scala 3, please visit the project [developer website](https://dotty.epfl.ch/docs/contributing/index.html), where you will find all the information you need to get started. We encourage everyone, regardless of their level of expertise, to contribute to Scala 3, as there are many ways to help, from fixing bugs and implementing new features to improving documentation and testing.
 
 If you have any questions, please feel free to ask them on the [Contributors Forum](https://contributors.scala-lang.org/c/scala-3/scala-3-contributors/9).
-
-Summary of the contribution guide on Scala 3:
-
-- [Getting-Started](https://dotty.epfl.ch/docs/contributing/getting-started.html)
-- [Workflow](https://dotty.epfl.ch/docs/contributing/workflow/index.html)
-- [IDEs and Tools](https://dotty.epfl.ch/docs/contributing/tools/index.html)
-- [Procedures](https://dotty.epfl.ch/docs/contributing/procedures/index.html)
-- [High Level Architecture](https://dotty.epfl.ch/docs/contributing/architecture/index.html)

--- a/_overviews/scala3-contribution/procedures-areas.md
+++ b/_overviews/scala3-contribution/procedures-areas.md
@@ -1,5 +1,5 @@
 ---
 title: Common Issue Locations
 description: This page describes common areas of issues around the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/areas.html
+redirect_to: https://dotty.epfl.ch/docs/contributing/diagnosing-your-issue/areas.html
 ---

--- a/_overviews/scala3-contribution/procedures-cheatsheet.md
+++ b/_overviews/scala3-contribution/procedures-cheatsheet.md
@@ -1,5 +1,5 @@
 ---
 title: Cheatsheets
 description: This page describes a cheatsheet for working with the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/index.html#sbt-commands-cheat-sheet-1
+redirect_to: https://dotty.epfl.ch/docs/contributing/cheatsheet.html
 ---

--- a/_overviews/scala3-contribution/procedures-checklist.md
+++ b/_overviews/scala3-contribution/procedures-checklist.md
@@ -1,5 +1,5 @@
 ---
 title: Pull Request Checklist
 description: This page describes a checklist before opening a Pull Request to the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/checklist.html
+redirect_to: https://dotty.epfl.ch/docs/contributing/sending-in-a-pr.html
 ---

--- a/_overviews/scala3-contribution/procedures-debugging.md
+++ b/_overviews/scala3-contribution/procedures-debugging.md
@@ -1,5 +1,5 @@
 ---
 title: Debugging the Compiler
 description: This page describes navigating around the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/debugging.html
+redirect_to: https://dotty.epfl.ch/docs/contributing/debugging-the-compiler/index.html
 ---

--- a/_overviews/scala3-contribution/procedures-efficiency.md
+++ b/_overviews/scala3-contribution/procedures-efficiency.md
@@ -1,5 +1,5 @@
 ---
 title: Improving Your Workflow
 description: This page describes improving efficiency of debugging the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/efficiency.html
+redirect_to: https://dotty.epfl.ch/docs/contributing/diagnosing-your-issue/index.html
 ---

--- a/_overviews/scala3-contribution/procedures-inspection.md
+++ b/_overviews/scala3-contribution/procedures-inspection.md
@@ -1,5 +1,5 @@
 ---
 title: How to Inspect Values
 description: This page describes inspecting semantic values in the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/inspection.html
+redirect_to: https://dotty.epfl.ch/docs/contributing/debugging-the-compiler/inspection.html
 ---

--- a/_overviews/scala3-contribution/procedures-intro.md
+++ b/_overviews/scala3-contribution/procedures-intro.md
@@ -1,5 +1,5 @@
 ---
 title: Contributing to Scala 3
 description: This page introduces the compiler procedures for the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/index.html
+redirect_to: https://dotty.epfl.ch/docs/contributing/procedures/index.html
 ---

--- a/_overviews/scala3-contribution/procedures-navigation.md
+++ b/_overviews/scala3-contribution/procedures-navigation.md
@@ -1,5 +1,5 @@
 ---
 title: Finding the Cause of an Issue
 description: This page describes navigating around the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/cause.html
+redirect_to: https://dotty.epfl.ch/docs/contributing/diagnosing-your-issue/cause.html
 ---

--- a/_overviews/scala3-contribution/procedures-reproduce.md
+++ b/_overviews/scala3-contribution/procedures-reproduce.md
@@ -1,5 +1,5 @@
 ---
 title: Reproducing an Issue
 description: This page describes reproducing an issue in the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/reproduce.html
+redirect_to: https://dotty.epfl.ch/docs/contributing/diagnosing-your-issue/reproduce.html
 ---

--- a/_overviews/scala3-contribution/procedures-testing.md
+++ b/_overviews/scala3-contribution/procedures-testing.md
@@ -1,5 +1,5 @@
 ---
 title: Testing Your Changes
 description: This page describes test procedures in the Scala 3 compiler.
-redirect_to: https://dotty.epfl.ch/docs/contributing/workflow/testing.html
+redirect_to: https://dotty.epfl.ch/docs/contributing/testing.html
 ---


### PR DESCRIPTION
**Problem**
Build is failing on CI, unable to resolve some of the dead links.

**Solution**
This redirects some of the Dotty pages to the new pages.