### PR TITLE
fix typo and bump scala 2.13 version

### DIFF
--- a/_overviews/scala3-migration/tutorial-macro-mixing.md
+++ b/_overviews/scala3-migration/tutorial-macro-mixing.md
@@ -106,8 +106,8 @@ lazy val example = project.in(file("example"))
 
 lazy val `example-compat` = project.in(file("example-compat"))
   .settings(
-    scalaVersion := "2.13.11",
-    libraryDependency += "org.scala-lang" % "scala-reflect" % scalaVersion.value
+    scalaVersion := "2.13.12",
+    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
   )
 ```
 
@@ -151,7 +151,7 @@ Since we want to execute the tests in Scala 2.13 and Scala 3, we create a cross-
 lazy val `example-test` = project.in(file("example-test"))
   .settings(
     scalaVersion := "3.3.1",
-    crossScalaVersions := Seq("3.3.1", "2.13.11"),
+    crossScalaVersions := Seq("3.3.1", "2.13.12"),
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 13)) => Seq("-Ytasty-reader")
@@ -185,7 +185,7 @@ class MacrosSpec extends munit.FunSuite {
 You should now be able to run the tests in both versions.
 
 {% highlight text %}
-sbt:example> ++2.13.11
+sbt:example> ++2.13.12
 sbt:example> example-test / test
 location.MacrosSpec:
   + location
@@ -213,7 +213,7 @@ You are now ready to publish your library.
 It can be used in Scala 3 projects, or in Scala 2.13 projects with these settings:
 
 ```scala
-scalaVersion := "2.13.11"
+scalaVersion := "2.13.12"
 libraryDependencies += ("org" %% "example" % "x.y.z").cross(CrossVersion.for2_13Use3)
 scalacOptions += "-Ytasty-reader"
 ```


### PR DESCRIPTION
I discovered that the suggested code did not compile, because it uses `libraryDependency` (doesn't exist) rather than `libraryDependencies`

This PR fixes that typo, and also updates the example version from 2.13.11 to 2.13.12 (latest)