### PR TITLE
Don't call out Apple Silicon as needing manual installation

### DIFF
--- a/_overviews/getting-started/index.md
+++ b/_overviews/getting-started/index.md
@@ -51,7 +51,7 @@ Install it on your system with the following instructions.
 {% tab macOS for=install-cs-setup-tabs %}
 Run the following command in your terminal, following the on-screen instructions:
 {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-brew %}
-{% altDetails cs-setup-macos-nobrew  "Alternatively for Apple Silicon, or if you don't use Homebrew:" %}
+{% altDetails cs-setup-macos-nobrew  "Alternatively, if you don't use Homebrew:" %}
   On the Apple Silicon (M1, M2, …) architecture:
   {% include code-snippet.html language='bash' codeSnippet=site.data.setup-scala.macOS-arm64 %}
   Otherwise, on the x86-64 architecture:


### PR DESCRIPTION
I have Apple Silicon and installed Scala fine for the first time via Homebrew.

See also https://github.com/scala/scala-lang/pull/1537