### PR TITLE
Bump runner image to ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby


### PR DESCRIPTION
The current image (ubuntu-20.04) we are using is no longer supported. See https://github.com/actions/runner-images/issues/11101 for more details. I chose to be conservative in bumping.