### PR TITLE
Remove all references to unsupported rewrite rules

### DIFF
--- a/_overviews/scala3-migration/incompat-contextual-abstractions.md
+++ b/_overviews/scala3-migration/incompat-contextual-abstractions.md
@@ -11,7 +11,7 @@ The redesign of [contextual abstractions]({{ site.scala3ref }}/contextual) bring
 
 |Incompatibility|Scala 2.13|Scala 3 Migration Rewrite|Scalafix Rule|Runtime Incompatibiltiy|
 |--- |--- |--- |--- |--- |
-|[Type of implicit def](#type-of-implicit-definition)|||[✅](https://github.com/ohze/scala-rewrites#fixexplicittypesexplicitimplicittypes)||
+|[Type of implicit def](#type-of-implicit-definition)|||[✅](https://scalacenter.github.io/scalafix/docs/rules/ExplicitResultTypes.html)||
 |[Implicit views](#implicit-views)||||**Possible**|
 |[View bounds](#view-bounds)|Deprecation||||
 |[Ambiguous conversion on `A` and `=> A`](#ambiguous-conversion-on-a-and--a)|||||
@@ -21,7 +21,7 @@ The redesign of [contextual abstractions]({{ site.scala3ref }}/contextual) bring
 The type of implicit definitions (`val` or `def`) needs to be given explicitly in Scala 3.
 They cannot be inferred anymore.
 
-The Scalafix rule named `ExplicitImplicitTypes` in [ohze/scala-rewrites](https://github.com/ohze/scala-rewrites#fixexplicittypesexplicitimplicittypes) repository can write the missing type annotations automatically.
+The Scalafix rule named [ExplicitResultTypes](https://scalacenter.github.io/scalafix/docs/rules/ExplicitResultTypes.html) can write the missing type annotations automatically.
 
 ## Implicit Views
 

--- a/_overviews/scala3-migration/incompat-syntactic.md
+++ b/_overviews/scala3-migration/incompat-syntactic.md
@@ -18,7 +18,8 @@ It is worth noting that most of the changes can be automatically handled during 
 |--- |--- |--- |--- |
 |[Restricted keywords](#restricted-keywords)||✅||
 |[Procedure syntax](#procedure-syntax)|Deprecation|✅|[✅](https://scalacenter.github.io/scalafix/docs/rules/ProcedureSyntax.html)|
-|[Parentheses around lambda parameter](#parentheses-around-lambda-parameter)||✅|||✅||
+|[Parentheses around lambda parameter](#parentheses-around-lambda-parameter)||✅||
+|[Open brace indentation for passing an argument](#open-brace-indentation-for-passing-an-argument)||✅||
 |[Wrong indentation](#wrong-indentation)||||
 |[`_` as a type parameter](#_-as-a-type-parameter)||||
 |[`+` and `-` as type parameters](#-and---as-type-parameters)||||

--- a/_overviews/scala3-migration/incompat-syntactic.md
+++ b/_overviews/scala3-migration/incompat-syntactic.md
@@ -18,8 +18,7 @@ It is worth noting that most of the changes can be automatically handled during 
 |--- |--- |--- |--- |
 |[Restricted keywords](#restricted-keywords)||✅||
 |[Procedure syntax](#procedure-syntax)|Deprecation|✅|[✅](https://scalacenter.github.io/scalafix/docs/rules/ProcedureSyntax.html)|
-|[Parentheses around lambda parameter](#parentheses-around-lambda-parameter)||✅|[✅](https://github.com/ohze/scala-rewrites/tree/dotty/#fixscala213parensaroundlambda)|
-|[Open brace indentation for passing an argument](#open-brace-indentation-for-passing-an-argument)||✅||
+|[Parentheses around lambda parameter](#parentheses-around-lambda-parameter)||✅|||✅||
 |[Wrong indentation](#wrong-indentation)||||
 |[`_` as a type parameter](#_-as-a-type-parameter)||||
 |[`+` and `-` as type parameters](#-and---as-type-parameters)||||

--- a/_overviews/scala3-migration/incompatibility-table.md
+++ b/_overviews/scala3-migration/incompatibility-table.md
@@ -37,7 +37,7 @@ Some of the old syntax is not supported anymore.
 |--- |--- |--- |--- |
 |[Restricted keywords](incompat-syntactic.html#restricted-keywords)||✅||
 |[Procedure syntax](incompat-syntactic.html#procedure-syntax)|Deprecation|✅|[✅](https://scalacenter.github.io/scalafix/docs/rules/ProcedureSyntax.html)|
-|[Parentheses around lambda parameter](incompat-syntactic.html#parentheses-around-lambda-parameter)||✅|[✅](https://github.com/ohze/scala-rewrites/tree/dotty/#fixscala213parensaroundlambda)|
+|[Parentheses around lambda parameter](incompat-syntactic.html#parentheses-around-lambda-parameter)||✅||
 |[Open brace indentation for passing an argument](incompat-syntactic.html#open-brace-indentation-for-passing-an-argument)||✅||
 |[Wrong indentation](incompat-syntactic.html#wrong-indentation)||||
 |[`_` as a type parameter](incompat-syntactic.html#_-as-a-type-parameter)||||
@@ -63,7 +63,7 @@ The redesign of [contextual abstractions]({{ site.scala3ref }}/contextual) bring
 
 |Incompatibility|Scala 2.13|Scala 3 Migration Rewrite|Scalafix Rule|Runtime Incompatibility|
 |--- |--- |--- |--- |--- |
-|[Type of implicit def](incompat-contextual-abstractions.html#type-of-implicit-definition)|||[✅](https://github.com/ohze/scala-rewrites#fixexplicittypesexplicitimplicittypes)||
+|[Type of implicit def](incompat-contextual-abstractions.html#type-of-implicit-definition)|||[✅](https://scalacenter.github.io/scalafix/docs/rules/ExplicitResultTypes.html)||
 |[Implicit views](incompat-contextual-abstractions.html#implicit-views)||||**Possible**|
 |[View bounds](incompat-contextual-abstractions.html#view-bounds)|Deprecation||||
 |[Ambiguous conversion on `A` and `=> A`](incompat-contextual-abstractions.html#ambiguous-conversion-on-a-and--a)|||||

--- a/_overviews/scala3-migration/scala3-migrate.md
+++ b/_overviews/scala3-migration/scala3-migrate.md
@@ -337,11 +337,11 @@ This command runs a number of Scalafix rules to patch some discarded syntax.
 
 The list of applied Scalafix rules are: 
 - [ProcedureSyntax](https://scalacenter.github.io/scalafix/docs/rules/ProcedureSyntax.html)
-- [fix.scala213.ConstructorProcedureSyntax](https://github.com/ohze/scala-rewrites/tree/dotty/#fixscala213constructorproceduresyntax)
 - [fix.scala213.ExplicitNullaryEtaExpansion](https://github.com/lightbend-labs/scala-rewrites/blob/main/rewrites/src/main/scala/fix/scala213/ExplicitNullaryEtaExpansion.scala)
-- [fix.scala213.ParensAroundLambda](https://github.com/ohze/scala-rewrites/tree/dotty/#fixscala213parensaroundlambda)
+- [migrate.ParensAroundLambda](https://github.com/scalacenter/scala3-migrate/blob/ebb4a4087ed11899b9010f4c75eb365532694c0a/scalafix/rules/src/main/scala/migrate/ParensAroundParam.scala#L9)
 - [fix.scala213.ExplicitNonNullaryApply](https://github.com/lightbend-labs/scala-rewrites/blob/main/rewrites/src/main/scala/fix/scala213/ExplicitNullaryEtaExpansion.scala)
 - [fix.scala213.Any2StringAdd](https://github.com/lightbend-labs/scala-rewrites/blob/main/rewrites/src/main/scala/fix/scala213/Any2StringAdd.scala)
+- [ExplicitResultTypes](https://scalacenter.github.io/scalafix/docs/rules/ExplicitResultTypes.html)
 
 For more information about the syntax changes between Scala 2.13 and Scala 3, you can refer to [the Incompatibility Table](incompatibility-table.html).
 

--- a/_overviews/scala3-migration/tooling-tour.md
+++ b/_overviews/scala3-migration/tooling-tour.md
@@ -107,7 +107,6 @@ So far the relevant rules are:
 - [Procedure Syntax](https://scalacenter.github.io/scalafix/docs/rules/ProcedureSyntax.html)
 - [Explicit Result Types](https://scalacenter.github.io/scalafix/docs/rules/ExplicitResultTypes.html)
 - Value Eta-Expansion: `fix.scala213.ExplicitNullaryEtaExpansion` in [scala/scala-rewrites](https://github.com/scala/scala-rewrites/blob/main/rewrites/src/main/scala/fix/scala213/ExplicitNullaryEtaExpansion.scala)
-- Parentheses Around Lambda Parameter: `fix.scala213.ParensAroundLambda` in [ohze/scala-rewrites](https://github.com/ohze/scala-rewrites/blob/dotty/rewrites/src/main/scala/fix/scala213/ParensAroundLambda.scala)
 - Auto Application: `fix.scala213.ExplicitNonNullaryApply` in [scala/scala-rewrites](https://github.com/scala/scala-rewrites/blob/main/rewrites/src/main/scala/fix/scala213/ExplicitNonNullaryApply.scala)
 - `any2stringadd` Conversion: `fix.scala213.Any2StringAdd` in [scala/scala-rewrites](https://github.com/scala/scala-rewrites/blob/main/rewrites/src/main/scala/fix/scala213/Any2StringAdd.scala)
 


### PR DESCRIPTION
I spent a while trying to get the documented rule to work, but the release versions of the rule were confusing and the rules hadn't been built by any recent version of scalafix and the older versions didn't work with the latest scala 2.13 versions.  It looked like they were knocked up to get a specific migration done and then unmaintained.

I didn't have any luck trying to build them myself, then once I gave up I found a ready made built in scalafix rule that did exactly what I needed!

This PR updates the docs accordingly.

I also had a search through and found a few more outdated references to update.