### PR TITLE
Patches for scala3-book/scala-for-java-devs.md (https://docs.scala-lang.org/scala3/book/scala-for-java-devs.html)

### DIFF
--- a/_overviews/scala3-book/scala-for-java-devs.md
+++ b/_overviews/scala3-book/scala-for-java-devs.md
@@ -1064,7 +1064,7 @@ Pair<String, Integer> pair =
 
 Triplet<String, Integer, Double> triplet =
   Triplet.with("Eleven", 11, 11.0);
-Quartet<String, Integer, Double,Person> quartet =
+Quartet<String, Integer, Double, Person> quartet =
   Quartet.with("Eleven", 11, 11.0, new Person("Eleven"));
 ```
 

--- a/_overviews/scala3-book/scala-for-java-devs.md
+++ b/_overviews/scala3-book/scala-for-java-devs.md
@@ -1064,7 +1064,7 @@ Pair<String, Integer> pair =
 
 Triplet<String, Integer, Double> triplet =
   Triplet.with("Eleven", 11, 11.0);
-Quartet<String, Integer, Double,Person> triplet =
+Quartet<String, Integer, Double,Person> quartet =
   Quartet.with("Eleven", 11, 11.0, new Person("Eleven"));
 ```
 


### PR DESCRIPTION
In line 1067 of file `_overviews/scala3-book/scala-for-java-devs.md`, under the `Tuples` topic:
1. Rename a Quartet object from `triplet` to `quartet`.
2. Add a missing space after a comma, i.e. `a,b` -> `a, b`.