### PR TITLE
Remove "-Xno-uescape" from compiler-options.yml

### DIFF
--- a/_data/compiler-options.yml
+++ b/_data/compiler-options.yml
@@ -469,10 +469,6 @@
     schema:
       type: "Boolean"
     description: "Don't perform exhaustivity/unreachability analysis. Also, ignore @switch annotation."
-  - option: "-Xno-uescape"
-    schema:
-      type: "Boolean"
-    description: "Disable handling of \\u unicode escapes."
   - option: "-Xnojline"
     schema:
       type: "Boolean"


### PR DESCRIPTION
Applying this PR removes the unused `-Xno-uescape` field from the `compilers-options.yml` data file, [as it was axed in this pull request](https://github.com/scala/scala/pull/8282)