### PR TITLE
Toolkit tutorials: update Scala version

### DIFF
--- a/_includes/_markdown/install-munit.md
+++ b/_includes/_markdown/install-munit.md
@@ -18,7 +18,7 @@ In your build.sbt file, you can add the dependency on toolkit-test:
 ```scala
 lazy val example = project.in(file("example"))
   .settings(
-    scalaVersion := "3.2.2",
+    scalaVersion := "3.3.3",
     libraryDependencies += "org.scala-lang" %% "toolkit-test" % "0.1.7" % Test
   )
 ```
@@ -33,7 +33,7 @@ libraryDependencies += "org.scalameta" %% "munit" % "1.0.0-M7" % Test
 In your build.sc file, you can add a `test` object extending `Tests` and `TestModule.Munit`:
 ```scala
 object example extends ScalaModule {
-  def scalaVersion = "3.2.2"
+  def scalaVersion = "3.3.3"
   object test extends Tests with TestModule.Munit {
     def ivyDeps =
       Agg(

--- a/_includes/_markdown/install-os-lib.md
+++ b/_includes/_markdown/install-os-lib.md
@@ -17,7 +17,7 @@ In your `build.sbt`, you can add a dependency on the toolkit:
 ```scala
 lazy val example = project.in(file("example"))
   .settings(
-    scalaVersion := "3.2.2",
+    scalaVersion := "3.3.3",
     libraryDependencies += "org.scala-lang" %% "toolkit" % "0.1.7"
   )
 ```
@@ -30,7 +30,7 @@ libraryDependencies += "com.lihaoyi" %% "os-lib" % "0.9.1"
 In your `build.sc` file, you can add a dependency on the Toolkit:
 ```scala
 object example extends ScalaModule {
-  def scalaVersion = "3.2.2"
+  def scalaVersion = "3.3.3"
   def ivyDeps =
     Agg(
       ivy"org.scala-lang::toolkit:0.1.7"

--- a/_includes/_markdown/install-sttp.md
+++ b/_includes/_markdown/install-sttp.md
@@ -17,7 +17,7 @@ In your build.sbt file, you can add a dependency on the Toolkit:
 ```scala
 lazy val example = project.in(file("example"))
   .settings(
-    scalaVersion := "3.2.2",
+    scalaVersion := "3.3.3",
     libraryDependencies += "org.scala-lang" %% "toolkit" % "0.1.7"
   )
 ```
@@ -31,7 +31,7 @@ libraryDependencies += "com.softwaremill.sttp.client4" %% "core" % "4.0.0-M1"
 In your build.sc file, you can add a dependency on the Toolkit:
 ```scala
 object example extends ScalaModule {
-  def scalaVersion = "3.2.2"
+  def scalaVersion = "3.3.3"
   def ivyDeps =
     Agg(
       ivy"org.scala-lang::toolkit:0.1.7"

--- a/_includes/_markdown/install-upickle.md
+++ b/_includes/_markdown/install-upickle.md
@@ -17,7 +17,7 @@ In your build.sbt file, you can add the dependency on the Toolkit:
 ```scala
 lazy val example = project.in(file("example"))
   .settings(
-    scalaVersion := "3.2.2",
+    scalaVersion := "3.3.3",
     libraryDependencies += "org.scala-lang" %% "toolkit" % "0.1.7"
   )
 ```
@@ -30,7 +30,7 @@ libraryDependencies += "com.lihaoyi" %% "upickle" % "3.1.0"
 In your build.sc file, you can add the dependency to the upickle library:
 ```scala
 object example extends ScalaModule {
-  def scalaVersion = "3.2.2"
+  def scalaVersion = "3.3.3"
   def ivyDeps =
     Agg(
       ivy"org.scala-lang::toolkit:0.1.7"


### PR DESCRIPTION
a language newcomer on Discord hit this today — the Toolkit examples didn't work because the user used a newer sttp milestone that was built on Scala 3.3 and thus didn't work with 3.2