### PR TITLE
docs(implicit-conversions): use new given syntax

### DIFF
--- a/_overviews/scala3-book/ca-implicit-conversions.md
+++ b/_overviews/scala3-book/ca-implicit-conversions.md
@@ -88,14 +88,14 @@ be defined by an implicit method (read more in the Scala 2 tab).
 For example, this code defines an implicit conversion from `Int` to `Long`:
 
 ```scala
-given int2long: Conversion[Int, Long] with
+given int2long: Conversion[Int, Long]:
   def apply(x: Int): Long = x.toLong
 ```
 
 Like other given definitions, implicit conversions can be anonymous:
 
 ~~~ scala
-given Conversion[Int, Long] with
+given Conversion[Int, Long]:
   def apply(x: Int): Long = x.toLong
 ~~~
 


### PR DESCRIPTION
given syntax was changed to use `:` over `with` since scala 3.6: https://docs.scala-lang.org/scala3/reference/contextual/givens.html