### PR TITLE
JDK 22 and 23

### DIFF
--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -14,6 +14,7 @@ Minimum Scala versions:
 
 | JDK         | 3        | 2.13      | 2.12      | 2.11       |
 |:-----------:|:--------:|:---------:|:---------:|:----------:|
+| 23 (ea)     | 3.3.5*   | 2.13.14*  | 2.12.20*  |            |
 | 22          | 3.3.4*   | 2.13.12   | 2.12.19   |            |
 | 21 (LTS)    | 3.3.1    | 2.13.11   | 2.12.18   |            |
 | 17 (LTS)    | 3.0.0    | 2.13.6    | 2.12.15   |            |
@@ -117,6 +118,15 @@ Scala 2.13.12+ and 2.12.19+ support JDK 22.
 
 We are working on adding JDK 22 support to the 3.3.x release
 series. (Support may be available in nightly builds.)
+
+For possible Scala issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), and [jdk21](https://github.com/scala/bug/labels/jdk21) labels in the Scala 2 bug tracker.
+
+## JDK 23 compatibility notes
+
+Early access builds of JDK 23 are available. JDK 23 will be non-LTS.
+
+We are working on adding JDK 22 support to Scala 3 and Scala 2.
+(Support may be available in nightly builds.)
 
 For possible Scala issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), and [jdk21](https://github.com/scala/bug/labels/jdk21) labels in the Scala 2 bug tracker.
 

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -14,7 +14,7 @@ Minimum Scala versions:
 
 | JDK         | 3        | 2.13      | 2.12      | 2.11       |
 |:-----------:|:--------:|:---------:|:---------:|:----------:|
-| 22 (ea)     | 3.3.4*   | 2.13.12   | 2.12.19   |            |
+| 22          | 3.3.4*   | 2.13.12   | 2.12.19   |            |
 | 21 (LTS)    | 3.3.1    | 2.13.11   | 2.12.18   |            |
 | 17 (LTS)    | 3.0.0    | 2.13.6    | 2.12.15   |            |
 | 11 (LTS)    | 3.0.0    | 2.13.0    | 2.12.4    | 2.11.12    |
@@ -111,13 +111,14 @@ For possible Scala issues, see the [jdk11](https://github.com/scala/bug/labels/j
 
 ## JDK 22 compatibility notes
 
-Early access builds of JDK 22 are available. JDK 22 will be non-LTS.
+JDK 22 is non-LTS.
 
-Initial support for JDK 22 has been merged and is now available in
-Scala 2.13.12 and 2.12.19.
+Scala 2.13.12+ and 2.12.19+ support JDK 22.
 
 We are working on adding JDK 22 support to the 3.3.x release
 series. (Support may be available in nightly builds.)
+
+For possible Scala issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), and [jdk21](https://github.com/scala/bug/labels/jdk21) labels in the Scala 2 bug tracker.
 
 ## GraalVM Native Image compatibility notes
 

--- a/_overviews/tutorials/binary-compatibility-for-library-authors.md
+++ b/_overviews/tutorials/binary-compatibility-for-library-authors.md
@@ -147,7 +147,7 @@ How can we, as library authors, spare our users of runtime errors and dependency
 It works by comparing the class files of two provided JARs and report any binary incompatibilities found. 
 Both backwards and forwards binary incompatibility can be detected by swapping input order of the JARs.
 
-By incorporating MiMa's [sbt plugin](https://github.com/lightbend/mima/wiki/sbt-plugin) into your sbt build, you can easily check whether 
+By incorporating MiMa's [sbt plugin](https://github.com/lightbend/mima#sbt) into your sbt build, you can easily check whether 
 you have accidentally introduced binary incompatible changes. Detailed instruction on how to use the sbt plugin can be found in the link.
 
 We strongly encourage every library author to incorporate MiMa into their continuous integration and release workflow.


### PR DESCRIPTION
- JDK 22 is now in General Availability
- add JDK 23 (early access)
