### PR TITLE
use scala instead of scala-cli in Cask tutorial

### DIFF
--- a/_overviews/toolkit/web-server-static.md
+++ b/_overviews/toolkit/web-server-static.md
@@ -139,7 +139,7 @@ Run the example with the build tool of your choice.
 {% tab 'Scala CLI' %}
 In the terminal, the following command will start the server:
 ```
-scala-cli run Example.scala
+scala run Example.scala
 ```
 {% endtab %}
 {% tab 'sbt' %}


### PR DESCRIPTION
I saw there were a few more examples across the tutorial - so those should also be updated