### PR TITLE
separate Scala 2/3 example for partial application in _tour/multiple-parameter-lists.md

### DIFF
--- a/_tour/multiple-parameter-lists.md
+++ b/_tour/multiple-parameter-lists.md
@@ -143,12 +143,25 @@ When a method is called with a fewer number of parameter lists, then this will y
 
 For example,
 
-{% tabs foldLeft_partial %}
+{% tabs foldLeft_partial class=tabs-scala-version %}
 
-{% tab 'Scala 2 and 3' for=foldLeft_partial %}
+{% tab 'Scala 2' for=foldLeft_partial %}
 ```scala mdoc:nest
 val numbers = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 val numberFunc = numbers.foldLeft(List[Int]()) _
+
+val squares = numberFunc((xs, x) => xs :+ x*x)
+println(squares) // List(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)
+
+val cubes = numberFunc((xs, x) => xs :+ x*x*x)
+println(cubes)  // List(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000)
+```
+{% endtab %}
+
+{% tab 'Scala 3' for=foldLeft_partial %}
+```scala mdoc:nest
+val numbers = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+val numberFunc = numbers.foldLeft(List[Int]())
 
 val squares = numberFunc((xs, x) => xs :+ x*x)
 println(squares) // List(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)

--- a/_tour/multiple-parameter-lists.md
+++ b/_tour/multiple-parameter-lists.md
@@ -159,7 +159,7 @@ println(cubes)  // List(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000)
 {% endtab %}
 
 {% tab 'Scala 3' for=foldLeft_partial %}
-```scala mdoc:nest
+```scala
 val numbers = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 val numberFunc = numbers.foldLeft(List[Int]())
 


### PR DESCRIPTION
I ran the example code in a Scala 3.6.3 repl to understand the behavior of the underscore. The interpreter warns that the syntax is no longer supported: 

```scala
scala> val numbers = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
val numbers: List[Int] = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)

scala> val numberFunc = numbers.foldLeft(List[Int]())
val numberFunc: ((List[Int], Int) => List[Int]) => List[Int] = Lambda$1752/0x0000008001565820@a4dcede

scala> numberFunc((xs, x) => xs :+ x*x)
val res1: List[Int] = List(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)

scala> val numberFunc = numbers.foldLeft(List[Int]()) _
1 warning found
-- Warning: ------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 |val numberFunc = numbers.foldLeft(List[Int]()) _
  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |                 The syntax `<function> _` is no longer supported;
  |                 you can simply leave out the trailing ` _`
val numberFunc: ((List[Int], Int) => List[Int]) => List[Int] = Lambda$1786/0x00000080015b59c0@2634d000
```

So I propose providing separate tabs for Scala 2 vs Scala 3.