### PR TITLE
Fix an invalid link

### DIFF
--- a/_sips/sips/futures-promises.md
+++ b/_sips/sips/futures-promises.md
@@ -714,13 +714,13 @@ Examples:
 
 
 ## References
-1. [The Task-Based Asynchronous Pattern, Stephen Toub, Microsoft, April 2011][1]
+1. [The Task-Based Asynchronous Pattern, Stephen Toub, Microsoft, February 2012][1]
 2. [Finagle Documentation][2]
 3. [Akka Documentation: Futures][3]
 4. [Scala Actors Futures][4]
 5. [Scalaz Futures][5]
 
-  [1]: https://www.microsoft.com/download/en/details.aspx?id=19957 "NETAsync"
+  [1]: https://download.microsoft.com/download/5/B/9/5B924336-AA5D-4903-95A0-56C6336E32C9/TAP.docx "NETAsync"
   [2]: https://twitter.github.io/scala_school/finagle.html "Finagle"
   [3]: https://doc.akka.io/docs/akka/current/futures.html "AkkaFutures"
   [4]: https://web.archive.org/web/20140814211520/https://www.scala-lang.org/api/2.9.3/scala/actors/Future.html "SActorsFutures"


### PR DESCRIPTION
There is an invalid link on the following page:
https://docs.scala-lang.org/sips/futures-promises.html

<img width="746" alt="image" src="https://github.com/user-attachments/assets/c2620d1c-5a4d-498d-850a-fc65f575e140" />

Fixed!

@SethTisue @adpi2 please, review this PR.