### PR TITLE
fix outdated default value of minThreads

### DIFF
--- a/_overviews/core/futures.md
+++ b/_overviews/core/futures.md
@@ -101,7 +101,7 @@ By default, the `ExecutionContext.global` sets the parallelism level of its unde
 ([Runtime.availableProcessors](https://docs.oracle.com/javase/7/docs/api/java/lang/Runtime.html#availableProcessors%28%29)).
 This configuration can be overridden by setting one (or more) of the following VM attributes:
 
-  * scala.concurrent.context.minThreads - defaults to `Runtime.availableProcessors`
+  * scala.concurrent.context.minThreads - defaults to `1`
   * scala.concurrent.context.numThreads - can be a number or a multiplier (N) in the form 'xN' ;  defaults to `Runtime.availableProcessors`
   * scala.concurrent.context.maxThreads - defaults to `Runtime.availableProcessors`
 


### PR DESCRIPTION
Fix an outdated default value for the `scala.concurrent.context.minThreads` VM attribute used in the global execution context.

This value was correct when this page was written but it is not the case anymore, since this commit:
https://github.com/scala/scala/commit/e230409c13de167b0f4010464c74328ff91d9043

The default value is now "1" as described in the JavaDoc of the global execution context:
https://github.com/scala/scala/blob/2.13.x/src/library/scala/concurrent/ExecutionContext.scala#L127

Or in the implementation directly:
https://github.com/scala/scala/blob/2.13.x/src/library/scala/concurrent/impl/ExecutionContextImpl.scala#L92