### PR TITLE
add JDK 24 to compat page

### DIFF
--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -14,7 +14,8 @@ Minimum Scala versions:
 
 | JDK         | 3        | 3 LTS    | 2.13      | 2.12      | 2.11       |
 |:-----------:|:--------:|:--------:|:---------:|:---------:|:----------:|
-| 23          | 3.6.2    | 3.3.5    | 2.13.15   | 2.12.20   |            |
+| 24 (ea)     | 3.6.x? 3.7.x?<br>(forthcoming) | 3.3.5?<br>(forthcoming) | 2.13.16<br>(forthcoming) | 2.12.21<br>(forthcoming)   | |
+| 23          | 3.6.2    | 3.3.5<br>(forthcoming) | 2.13.15   | 2.12.20   |            |
 | 22          | 3.4.0    | 3.3.4    | 2.13.13   | 2.12.19   |            |
 | 21 (LTS)    | 3.4.0    | 3.3.1    | 2.13.11   | 2.12.18   |            |
 | 17 (LTS)    | 3.0.0    | 3.3.0    | 2.13.6    | 2.12.15   |            |
@@ -115,10 +116,7 @@ For possible Scala issues, see the [jdk11](https://github.com/scala/bug/labels/j
 
 JDK 22 is non-LTS.
 
-Scala 2.13.13+ and 2.12.19+ support JDK 22.
-
-We are working on adding JDK 22 support to the 3.3.x release
-series. (Support may be available in nightly builds.)
+Scala 2.13.13+, 2.12.19+, 3.3.4+, and 3.6.2+ support JDK 22.
 
 For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), and [jdk21](https://github.com/scala/bug/labels/jdk21) labels in the Scala 2 bug tracker.
 
@@ -126,10 +124,18 @@ For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels
 
 JDK 23 is non-LTS.
 
-Scala 2.13.15+ and Scala 2.12.20+ support JDK 23.
+Scala 2.13.15+, Scala 2.12.20+, and Scala 3.6.2+ support JDK 23.
 
-We are working on adding JDK 23 support to Scala 3.
+We are working on adding JDK 23 support to Scala 3.3.x.
 (Support may be available in nightly builds and/or release candidates.)
+
+For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), and [jdk21](https://github.com/scala/bug/labels/jdk21) labels in the Scala 2 bug tracker.
+
+## JDK 24 compatibility notes
+
+JDK 24 will be non-LTS.
+
+Scala 2.13.16 (forthcoming) and Scala 2.12.21 (forthcoming) will support JDK 24. We are also working on adding JDK 24 support to Scala 3. (Support may be available in nightly builds and/or release candidates.)
 
 For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), and [jdk21](https://github.com/scala/bug/labels/jdk21) labels in the Scala 2 bug tracker.
 


### PR DESCRIPTION
(I didn't add a JDK 24 row to the tooling table, I figure that can wait.)