### PR TITLE
Scala 2.12.19

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ keywords:
 - Guide
 
 scala-version: 2.13.12
-scala-212-version: 2.12.18
+scala-212-version: 2.12.19
 scala-3-version: 3.3.1
 
 collections:

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -14,9 +14,8 @@ Minimum Scala versions:
 
 | JDK         | 3        | 2.13      | 2.12      | 2.11       |
 |:-----------:|:--------:|:---------:|:---------:|:----------:|
-| 22 (ea)     | 3.3.2*   | 2.13.12   | 2.12.19*  |            |
+| 22 (ea)     | 3.3.2*   | 2.13.12   | 2.12.19   |            |
 | 21 (LTS)    | 3.3.1    | 2.13.11   | 2.12.18   |            |
-| 20          | 3.3.0    | 2.13.11   | 2.12.18   |            |
 | 17 (LTS)    | 3.0.0    | 2.13.6    | 2.12.15   |            |
 | 11 (LTS)    | 3.0.0    | 2.13.0    | 2.12.4    | 2.11.12    |
 | 8 (LTS)     | 3.0.0    | 2.13.0    | 2.12.0    | 2.11.0     |
@@ -36,7 +35,6 @@ Minimum working versions:
 | JDK         | sbt             | mill       |
 |:-----------:|:---------------:|:-----------|
 | 21 (LTS)    | 1.9.0           | 0.11.5     |
-| 20          | 1.9.0           | 0.11.0     |
 | 17 (LTS)    | 1.6.0           | 0.7.0      |
 | 11 (LTS)    | 1.1.0           | 0.1.5      |
 | 8 (LTS)     | 1.0.0           | 0.1.0      |
@@ -116,10 +114,10 @@ For possible Scala issues, see the [jdk11](https://github.com/scala/bug/labels/j
 Early access builds of JDK 22 are available. JDK 22 will be non-LTS.
 
 Initial support for JDK 22 has been merged and is now available in
-Scala 2.13.12.
+Scala 2.13.12 and 2.12.19.
 
-We are working on adding JDK 22 support to the 2.12.x and 3.3.x
-release series. (Support may be available in nightly builds.)
+We are working on adding JDK 22 support to the 3.3.x release
+series. (Support may be available in nightly builds.)
 
 ## GraalVM Native Image compatibility notes
 

--- a/api/all.md
+++ b/api/all.md
@@ -14,14 +14,14 @@ redirect_from:
   * [Library API](https://www.scala-lang.org/api/2.13.12/)
   * [Compiler API](https://www.scala-lang.org/api/2.13.12/scala-compiler/scala/)
   * [Reflection API](https://www.scala-lang.org/api/2.13.12/scala-reflect/scala/reflect/)
-* Scala 2.12.18
-  * [Library API](https://www.scala-lang.org/api/2.12.18/)
-  * [Compiler API](https://www.scala-lang.org/api/2.12.18/scala-compiler/scala/)
-  * [Reflection API](https://www.scala-lang.org/api/2.12.18/scala-reflect/scala/reflect/)
+* Scala 2.12.19
+  * [Library API](https://www.scala-lang.org/api/2.12.19/)
+  * [Compiler API](https://www.scala-lang.org/api/2.12.19/scala-compiler/scala/)
+  * [Reflection API](https://www.scala-lang.org/api/2.12.19/scala-reflect/scala/reflect/)
   * Scala Modules
-    * [XML API](https://www.scala-lang.org/api/2.12.18/scala-xml/scala/xml/)
-    * [Parser Combinators API](https://www.scala-lang.org/api/2.12.18/scala-parser-combinators/scala/util/parsing/)
-    * [Swing API](https://www.scala-lang.org/api/2.12.18/scala-swing/scala/swing/)
+    * [XML API](https://www.scala-lang.org/api/2.12.19/scala-xml/scala/xml/)
+    * [Parser Combinators API](https://www.scala-lang.org/api/2.12.19/scala-parser-combinators/scala/util/parsing/)
+    * [Swing API](https://www.scala-lang.org/api/2.12.19/scala-swing/scala/swing/)
 * Scala 2.11.12
   * [Library API](https://www.scala-lang.org/api/2.11.12/)
   * [Compiler API](https://www.scala-lang.org/api/2.11.12/scala-compiler/)
@@ -132,6 +132,14 @@ https://scala-ci.typesafe.com/artifactory/scala-integration/org/scala-lang/
   * [Library API](https://www.scala-lang.org/api/2.13.0/)
   * [Compiler API](https://www.scala-lang.org/api/2.13.0/scala-compiler/scala/)
   * [Reflection API](https://www.scala-lang.org/api/2.13.0/scala-reflect/scala/reflect/)
+* Scala 2.12.18
+  * [Library API](https://www.scala-lang.org/api/2.12.18/)
+  * [Compiler API](https://www.scala-lang.org/api/2.12.18/scala-compiler/scala/)
+  * [Reflection API](https://www.scala-lang.org/api/2.12.18/scala-reflect/scala/reflect/)
+  * Scala Modules
+    * [XML API](https://www.scala-lang.org/api/2.12.18/scala-xml/scala/xml/)
+    * [Parser Combinators API](https://www.scala-lang.org/api/2.12.18/scala-parser-combinators/scala/util/parsing/)
+    * [Swing API](https://www.scala-lang.org/api/2.12.18/scala-swing/scala/swing/)
 * Scala 2.12.17
   * [Library API](https://www.scala-lang.org/api/2.12.17/)
   * [Compiler API](https://www.scala-lang.org/api/2.12.17/scala-compiler/scala/)


### PR DESCRIPTION
for merge later this week; see https://github.com/scala/scala-dev/issues/858 and https://contributors.scala-lang.org/t/scala-2-12-19-release-planning/6216/