### PR TITLE
Update ca-implicit-conversions.md

### DIFF
--- a/_overviews/scala3-book/ca-implicit-conversions.md
+++ b/_overviews/scala3-book/ca-implicit-conversions.md
@@ -150,7 +150,7 @@ object `Conversions`:
 import scala.language.implicitConversions
 
 object Conversions {
-  implicit def fromStringToUser(name: String): User = (name: String) => User(name)
+  implicit def fromStringToUser(name: String): User = User(name)
 }
 ~~~
 {% endtab %}


### PR DESCRIPTION
implicit def syntax in scala 2 was return type as User. not String => User.