### PR TITLE
Update and correct macro cross tutorial

### DIFF
--- a/_overviews/scala3-migration/tutorial-macro-mixing.md
+++ b/_overviews/scala3-migration/tutorial-macro-mixing.md
@@ -67,9 +67,9 @@ object Macros:
 
   private def locationImpl(using quotes: Quotes): Expr[Location] =
     import quotes.reflect.Position
-    val file = Expr(Position.ofMacroExpansion.sourceFile.jpath.toString)
+    val path = Expr(Position.ofMacroExpansion.sourceFile.path)
     val line = Expr(Position.ofMacroExpansion.startLine + 1)
-    '{new Location($file, $line)}
+    '{new Location($path, $line)}
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/20591

Besides the use of jpath, the scala 2 macro impl must be public. I tried to verify the steps as presented, but did not quite have the patience; probably the sophisticated user will fill in any gaps.

It's hard not to turn it into an sbt tutorial.

It's nicer just to say `+ test`.