### PR TITLE
minor fixes to concurrency page

### DIFF
--- a/_overviews/scala3-book/concurrency.md
+++ b/_overviews/scala3-book/concurrency.md
@@ -141,7 +141,7 @@ In addition to higher-order functions like `map`, you can also use callback meth
 One commonly used callback method is `onComplete`, which takes a *partial function* in which you handle the `Success` and `Failure` cases:
 
 ```scala
-eventualInt.onComplete {
+Future(longRunningAlgorithm()).onComplete {
   case Success(value) => println(s"Got the callback, value = $value")
   case Failure(e) => e.printStackTrace
 }

--- a/_overviews/scala3-book/concurrency.md
+++ b/_overviews/scala3-book/concurrency.md
@@ -117,10 +117,10 @@ Therefore, when you work with the result of a future, you use the usual `Try`-ha
 ### Using `map` with futures
 
 `Future` has a `map` method, which you use just like the `map` method on collections.
-This is what the result looks like when you call `map` right after creating the variable `f`:
+This is what the result looks like when you call `map` right after creating the variable `a`:
 
 ```scala
-scala> val a = eventualInt.map(_ * 2)
+scala> val a = Future(longRunningAlgorithm()).map(_ * 2)
 a: scala.concurrent.Future[Int] = Future(<not completed>)
 ```
 


### PR DESCRIPTION
If the user has been following along with a Scala REPL, `eventualInt` will have already been completed, and thus will return a result. Calling the function again and wrapping it in a Future will deterministically produce the intended result of an uncompleted Future.