### PR TITLE
Fix build workflow (Broken link)

### DIFF
--- a/_overviews/scala-book/scala-build-tool-sbt.md
+++ b/_overviews/scala-book/scala-build-tool-sbt.md
@@ -161,5 +161,5 @@ Here’s a list of other build tools you can use to build Scala projects:
 - [Ant](http://ant.apache.org/)
 - [Gradle](https://gradle.org/)
 - [Maven](https://maven.apache.org/)
-- [Fury](https://propensive.com/opensource/fury)
+- [Fury](https://github.com/propensive/fury)
 - [Mill](https://com-lihaoyi.github.io/mill/)


### PR DESCRIPTION
## What's wrong?
- The build workflow is not working, its failing on every merge
![image](https://github.com/scala/docs.scala-lang/assets/72286405/3501c583-51b1-4d74-9587-bed650dad0a0)

- As we can see, the problem is an external link (status code 404)
![image](https://github.com/scala/docs.scala-lang/assets/72286405/7ff21a6a-79d5-4137-bada-f5be8b3d8ead)

- On the Propensive page we can see it's a different url, but it doesn't work either
![image](https://github.com/scala/docs.scala-lang/assets/72286405/35d51c4c-c519-41e6-b832-2853bf836a25)
![image](https://github.com/scala/docs.scala-lang/assets/72286405/c7bf11b8-a29e-4be9-bb29-c5f62884eef2)

## Fix
- Update the link to the GitHub repository
- Alternatively we can remove this one if a page is needed

## Reference
Broken links: 
- https://propensive.com/opensource/fury
- https://propensive.com/opensource/fury.html

Working link:
- https://github.com/propensive/fury