### PR TITLE
Update regular-expression-patterns.md

### DIFF
--- a/_tour/regular-expression-patterns.md
+++ b/_tour/regular-expression-patterns.md
@@ -34,9 +34,10 @@ import scala.util.matching.Regex
 
 val numberPattern: Regex = "[0-9]".r
 
-numberPattern.findFirstMatchIn("awesomepassword") match
+numberPattern.findFirstMatchIn("awesomepassword") match {
   case Some(_) => println("Password OK")
   case None => println("Password must contain a number")
+}
 ```
 {% endtab %}
 


### PR DESCRIPTION
Even the Scala 3 requires curly braces when I run it in Scastie.  

Is this a problem with Scastie's default build [which uses Scala 3] or with the sample code -- which I just fixed?  

I'm guessing based on my 0 experience with Scala that use of the imported function causes an inference which requires the curly braces.

Kept getting  “error: recursive value $t needs type” in Scastie using Scala 3 without this fix.  Took it as a learning exercise to find out why.