### PR TITLE
Scala 2.13.12

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ keywords:
 - Document
 - Guide
 
-scala-version: 2.13.11
+scala-version: 2.13.12
 scala-212-version: 2.12.18
 scala-3-version: 3.3.1
 

--- a/_overviews/FAQ/index.md
+++ b/_overviews/FAQ/index.md
@@ -120,14 +120,18 @@ with only minor supplements.  That's why `versionString` and
 `versionNumberString` report that Scala 2 is in use:
 
 ```
-Welcome to Scala 3.3.0 (17.0.3, Java OpenJDK 64-Bit Server VM).
+Welcome to Scala 3.3.1 (17.0.3, Java OpenJDK 64-Bit Server VM).
 Type in expressions for evaluation. Or try :help.
 
 scala> util.Properties.versionNumberString
-val res0: String = 2.13.11
+val res0: String = 2.13.10
 ```
 
-Note that Scala 3 offers
+Note that even the latest Scala 3 version might not use the very
+latest Scala 2 standard library, since the 3 and 2 release schedules
+aren't coordinated.
+
+So how do you ask for the Scala 3 version number? Scala 3 offers
 `dotty.tools.dotc.config.Properties.versionNumberString`, but only if
 you have scala3-compiler on the classpath. So that works in the Scala 3
 REPL, but won't work in typical Scala 3 application code.

--- a/_overviews/FAQ/index.md
+++ b/_overviews/FAQ/index.md
@@ -120,7 +120,7 @@ with only minor supplements.  That's why `versionString` and
 `versionNumberString` report that Scala 2 is in use:
 
 ```
-Welcome to Scala 3.2.0 (17.0.3, Java OpenJDK 64-Bit Server VM).
+Welcome to Scala 3.3.0 (17.0.3, Java OpenJDK 64-Bit Server VM).
 Type in expressions for evaluation. Or try :help.
 
 scala> util.Properties.versionNumberString

--- a/_overviews/contribute/bug-reporting-guide.md
+++ b/_overviews/contribute/bug-reporting-guide.md
@@ -65,7 +65,7 @@ If you cannot find your issue in the issue tracker, create a new bug. The detail
 
 Please make sure to fill in as many fields as possible. Make sure you've indicated the following:
 
- 1. **Exact Scala version** that you are using. For example, `2.13.11` or `3.3.0`. If the bug happens in multiple versions indicate all of them.
+ 1. **Exact Scala version** that you are using. For example, `2.13.12` or `3.3.0`. If the bug happens in multiple versions indicate all of them.
  2. **The component** that is affected by the bug. For example, the Standard Library, Scaladoc, etc.
  3. **Labels** related to your issue. For example, if you think your issue is related to the typechecker, and if you have successfully minimized your issue, label your bug as "typechecker" and "minimized". Issue tracker will suggest names for existing labels as you type them so try not to create duplicates.
  4. **Running environment**. Are you running on Linux? Windows? What JVM version are you using?

--- a/_overviews/contributors/index.md
+++ b/_overviews/contributors/index.md
@@ -360,7 +360,7 @@ If you have written a library, you probably want it to be usable from several Sc
 Define the versions you want to support in the `crossScalaVersions` setting, in your `build.sbt` file:
 
 ~~~ scala
-crossScalaVersions := Seq("3.3.0", "2.13.11", "2.12.18")
+crossScalaVersions := Seq("3.3.0", "2.13.12", "2.12.18")
 scalaVersion := crossScalaVersions.value.head
 ~~~
 

--- a/api/all.md
+++ b/api/all.md
@@ -10,10 +10,10 @@ redirect_from:
 
 * Scala 3.3.1 LTS
   * [Library API](https://www.scala-lang.org/api/3.3.1/)
-* Scala 2.13.11
-  * [Library API](https://www.scala-lang.org/api/2.13.11/)
-  * [Compiler API](https://www.scala-lang.org/api/2.13.11/scala-compiler/scala/)
-  * [Reflection API](https://www.scala-lang.org/api/2.13.11/scala-reflect/scala/reflect/)
+* Scala 2.13.12
+  * [Library API](https://www.scala-lang.org/api/2.13.12/)
+  * [Compiler API](https://www.scala-lang.org/api/2.13.12/scala-compiler/scala/)
+  * [Reflection API](https://www.scala-lang.org/api/2.13.12/scala-reflect/scala/reflect/)
 * Scala 2.12.18
   * [Library API](https://www.scala-lang.org/api/2.12.18/)
   * [Compiler API](https://www.scala-lang.org/api/2.12.18/scala-compiler/scala/)
@@ -84,6 +84,10 @@ https://scala-ci.typesafe.com/artifactory/scala-integration/org/scala-lang/
   * [Library API](https://www.scala-lang.org/api/3.0.1/)
 * Scala 3.0.0
   * [Library API](https://www.scala-lang.org/api/3.0.0/)
+* Scala 2.13.11
+  * [Library API](https://www.scala-lang.org/api/2.13.11/)
+  * [Compiler API](https://www.scala-lang.org/api/2.13.11/scala-compiler/scala/)
+  * [Reflection API](https://www.scala-lang.org/api/2.13.11/scala-reflect/scala/reflect/)
 * Scala 2.13.10
   * [Library API](https://www.scala-lang.org/api/2.13.10/)
   * [Compiler API](https://www.scala-lang.org/api/2.13.10/scala-compiler/scala/)

--- a/scripts/run-mdoc.sh
+++ b/scripts/run-mdoc.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -eux
 
-cs launch --scala-version 2.13.11 org.scalameta::mdoc:2.3.3 -- \
+cs launch --scala-version 2.13.12 org.scalameta::mdoc:2.3.3 -- \
   --in . \
   --out /tmp/mdoc-out/ \
   --classpath \
-  $(cs fetch --scala-version 2.13.11 -p \
+  $(cs fetch --scala-version 2.13.12 -p \
     com.chuusai::shapeless:2.3.10 \
     org.scala-lang::toolkit:0.1.7 \
     org.scala-lang::toolkit-test:0.1.7 \


### PR DESCRIPTION
(should re-run CI after API docs finish publishing)