### PR TITLE
update os-lib versions in example

### DIFF
--- a/_includes/_markdown/install-cask.md
+++ b/_includes/_markdown/install-cask.md
@@ -5,7 +5,7 @@
 {% tab 'Scala CLI' %}
 You can declare a dependency on Cask with the following `using` directive:
 ```scala
-//> using dep com.lihaoyi::cask::0.9.2
+//> using dep com.lihaoyi::cask::0.10.2
 ```
 {% endtab %}
 
@@ -15,7 +15,7 @@ In your `build.sbt`, you can add a dependency on Cask:
 lazy val example = project.in(file("example"))
   .settings(
     scalaVersion := "3.4.2",
-    libraryDependencies += "com.lihaoyi" %% "cask" % "0.9.2",
+    libraryDependencies += "com.lihaoyi" %% "cask" % "0.10.2",
     fork := true
   )
 ```
@@ -25,9 +25,9 @@ lazy val example = project.in(file("example"))
 In your `build.sc`, you can add a dependency on Cask:
 ```scala
 object example extends RootModule with ScalaModule {
-  def scalaVersion = "3.3.4"
+  def scalaVersion = "3.4.2"
   def ivyDeps = Agg(
-    ivy"com.lihaoyi::cask::0.9.2"
+    ivy"com.lihaoyi::cask::0.10.2"
   )
 }
 ```

--- a/_includes/_markdown/install-munit.md
+++ b/_includes/_markdown/install-munit.md
@@ -10,7 +10,7 @@ MUnit, being a testing framework, is only available in test files: files in a `t
 
 Alternatively, you can require just a specific version of MUnit:
 ```scala
-//> using dep org.scalameta::munit:1.0.3
+//> using dep org.scalameta::munit:1.1.0
 ```
 {% endtab %}
 {% tab 'sbt' %}
@@ -18,8 +18,8 @@ In your build.sbt file, you can add the dependency on toolkit-test:
 ```scala
 lazy val example = project.in(file("."))
   .settings(
-    scalaVersion := "3.3.4",
-    libraryDependencies += "org.scala-lang" %% "toolkit-test" % "0.1.7" % Test
+    scalaVersion := "3.4.2",
+    libraryDependencies += "org.scala-lang" %% "toolkit-test" % "0.7.0" % Test
   )
 ```
 
@@ -27,18 +27,18 @@ Here the `Test` configuration means that the dependency is only used by the sour
 
 Alternatively, you can require just a specific version of MUnit:
 ```scala
-libraryDependencies += "org.scalameta" %% "munit" % "1.0.3" % Test
+libraryDependencies += "org.scalameta" %% "munit" % "1.1.0" % Test
 ```
 {% endtab %}
 {% tab 'Mill' %}
 In your build.sc file, you can add a `test` object extending `Tests` and `TestModule.Munit`:
 ```scala
 object example extends ScalaModule {
-  def scalaVersion = "3.3.4"
+  def scalaVersion = "3.4.2"
   object test extends Tests with TestModule.Munit {
     def ivyDeps =
       Agg(
-        ivy"org.scala-lang::toolkit-test:0.1.7"
+        ivy"org.scala-lang::toolkit-test:0.7.0"
       )
   }
 }
@@ -46,7 +46,7 @@ object example extends ScalaModule {
 
 Alternatively, you can require just a specific version of MUnit:
 ```scala
