### PR TITLE
Fix wrong naming in variables and method

### DIFF
--- a/_es/tour/named-arguments.md
+++ b/_es/tour/named-arguments.md
@@ -11,24 +11,23 @@ previous-page: default-parameter-values
 
 En la invocación de métodos y funciones se puede usar el nombre de las variables explícitamente en la llamada, de la siguiente manera:
 
-      def imprimirNombre(nombre:String, apellido:String) = {
+      def imprimirNombre(nombre: String, apellido: String) = {
         println(nombre + " " + apellido)
       }
 
       imprimirNombre("John","Smith")
       // Imprime "John Smith"
-      imprimirNombre(first = "John",last = "Smith")
+      imprimirNombre(nombre = "John", apellido = "Smith")
       // Imprime "John Smith"
-      imprimirNombre(last = "Smith",first = "John")
       // Imprime "John Smith"
 
 Note que una vez que se utilizan parámetros nombrados en la llamada, el orden no importa, mientras todos los parámetros sean nombrados. Esta característica funciona bien en conjunción con valores de parámetros por defecto:
 
-      def imprimirNombre(nombre:String = "John", apellido:String = "Smith") = {
+      def imprimirNombre(nombre: String = "John", apellido: String = "Smith") = {
         println(nombre + " " + apellido)
       }
 
-      printName(apellido = "Jones")
+      imprimirNombre(apellido = "Jones")
       // Imprime "John Jones"
 
 language: es

--- a/_es/tour/named-arguments.md
+++ b/_es/tour/named-arguments.md
@@ -19,6 +19,7 @@ En la invocación de métodos y funciones se puede usar el nombre de las variabl
       // Imprime "John Smith"
       imprimirNombre(nombre = "John", apellido = "Smith")
       // Imprime "John Smith"
+      imprimirNombre(apellido = "Smith", nombre = "John")
       // Imprime "John Smith"
 
 Note que una vez que se utilizan parámetros nombrados en la llamada, el orden no importa, mientras todos los parámetros sean nombrados. Esta característica funciona bien en conjunción con valores de parámetros por defecto:

--- a/_es/tour/unified-types.md
+++ b/_es/tour/unified-types.md
@@ -17,7 +17,7 @@ A diferencia de Java, todos los valores en Scala son objetos (incluyendo valores
 ## Jerarquía de clases en Scala ##
 
 La superclase de todas las clases, `scala.Any`, tiene dos subclases directas, `scala.AnyVal` y `scala.AnyRef` que representan dos mundos de clases muy distintos: clases para valores y clases para referencias. Todas las clases para valores están predefinidas; se corresponden con los tipos primitivos de los lenguajes tipo Java. Todas las otras clases definen tipos referenciables. Las clases definidas por el usuario son definidas como tipos referenciables por defecto, es decir, siempre (indirectamente) extienden de `scala.AnyRef`. Toda clase definida por usuario en Scala extiende implicitamente el trait `scala.ScalaObject`. Clases pertenecientes a la infraestructura en la cual Scala esté corriendo (ejemplo, el ambiente de ejecución de Java) no extienden de `scala.ScalaObject`. Si Scala es usado en el contexto de un ambiente de ejecución de Java, entonces `scala.AnyRef` corresponde a `java.lang.Object`.
-Por favor note que el diagrama superior también muestra conversiones implícitas llamadas viestas entre las clases para valores.
+Por favor note que el diagrama superior también muestra conversiones implícitas llamadas vistas entre las clases para valores.
 
 Aquí se muestra un ejemplo que demuestra que tanto valores numéricos, de caracteres, buleanos y funciones son objetos, tal como cualquier otro objeto:
 


### PR DESCRIPTION
![image](https://github.com/scala/docs.scala-lang/assets/63934927/beae2db6-2b3e-4449-954b-eaa46a74c2a3)
I noticed some errors with the arguments, they were not following the naming in Spanish. Also it should call `imprimirNombre` instead of `printName` and I fixed a small typo.