### PR TITLE
FAQ: add Q about online courses

### DIFF
--- a/_overviews/FAQ/index.md
+++ b/_overviews/FAQ/index.md
@@ -27,7 +27,7 @@ See our [Community page](https://scala-lang.org/community/).
 
 ### What's a good book about Scala?
 
-Our [Books page](https://docs.scala-lang.org/books.html) lists a few
+Our [Books page](https://docs.scala-lang.org/books.html) lists some
 especially popular, well-known books.
 
 We don't have a list of all the Scala books that
@@ -36,6 +36,17 @@ are out there; there are many.
 You can go on the \#scala-users room [on
 Discord](https://discord.com/invite/scala) or another community forum and
 ask for book recommendations. You'll get more helpful
+answers if you provide some information about your background and your
+reasons for wanting to learn Scala.
+
+### What's a good video course about Scala?
+
+Our [Online Courses page](https://docs.scala-lang.org/online-courses.html)
+lists some especially popular, well-known courses.
+
+As with books, you can go on the \#scala-users room [on
+Discord](https://discord.com/invite/scala) or another community forum and
+ask for online course recommendations. You'll get more helpful
 answers if you provide some information about your background and your
 reasons for wanting to learn Scala.
 


### PR DESCRIPTION
this does actually come up a lot — either people ask for videos, or they ask for "resources" without specifying book vs video — and it seems like it was just an oversight that this wasn't already included