### PR TITLE
Fix numbering conflict in methods-main-methods.md.

### DIFF
--- a/_overviews/scala3-book/methods-main-methods.md
+++ b/_overviews/scala3-book/methods-main-methods.md
@@ -123,8 +123,8 @@ The Scala compiler generates a program from an `@main` method `f` as follows:
 
 For instance, the `happyBirthday` method above generates additional code equivalent to the following class:
 
-{% tabs method_3 %}
-{% tab 'Scala 3 Only' for=method_3 %}
+{% tabs method_4 %}
+{% tab 'Scala 3 Only' for=method_4 %}
 
 ```scala
 final class happyBirthday {
@@ -158,7 +158,7 @@ The previous functionality of `App`, which relied on the “magic” `DelayedIni
 
 If programs need to cross-build between Scala 2 and Scala 3, it’s recommended to use an `object` with an explicit `main` method and a single `Array[String]` argument instead:
 
-{% tabs method_4 %}
+{% tabs method_5 %}
 {% tab 'Scala 2 and 3' %}
 
 ```scala


### PR DESCRIPTION
Two different code snippets on the same page are named `method_3`. This causes a rendering bug (at least on Chrome 122.0.6261.94 for MacOS/Intel).

This PR renumbers the second `method_3` and `method_4` to remove the conflict.