### PR TITLE
Update extractor-objects.md

### DIFF
--- a/_tour/extractor-objects.md
+++ b/_tour/extractor-objects.md
@@ -49,9 +49,10 @@ object CustomerID:
     if stringArray.tail.nonEmpty then Some(stringArray.head) else None
 
 val customer1ID = CustomerID("Sukyoung")  // Sukyoung--23098234908
-customer1ID match
+customer1ID match {
   case CustomerID(name) => println(name)  // prints Sukyoung
   case _ => println("Could not extract a CustomerID")
+}
 ```
 {% endtab %}
 


### PR DESCRIPTION
The customerid match case does not run in Scastie for Scala 3 without curly braces.

I've added them here.

Is this a problem with Scastie's Scala 3? If so, you can reject the PR and fix Scastie.

Is this a fix for the tutorial code for Scala 3?  If so, please accept this PR.