### PR TITLE
Toolkit tutorial: use same sttp version as toolkit actually includes

### DIFF
--- a/_includes/_markdown/install-sttp.md
+++ b/_includes/_markdown/install-sttp.md
@@ -9,7 +9,7 @@ You can require the entire toolkit in a single line:
 
 Alternatively, you can require just a specific version of sttp:
 ```scala
-//> using dep com.softwaremill.sttp.client4::core:4.0.0-M1
+//> using dep com.softwaremill.sttp.client4::core:4.0.0-M6
 ```
 {% endtab %}
 {% tab 'sbt' %}
@@ -24,7 +24,7 @@ lazy val example = project.in(file("example"))
 
 Alternatively, you can require just a specific version of sttp:
 ```scala
-libraryDependencies += "com.softwaremill.sttp.client4" %% "core" % "4.0.0-M1"
+libraryDependencies += "com.softwaremill.sttp.client4" %% "core" % "4.0.0-M6"
 ```
 {% endtab %}
 {% tab 'Mill' %}
@@ -40,7 +40,7 @@ object example extends ScalaModule {
 ```
 Alternatively, you can require just a specific version of sttp:
 ```scala
-ivy"com.softwaremill.sttp.client4::core:4.0.0-M1"
+ivy"com.softwaremill.sttp.client4::core:4.0.0-M6"
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
even M6 is old (M13 is latest), but M6 is what the toolkit actually currently includes, as per https://github.com/scala/toolkit/issues/45