### PR TITLE
Fix `scala run hello.scala` not working

### DIFF
--- a/_overviews/scala3-book/taste-hello-world.md
+++ b/_overviews/scala3-book/taste-hello-world.md
@@ -50,7 +50,7 @@ object hello {
 Next, compile and run the code with `scala`:
 
 ```bash
-$ scala run hello.scala
+$ scala hello.scala
 ```
 
 The command should produce an output similar to:


### PR DESCRIPTION
When running `scala run hello.scala` as shown in the tutorial (https://docs.scala-lang.org/scala3/book/taste-hello-world.html) I get:
```
source file not found: run
1 error found
Errors encountered during compilation
```

This happens with scala 3.3.6:
```
> scala --version
Scala code runner version 3.3.6 -- Copyright 2002-2025, LAMP/EPFL
```

Am I doing something wrong, or is the documentation out of date?

If I only do `scala hello.scala`, it works as expected, which is why I propose this PR.