### PR TITLE
Re-order navbar links

### DIFF
--- a/_data/doc-nav-header.yml
+++ b/_data/doc-nav-header.yml
@@ -5,17 +5,6 @@
       url: "/getting-started/install-scala.html"
     - title: Scala IDEs
       url: "/getting-started/scala-ides.html"
-- title: Scala 3
-  url: "#"
-  submenu:
-    - title: What's New?
-      url: "/scala3/new-in-scala3.html"
-    - title: Migrating From Scala 2
-      url: "/scala3/guides/migration/compatibility-intro.html"
-    - title: New Features for Scaladoc
-      url: "/scala3/scaladoc.html"
-    - title: Videos and Talks
-      url: "/scala3/talks.html"
 - title: Learn
   url: "#"
   submenu:
@@ -29,6 +18,17 @@
       url: "/online-courses.html"
     - title: Online Resources
       url: "/learn.html"
+- title: Scala 3 Migration
+  url: "#"
+  submenu:
+    - title: What's New?
+      url: "/scala3/new-in-scala3.html"
+    - title: Migrating From Scala 2
+      url: "/scala3/guides/migration/compatibility-intro.html"
+    - title: New Features for Scaladoc
+      url: "/scala3/scaladoc.html"
+    - title: Videos and Talks
+      url: "/scala3/talks.html"
 - title: Tutorials
   url: "#"
   submenu:


### PR DESCRIPTION
`Scala 3` is too vague and as such it can be misleading. To learn Scala 3, one should click on `Learn` instead of `Scala 3`. `Scala 3` is mostly about the differences between Scala 2 and Scala 3 and the migration.

To make things clearer:
- Moved `Learn` before `Scala 3`
- Renamed `Scala 3` to `Scala 3 Migration`

![image](https://github.com/user-attachments/assets/2ab18b15-1488-4958-95e2-5d01aa2f7cbd)
