### PR TITLE
add Scala FAQ entry about nilary vs nullary methods

### DIFF
--- a/_overviews/FAQ/index.md
+++ b/_overviews/FAQ/index.md
@@ -273,6 +273,15 @@ for multiple reasons, most notoriously
 For an in-depth treatment of types vs. classes, see the blog post
 ["There are more types than classes"](https://typelevel.org/blog/2017/02/13/more-types-than-classes.html).
 
+### Should I declare my parameterless method with or without parentheses?
+
+In other words, should one write `def foo()` or just `def foo`?
+
+Answer: by convention, the former is used to indicate that a method
+has side effects.
+
+For more details, see the Scala Style Guide, [here](https://docs.scala-lang.org/style/naming-conventions.html#parentheses).
+
 ### How can a method in a superclass return a value of the “current” type?
 
 First, note that using `this.type` won't work. People often try that,


### PR DESCRIPTION
My experience on Discord is that this is in fact asked often enough to merit a spot in the FAQ.

The style guide entry the answer points to could definitely use improvement. I've opened a separate PR on that: https://github.com/scala/docs.scala-lang/pull/3053. But in the meantime, I think it's still okay for the FAQ to link to the old version.

fyi @BalmungSan 