### PR TITLE
CI: bump actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,14 +4,14 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0.5
           bundler-cache: true
       - name: Set up coursier
-        uses: coursier/setup-action@v1.2.0-M2
+        uses: coursier/setup-action@v1.3.4
         with:
           jvm: adopt:11
       - name: Run mdoc

--- a/_overviews/scala-book/sbt-scalatest-bdd.md
+++ b/_overviews/scala-book/sbt-scalatest-bdd.md
@@ -113,5 +113,5 @@ If you want to have a little fun with this, change one or more of the tests so t
 
 For more information about sbt and ScalaTest, see the following resources:
 
-- [The main sbt documentation](http://www.scala-sbt.org/documentation.html)
-- [The ScalaTest documentation](http://www.scalatest.org/user_guide)
+- [The main sbt documentation](https://www.scala-sbt.org/1.x/docs/)
+- [The ScalaTest documentation](https://www.scalatest.org/user_guide)


### PR DESCRIPTION
GitHub is whining (rightly, I guess) about this at e.g. https://github.com/scala/docs.scala-lang/actions/runs/7731097673