### PR TITLE
Fixed types-variance.md contravariant example code comment

### DIFF
--- a/_overviews/scala3-book/types-variance.md
+++ b/_overviews/scala3-book/types-variance.md
@@ -219,7 +219,7 @@ val f: Function[Buyable, Buyable] = b => b
 // OK to return a Buyable where a Item is expected
 val g: Function[Buyable, Item] = f
 
-// OK to provide a Book where a Buyable is expected
+// OK to provide a Buyable where a Book is expected
 val h: Function[Book, Buyable] = f
 ```
 {% endtab %}


### PR DESCRIPTION
Fixed the second code comment for the last example just before the summary. The words "Book" and "Buyable" needed to be swapped. This makes it consistent with how the first comment uses the term "expected", where "expected" refers to the type you see in the following line of code. The first code comment is referring to the return type in the next line of code. The second comment is referring to the parameter type in the following line of code. Therefore, in the second code comment, "Book" is what is "expected" (by the h type), and "Buyable" is what is "provided" by the f parameter type.