### PR TITLE
Update version of os-lib in install-scala.md

### DIFF
--- a/_overviews/getting-started/install-scala.md
+++ b/_overviews/getting-started/install-scala.md
@@ -202,7 +202,7 @@ We use the [os-lib](https://github.com/com-lihaoyi/os-lib) library from the [Sca
 for that purpose. A dependency on the library can be added with the `//> using` directive. Put the following code in `counter.scala`.
 ```scala
 //> using scala {{site.scala-3-version}}
-//> using dep "com.lihaoyi::os-lib:0.10.7"
+//> using dep "com.lihaoyi::os-lib:0.11.4"
 
 @main
 def countFiles(): Unit =


### PR DESCRIPTION
With the version 0.10.7, currently in the documentation, the output includes a hint suggesting to update the version of the library:

```
[hint] ./counter.scala:2:16
[hint] "os-lib is outdated, update to 0.11.4"
[hint]      os-lib 0.10.7 -> com.lihaoyi::os-lib:0.11.4
[hint] //> using dep "com.lihaoyi::os-lib:0.10.7"
[hint]                ^^^^^^^^^^^^^^^^^^^^^^^^^^
```