### PR TITLE
Update doc domain-modeling-tools for Java method call without parentheses

### DIFF
--- a/_overviews/scala3-book/domain-modeling-tools.md
+++ b/_overviews/scala3-book/domain-modeling-tools.md
@@ -373,7 +373,7 @@ Those constructors can be called like this:
 
 ```scala
 val s1 = new Student("Mary", "123")
-val s2 = new Student("Mary", "123", LocalDate.now)
+val s2 = new Student("Mary", "123", LocalDate.now())
 val s3 = new Student("Mary", "123", 456)
 ```
 
@@ -383,7 +383,7 @@ val s3 = new Student("Mary", "123", 456)
 
 ```scala
 val s1 = Student("Mary", "123")
-val s2 = Student("Mary", "123", LocalDate.now)
+val s2 = Student("Mary", "123", LocalDate.now())
 val s3 = Student("Mary", "123", 456)
 ```
 


### PR DESCRIPTION
Add parentheses when calling `LocalDate.now` to get an instance of `LocalDate`.

For a parameterless method, the recommended convention is that if no side effects, it should be without parentheses, so that `def` can be replaced by `val`/`var`.

In Scala3, the call site is enforced to match the method definition:
```scala
scala> def foo = 1
def foo: Int
scala> def bar() = 1
def bar(): Int    
scala> foo
val res3: Int = 1                  
scala> bar
-- [E100] Syntax Error
```

But this is not true when citing Java method:
```scala
scala> import java.time.*              
scala> val f = LocalDate.now // Questionable, side effect (reading external value)
val f: java.time.LocalDate = 2024-10-03                
scala> val t = LocalDate.now() // Good, explicitly mark the side effect performed
val t: java.time.LocalDate = 2024-10-03                  
scala> val f: () => LocalDate = LocalDate.now
val f: () => java.time.LocalDate = Lambda/0x000076984050d000@6c9151c1
```

This PR is to make the doc example follow the convention strictly.