### PR TITLE
Update tooling-syntax-rewriting.md

### DIFF
--- a/_overviews/scala3-migration/tooling-syntax-rewriting.md
+++ b/_overviews/scala3-migration/tooling-syntax-rewriting.md
@@ -52,7 +52,7 @@ Each of the first four options corresponds to a specific syntax:
 | Syntax | Compiler Option |
 |-|-|
 | Significant Indentation | `-indent` |
-| Classical Braces | `-noindent` |
+| Classical Braces | `-no-indent` |
 
 
 As we will see in further detail these options can be used in combination with the `-rewrite` option to automate the conversion to a particular syntax.


### PR DESCRIPTION
I checked scalac command options as follows:

```bash
$ scalac --help
 -javaextdirs  Override java extdirs classpath.
    -language  Enable one or more language features.
  -new-syntax  Require `then` and `do` in control expressions.
   **-no-indent  Require classical {...} syntax, indentation is not significant.**
   -nowarn  Silence all warnings.
```

But in docs wrote as `-noindent`. So I change it to `-no-indent`