### PR TITLE
Remove a rotten link on https://docs.scala-lang.org/scala3/book/fp-intro.html

### DIFF
--- a/_overviews/scala3-book/fp-intro.md
+++ b/_overviews/scala3-book/fp-intro.md
@@ -10,7 +10,7 @@ next-page: fp-what-is-fp
 
 
 Scala lets you write code in an object-oriented programming (OOP) style, a functional programming (FP) style, and also in a hybrid style---using both approaches in combination.
-The essence of Scala is a fusion of functional and object-oriented programming in a typed setting:
+As stated by Martin Odersky, the creator of Scala, the essence of Scala is a fusion of functional and object-oriented programming in a typed setting:
 
 - Functions for the logic
 - Objects for the modularity

--- a/_overviews/scala3-book/fp-intro.md
+++ b/_overviews/scala3-book/fp-intro.md
@@ -10,7 +10,7 @@ next-page: fp-what-is-fp
 
 
 Scala lets you write code in an object-oriented programming (OOP) style, a functional programming (FP) style, and also in a hybrid style---using both approaches in combination.
-[As Martin Odersky has stated](https://twitter.com/alexelcu/status/996408359514525696), the essence of Scala is a fusion of functional and object-oriented programming in a typed setting:
+The essence of Scala is a fusion of functional and object-oriented programming in a typed setting:
 
 - Functions for the logic
 - Objects for the modularity


### PR DESCRIPTION
Maybe the link is not 'rotten' in a common sense of it, but it definitely does not work for me as a signed out user: https://twitter.com/alexelcu/status/996408359514525696
<img width="1440" alt="image" src="https://github.com/scala/docs.scala-lang/assets/4324068/87e95180-9146-49e9-b347-5ddaea1239e3">
