### PR TITLE
Update docs for `-release` to make it clear it accepts recent Java versions

### DIFF
--- a/_data/compiler-options.yml
+++ b/_data/compiler-options.yml
@@ -260,7 +260,7 @@
       type: "String"
       arg: "release"
       default:
-    description: "Compile for a specific version of the Java platform. Supported targets: 6, 7, 8, 9"
+    description: "Compile for a specific version of the Java platform. Supported targets: 8, 11, or any higher version listed at https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html"
     abbreviations:
     - "--release"
   - option: "-sourcepath"


### PR DESCRIPTION
The old displayed values of `6, 7, 8, 9` are confusing for developers contemplating updating to recent Java versions like `21` - [eg](https://github.com/guardian/mobile-save-for-later/pull/109/files#r1559390842)  :

> I was getting an error that -release:21 is not a valid compiler option when I ran the code. Looking at the docs: https://docs.scala-lang.org/overviews/compiler-options/ my understanding is that this is not supported for Java 21.

That's an incorrect understanding from the docs, as newer Java versions definitely are supported by the `-release` Scala compiler parameter - so it's best to clarify that!

In this case, the developer was getting the error because they were accidentally running with an older Java version (the compiler error could probably be clearer there too).