### PR TITLE
Fix for multiple generators in a loop example code Scala/JS

### DIFF
--- a/_overviews/scala3-book/scala-for-javascript-devs.md
+++ b/_overviews/scala3-book/scala-for-javascript-devs.md
@@ -992,7 +992,7 @@ val nums = List(1, 2, 3)
         <code>let str = &quot;ab&quot;;
         <br>for (let i = 1; i &lt; 3; i++) {
         <br>&nbsp; for (var j = 0; j &lt; str.length; j++) {
-        <br>&nbsp;&nbsp;&nbsp; for (let k = 1; k &lt; 11; k++) {
+        <br>&nbsp;&nbsp;&nbsp; for (let k = 1; k &lt; 11; k += 5) {
         <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; let c = str.charAt(j);
         <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; console.log(`i: ${i} j: ${c} k: ${k}`);
         <br>&nbsp;&nbsp;&nbsp; }


### PR DESCRIPTION
### What's wrong?
- The Scala 3rd nested loop has an increment by 5 and the JS example has increment by 1

### Fix
- Update the 3rd nested loop on JS to increment by 5 like the Scala example

Code on page:
![image](https://github.com/scala/docs.scala-lang/assets/72286405/fcd95b27-460d-4155-9d5f-117b35b221b7)

Fix implementation:
![image](https://github.com/scala/docs.scala-lang/assets/72286405/a8d37a5b-2b58-46dd-8c61-b1461de7e9a9)

## Reference
Page Link: https://docs.scala-lang.org/scala3/book/scala-for-javascript-devs.html
