### PR TITLE
drop link to a removed feed

### DIFF
--- a/_includes/headertop.html
+++ b/_includes/headertop.html
@@ -56,8 +56,7 @@
     <link rel="stylesheet" href="{{ site.baseurl }}/resources/css/monospace.css" type="text/css" />
 
     <!-- Atom feeds -->
-    <link rel="alternate" type="application/atom+xml" title="News Feed" href="http://scala-lang.org/feed/index.xml" />
-    <link rel="alternate" type="application/atom+xml" title="Blog Feed" href="http://scala-lang.org/feed/blog.xml" />
+    <link rel="alternate" type="application/atom+xml" title="News Feed" href="https://scala-lang.org/feed/index.xml" />
 
     <!-- Algolia stylesheet -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />


### PR DESCRIPTION
Tests are currently broken, HTMLProofer emits hundreds of errors along the lines of

```
At ./_site/api/all.html:49:

  External link http://scala-lang.org/feed/blog.xml failed (status code 404)
```

That's because the referenced feed has been recently dropped from the site: https://github.com/scala/scala-lang/pull/1750