### PR TITLE
Change the performance of the Queue prepend operation

### DIFF
--- a/_overviews/collections-2.13/performance-characteristics.md
+++ b/_overviews/collections-2.13/performance-characteristics.md
@@ -23,7 +23,7 @@ Performance characteristics of sequence types:
 | `LazyList`    | C    | C    | L     | L     |  C      | L      |  -     |
 | `ArraySeq`    | C    | L    | C     | L     |  L      | L      |  -     |
 | `Vector`      | eC   | eC   | eC    | eC    |  eC     | eC     |  -     |
-| `Queue`       | aC   | aC   | L     | L     |  L      | C      |  -     |
+| `Queue`       | aC   | aC   | L     | L     |  C      | C      |  -     |
 | `Range`       | C    | C    | C     | -     |  -      | -      |  -     |
 | `String`      | C    | L    | C     | L     |  L      | L      |  -     |
 | **mutable**   |      |      |       |       |         |        |        |


### PR DESCRIPTION
If I'm not mistaken the `prepend` performance is incorrect. It should be constant instead of linear. The same performance is written in the russian lang docs ([Link](https://docs.scala-lang.org/ru/overviews/collections-2.13/performance-characteristics.html)).

I've also looked into sources and `prepended` seems to be a simple O(1) operation

![001691@2x](https://github.com/user-attachments/assets/2b172906-0577-4192-a970-c376fa45a19a)
