### PR TITLE
Macro doc: fix example about reporting error

### DIFF
--- a/_overviews/scala3-macros/tutorial/macros.md
+++ b/_overviews/scala3-macros/tutorial/macros.md
@@ -154,7 +154,7 @@ We will provide the custom error message by calling `errorAndAbort` on the `repo
 def powerCode(
   x: Expr[Double],
   n: Expr[Int]
-)(using Quotes): Expr[Double] =
+)(using quotes: Quotes): Expr[Double] =
   import quotes.reflect.report
   (x.value, n.value) match
     case (Some(base), Some(exponent)) =>


### PR DESCRIPTION
since `quotes.reflect.report` is used, the `given` must be given a variable name