### PR TITLE
Clearer points in favour of macro mixing

### DIFF
--- a/_overviews/scala3-migration/compatibility-metaprogramming.md
+++ b/_overviews/scala3-migration/compatibility-metaprogramming.md
@@ -63,7 +63,10 @@ You can learn all the new metaprogramming concepts by reading the [Macros in Sca
 ## Cross-building a Macro Library
 
 You have written a wonderful macro library and you would like it to be available in Scala 2.13 and Scala 3.
-There are two different approaches, the traditional cross-building technique and the more experimental mixing macro technique.
+There are two different approaches, the traditional cross-building technique and the more flexible macro mixing technique.
+
+The benefit of macro mixing is that consumers who take advantage of the `-Ytasty-reader` option can still use your macros.
+
 You can learn about them by reading these tutorials:
 - [Cross-Building a Macro Library](tutorial-macro-cross-building.html)
 - [Mixing Scala 2.13 and Scala 3 Macros](tutorial-macro-mixing.html)

--- a/_overviews/scala3-migration/tutorial-macro-mixing.md
+++ b/_overviews/scala3-migration/tutorial-macro-mixing.md
@@ -7,10 +7,12 @@ previous-page: tutorial-macro-mixing
 next-page: tooling-syntax-rewriting
 ---
 
-This tutorial shows how to mix Scala 2.13 and Scala 3 macros in a single artifact.  There are two main benefits of this:
+This tutorial shows how to mix Scala 2.13 and Scala 3 macros in a single artifact.  This means that consumers can use '-Ytasty-reader' from Scala 2.13 code that uses your macros.
+
+There are two main benefits of this:
 
 1. Making a new or existing scala 3 macro library available for Scala 2.13 users without having to provide a separate 2.13 version
-2. Allowing multi-project builds to be upgraded module by module, even where macro libraries are used.
+2. Allowing your macros to be usable in multi-project builds that are being upgraded module by module.
 
 ## Introduction
 

--- a/_overviews/scala3-migration/tutorial-macro-mixing.md
+++ b/_overviews/scala3-migration/tutorial-macro-mixing.md
@@ -7,10 +7,10 @@ previous-page: tutorial-macro-mixing
 next-page: tooling-syntax-rewriting
 ---
 
-This tutorial shows how to mix Scala 2.13 and Scala 3 macros in a single artifact.
+This tutorial shows how to mix Scala 2.13 and Scala 3 macros in a single artifact.  There are two main benefits of this:
 
-It can be used to create a new Scala 3 macro library and make it available for Scala 2.13 users.
-It can also be used to port an existing Scala 2.13 macro library to Scala 3, although it is probably easier to cross-build.
+1. Making a new or existing scala 3 macro library available for Scala 2.13 users without having to provide a separate 2.13 version
+2. Allowing multi-project builds to be upgraded module by module, even where macro libraries are used.
 
 ## Introduction
 


### PR DESCRIPTION
This PR updates the scala 3 migration docs to emphasis the benefits of macro mixing rather than indicating that it's experimental.

--

The background is as follows:

We are trying to update our code gradually to scala 3.  In one case we have a large multi project build which produces many semi-related jar files for deployment into AWS lambda.

I am trying to update this module by module, but I quickly hit an issue where play-json had scala 2.13 and 3 versions.

Normally I would just force version 3 and use `-Ytasty-reader`, however in this case because it's a macro library, the modules remaining on scala 2.13 didn't compile any more.

I proposed adding macro mixing to the library, but this was pushed back on the basis that it wasn't necessary and is not promoted by the docs.  See the issue below:
https://github.com/playframework/play-json/issues/954

I think this is not really accurate (is it?) and I think this is going to be a blocker for all of our larger repos in our company, and possibly other organisations.