-ivy"org.scalameta::munit:1.0.3"
+ivy"org.scalameta::munit:1.1.0"
 ```
 {% endtab %}
 {% endtabs %}

--- a/_includes/_markdown/install-os-lib.md
+++ b/_includes/_markdown/install-os-lib.md
@@ -17,7 +17,7 @@ In your `build.sbt`, you can add a dependency on the toolkit:
 ```scala
 lazy val example = project.in(file("."))
   .settings(
-    scalaVersion := "3.4.0",
+    scalaVersion := "3.4.2",
     libraryDependencies += "org.scala-lang" %% "toolkit" % "0.7.0"
   )
 ```
@@ -30,7 +30,7 @@ libraryDependencies += "com.lihaoyi" %% "os-lib" % "0.11.3"
 In your `build.sc` file, you can add a dependency on the Toolkit:
 ```scala
 object example extends ScalaModule {
-  def scalaVersion = "3.4.0"
+  def scalaVersion = "3.4.2"
   def ivyDeps =
     Agg(
       ivy"org.scala-lang::toolkit:0.7.0"

--- a/_includes/_markdown/install-os-lib.md
+++ b/_includes/_markdown/install-os-lib.md
@@ -9,7 +9,7 @@ You can require the entire toolkit in a single line:
 
 Alternatively, you can require just a specific version of OS-Lib:
 ```scala
-//> using dep com.lihaoyi::os-lib:0.9.1
+//> using dep com.lihaoyi::os-lib:0.11.3
 ```
 {% endtab %}
 {% tab 'sbt' %}
@@ -17,29 +17,29 @@ In your `build.sbt`, you can add a dependency on the toolkit:
 ```scala
 lazy val example = project.in(file("."))
   .settings(
-    scalaVersion := "3.3.4",
-    libraryDependencies += "org.scala-lang" %% "toolkit" % "0.1.7"
+    scalaVersion := "3.4.0",
+    libraryDependencies += "org.scala-lang" %% "toolkit" % "0.7.0"
   )
 ```
 Alternatively, you can require just a specific version of OS-Lib:
 ```scala
-libraryDependencies += "com.lihaoyi" %% "os-lib" % "0.9.1"
+libraryDependencies += "com.lihaoyi" %% "os-lib" % "0.11.3"
 ```
 {% endtab %}
 {% tab 'Mill' %}
 In your `build.sc` file, you can add a dependency on the Toolkit:
 ```scala
 object example extends ScalaModule {
-  def scalaVersion = "3.3.4"
+  def scalaVersion = "3.4.0"
   def ivyDeps =
     Agg(
-      ivy"org.scala-lang::toolkit:0.1.7"
+      ivy"org.scala-lang::toolkit:0.7.0"
     )
 }
 ```
 Alternatively, you can require just a specific version of OS-Lib:
 ```scala
-ivy"com.lihaoyi::os-lib:0.9.1"
+ivy"com.lihaoyi::os-lib:0.11.3"
 ```
 {% endtab %}
 {% endtabs %}

--- a/_includes/_markdown/install-sttp.md
+++ b/_includes/_markdown/install-sttp.md
@@ -9,7 +9,7 @@ You can require the entire toolkit in a single line:
 
 Alternatively, you can require just a specific version of sttp:
 ```scala
-//> using dep com.softwaremill.sttp.client4::core:4.0.0-M26
+//> using dep com.softwaremill.sttp.client4::core:4.0.0-RC1
 ```
 {% endtab %}
 {% tab 'sbt' %}
@@ -24,7 +24,7 @@ lazy val example = project.in(file("."))
 
 Alternatively, you can require just a specific version of sttp:
 ```scala
-libraryDependencies += "com.softwaremill.sttp.client4" %% "core" % "4.0.0-M26"
+libraryDependencies += "com.softwaremill.sttp.client4" %% "core" % "4.0.0-RC1"
 ```
 {% endtab %}
 {% tab 'Mill' %}
@@ -40,7 +40,7 @@ object example extends ScalaModule {
 ```
 Alternatively, you can require just a specific version of sttp:
 ```scala
-ivy"com.softwaremill.sttp.client4::core:4.0.0-M26"
+ivy"com.softwaremill.sttp.client4::core:4.0.0-RC1"
 ```
 {% endtab %}
 {% endtabs %}

--- a/_includes/_markdown/install-sttp.md
+++ b/_includes/_markdown/install-sttp.md
@@ -9,7 +9,7 @@ You can require the entire toolkit in a single line:
 
 Alternatively, you can require just a specific version of sttp:
 ```scala
-//> using dep com.softwaremill.sttp.client4::core:4.0.0-M6
+//> using dep com.softwaremill.sttp.client4::core:4.0.0-M26
 ```
 {% endtab %}
 {% tab 'sbt' %}
@@ -17,30 +17,30 @@ In your build.sbt file, you can add a dependency on the Toolkit:
 ```scala
 lazy val example = project.in(file("."))
   .settings(
-    scalaVersion := "3.3.4",
-    libraryDependencies += "org.scala-lang" %% "toolkit" % "0.1.7"
+    scalaVersion := "3.4.2",
+    libraryDependencies += "org.scala-lang" %% "toolkit" % "0.7.0"
   )
 ```
 
 Alternatively, you can require just a specific version of sttp:
 ```scala
-libraryDependencies += "com.softwaremill.sttp.client4" %% "core" % "4.0.0-M6"
+libraryDependencies += "com.softwaremill.sttp.client4" %% "core" % "4.0.0-M26"
 ```
 {% endtab %}
 {% tab 'Mill' %}
 In your build.sc file, you can add a dependency on the Toolkit:
 ```scala
 object example extends ScalaModule {
-  def scalaVersion = "3.3.4"
+  def scalaVersion = "3.4.2"
   def ivyDeps =
     Agg(
-      ivy"org.scala-lang::toolkit:0.1.7"
+      ivy"org.scala-lang::toolkit:0.7.0"
     )
 }
 ```
 Alternatively, you can require just a specific version of sttp:
 ```scala
-ivy"com.softwaremill.sttp.client4::core:4.0.0-M6"
+ivy"com.softwaremill.sttp.client4::core:4.0.0-M26"
 ```
 {% endtab %}
 {% endtabs %}

--- a/_includes/_markdown/install-upickle.md
+++ b/_includes/_markdown/install-upickle.md
@@ -9,7 +9,7 @@ Using Scala CLI, you can require the entire toolkit in a single line:
 
 Alternatively, you can require just a specific version of UPickle:
 ```scala
-//> using dep com.lihaoyi::upickle:3.1.0
+//> using dep com.lihaoyi::upickle:4.1.0
 ```
 {% endtab %}
 {% tab 'sbt' %}
@@ -17,29 +17,29 @@ In your build.sbt file, you can add the dependency on the Toolkit:
 ```scala
 lazy val example = project.in(file("."))
   .settings(
-    scalaVersion := "3.3.4",
-    libraryDependencies += "org.scala-lang" %% "toolkit" % "0.1.7"
+    scalaVersion := "3.4.2",
+    libraryDependencies += "org.scala-lang" %% "toolkit" % "0.7.0"
   )
 ```
 Alternatively, you can require just a specific version of UPickle:
 ```scala
-libraryDependencies += "com.lihaoyi" %% "upickle" % "3.1.0"
+libraryDependencies += "com.lihaoyi" %% "upickle" % "4.1.0"
 ```
 {% endtab %}
 {% tab 'Mill' %}
 In your build.sc file, you can add the dependency to the upickle library:
 ```scala
 object example extends ScalaModule {
-  def scalaVersion = "3.3.4"
+  def scalaVersion = "3.4.2"
   def ivyDeps =
     Agg(
-      ivy"org.scala-lang::toolkit:0.1.7"
+      ivy"org.scala-lang::toolkit:0.7.0"
     )
 }
 ```
 Alternatively, you can require just a specific version of UPickle:
 ```scala
-ivy"com.lihaoyi::upickle:3.1.0"
+ivy"com.lihaoyi::upickle:4.1.0"
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
This is nothing that's really that important to merge as the tooling tells you exactly what to do and the documentation is really good.  When compiling the examples from the documentation with scala-cli, we get warnings about the version being outdated.  

```
[hint] "os-lib is outdated, update to 0.11.3"
[hint]      os-lib 0.9.1 -> com.lihaoyi::os-lib:0.11.3
[hint] //> using dep com.lihaoyi::os-lib:0.9.1
[hint]               ^^^^^^^^^^^^^^^^^^^^^^^^^
```

This bumps the versions to the latest versions that I could find and that would compile on my machine.