### PR TITLE
update scalatest version

### DIFF
--- a/_ja/getting-started/intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/_ja/getting-started/intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -16,7 +16,7 @@ Scala には複数のライブラリとテスト方法がありますが、こ�
 1. ScalaTest への依存を追加します。
     1. `build.sbt` ファイルに ScalaTest への依存を追加します。
         ```
-        libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % Test
+        libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test
         ```
     1. `build.sbt was changed` という通知が出たら、**auto-import** を選択します。
     1. これらの2つのアクションにより、`sbt` が ScalaTest ライブラリをダウンロードします。

--- a/_overviews/getting-started/intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/_overviews/getting-started/intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -20,7 +20,7 @@ This assumes you know [how to build a project in IntelliJ](building-a-scala-proj
 1. Add the ScalaTest dependency:
     1. Add the ScalaTest dependency to your `build.sbt` file:
         ```
-        libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.11" % Test
+        libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test
         ```
     1. If you get a notification "build.sbt was changed", select **auto-import**.
     1. These two actions will cause `sbt` to download the ScalaTest library.

--- a/_overviews/scala-book/sbt-scalatest-tdd.md
+++ b/_overviews/scala-book/sbt-scalatest-tdd.md
@@ -39,7 +39,7 @@ version := "1.0"
 scalaVersion := "{{site.scala-version}}"
 
 libraryDependencies +=
-    "org.scalatest" %% "scalatest" % "3.2.11" % Test
+    "org.scalatest" %% "scalatest" % "3.2.19" % Test
 
 ```
 
@@ -47,7 +47,7 @@ The first three lines of this file are essentially the same as the first example
 
 ```scala
 libraryDependencies +=
-    "org.scalatest" %% "scalatest" % "3.2.11" % Test
+    "org.scalatest" %% "scalatest" % "3.2.19" % Test
 ```
 
 >The ScalaTest documentation has always been good, and you can always find the up to date information on what those lines should look like on the [Installing ScalaTest](http://www.scalatest.org/install) page.

--- a/_overviews/scala3-book/tools-sbt.md
+++ b/_overviews/scala3-book/tools-sbt.md
@@ -369,7 +369,7 @@ version := "0.1"
 scalaVersion := "{{site.scala-3-version}}"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test
 )
 ```
 

--- a/_overviews/scala3-migration/tutorial-prerequisites.md
+++ b/_overviews/scala3-migration/tutorial-prerequisites.md
@@ -43,7 +43,7 @@ The dependency to `"scalatest" %% "scalatest" % "3.0.9"` must be upgraded becaus
 - The `scalatest` API is based on some macro definitions.
 - The `3.0.9` version is not published for Scala 3.
 
-We can upgrade it to version `3.2.7`, which is cross-published in Scala 2.13 and Scala 3.
+We can upgrade it to version `3.2.19`, which is cross-published in Scala 2.13 and Scala 3.
 
 ```scala
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19"

--- a/_overviews/scala3-migration/tutorial-prerequisites.md
+++ b/_overviews/scala3-migration/tutorial-prerequisites.md
@@ -46,7 +46,7 @@ The dependency to `"scalatest" %% "scalatest" % "3.0.9"` must be upgraded becaus
 We can upgrade it to version `3.2.7`, which is cross-published in Scala 2.13 and Scala 3.
 
 ```scala
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.7"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19"
 ```
 
 ## Compiler plugins

--- a/_ru/getting-started/intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/_ru/getting-started/intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -18,7 +18,7 @@ previous-page: /ru/building-a-scala-project-with-intellij-and-sbt
 1. Добавьте зависимость ScalaTest:
     1. Добавьте зависимость ScalaTest в свой файл `build.sbt`:
         ```
-        libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.11" % Test
+        libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test
         ```
     1. Если вы получили уведомление "build.sbt was changed", выберите **auto-import**.
     1. Эти два действия заставят `sbt` подгрузить библиотеки ScalaTest.

--- a/_ru/scala3/book/tools-sbt.md
+++ b/_ru/scala3/book/tools-sbt.md
@@ -365,7 +365,7 @@ version := "0.1"
 scalaVersion := "{{site.scala-3-version}}"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test
 )
 ```
 

--- a/_uk/getting-started/intellij-track/testing-scala-in-intellij-with-scalatest.md
+++ b/_uk/getting-started/intellij-track/testing-scala-in-intellij-with-scalatest.md
@@ -18,7 +18,7 @@ previous-page: /uk/building-a-scala-project-with-intellij-and-sbt
 1. Додайте залежність ScalaTest:
     1. Додайте залежність ScalaTest у файл `build.sbt` вашого проєкту:
         ```
-        libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.11" % Test
+        libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test
         ```
     1. Ви побачите сповіщення "build.sbt was changed", оберіть **auto-import**.
     1. Ці дві дії призведуть до того, що `sbt` завантажить бібліотеку ScalaTest.

--- a/_zh-cn/overviews/scala3-book/tools-sbt.md
+++ b/_zh-cn/overviews/scala3-book/tools-sbt.md
@@ -361,7 +361,7 @@ version := "0.1"
 scalaVersion := "{{site.scala-3-version}}"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test
 )
 ```
 


### PR DESCRIPTION
The main issue lies with the Japanese page.
The version specification for ScalaTest was incorrect, so I updated it.
However, sbt fails to resolve ScalaTest, resulting in an error.

I updated the version to the latest stable one (3.1.19).

I also updated the versions on other language pages as well.
This was likely not necessary, but I changed them for consistency, as having different versions across pages was a concern.