### PR TITLE
update JDK compat page for JDK 25 going GA

### DIFF
--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -134,7 +134,9 @@ For information on timing of the forthcoming releases, see:
 
 <!-- TODO For sbt users, sbt 1.9.0 is the first version to support JDK 21.-->
 
-For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), [jdk21](https://github.com/scala/bug/labels/jdk21), and [jdk25](https://github.com/scala/bug/labels/jdk25) labels in the Scala 2 bug tracker
+For possible Scala 3 issues, see the [area:jdk](https://github.com/scala/scala3/labels/area%3Ajdk) and [compat:java](https://github.com/scala/scala3/labels/compat%3Ajava) labels in [the Scala 3 issue tracker](https://github.com/scala/scala3/issues).
+
+For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), [jdk21](https://github.com/scala/bug/labels/jdk21), and [jdk25](https://github.com/scala/bug/labels/jdk25) labels in [the Scala 2 bug tracker](https://github.com/scala/bug/issues).
 
 ## GraalVM Native Image compatibility notes
 

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -125,6 +125,11 @@ The Scala test suite and Scala 2.13 community build are green on JDK 25.
 The forthcoming Scala 2.13.17 and 2.12.21 releases will support JDK 25.
 Support is already available in [nightlies](https://docs.scala-lang.org/overviews/core/nightlies.html).
 
+For information on timing of the forthcoming releases, see:
+
+* https://contributors.scala-lang.org/t/scala-2-13-17-release-planning/6994
+* https://contributors.scala-lang.org/t/scala-2-12-21-release-planning/6753
+
 <!-- TODO For sbt users, sbt 1.9.0 is the first version to support JDK 21.-->
 
 For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), [jdk21](https://github.com/scala/bug/labels/jdk21), and [jdk25](https://github.com/scala/bug/labels/jdk25) labels in the Scala 2 bug tracker

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -14,16 +14,13 @@ Minimum Scala versions:
 
 | JDK         | 3        | 3 LTS    | 2.13      | 2.12      | 2.11       |
 |:-----------:|:--------:|:--------:|:---------:|:---------:|:----------:|
-| 25 (ea)     | 3.7.1    | 3.3.6    | 2.13.17*  | 2.12.21*  |            |
-| 24          | 3.6.4    | 3.3.6    | 2.13.16   | 2.12.21*  |            |
-| 23          | 3.6.2    | 3.3.5    | 2.13.15   | 2.12.20   |            |
-| 22          | 3.4.0    | 3.3.4    | 2.13.13   | 2.12.19   |            |
+| 25 (LTS)    | 3.7.1    | 3.3.6    | 2.13.17*  | 2.12.21*  |            |
 | 21 (LTS)    | 3.4.0    | 3.3.1    | 2.13.11   | 2.12.18   |            |
 | 17 (LTS)    | 3.0.0    | 3.3.0    | 2.13.6    | 2.12.15   |            |
 | 11 (LTS)    | 3.0.0    | 3.3.0    | 2.13.0    | 2.12.4    | 2.11.12    |
 | 8 (LTS)     | 3.0.0    | 3.3.0    | 2.13.0    | 2.12.0    | 2.11.0     |
 
-\* = forthcoming; support available in [nightly builds](https://stackoverflow.com/q/40622878/86485)
+\* = forthcoming; support available in [nightly builds](https://docs.scala-lang.org/overviews/core/nightlies.html)
 
 Even when a version combination isn't listed as supported, most features might still work.
 
@@ -45,26 +42,30 @@ Minimum working versions:
 
 Even when a version combination isn't listed as supported, most features might still work.
 
+We will update this table soon to include information about JDK 25. <!-- TODO -->
+
 Using a different build tool, such as Gradle or Maven? We invite pull
 requests adding additional columns to this table.
 
 ## Running versus compiling
 
-JDK 8, 11, 17, and 21 are all reasonable choices both for *compiling* and *running* Scala code.
+JDK 8, 11, 17, 21, and 25 are all reasonable choices both for *compiling* and *running* Scala code.
 
 Since the JVM is normally backwards compatible, it is usually safe to use a newer JVM for *running* your code than the one it was compiled on, especially if you are not using JVM features designated "experimental" or "unsafe".
 
 JDK 8 remains in use at some shops (as of 2023), but usage is declining and some projects are dropping support. If you compile on JDK 11+ but want to allow your users to stay on 8, additional care is needed to avoid using APIs and features that don't exist in 8. (For this reason, some Scala developers use a newer JDK for their daily work but do release builds on JDK 8.)
 
+As per [this blog post](https://www.scala-lang.org/news/next-scala-lts-jdk.html), Scala 3.8 will have a new minimum JDK version of 17.
+
 ## Long Term Support (LTS) versions
 
 After Java 8, Oracle introduced the concept of LTS versions of the JDK. These versions will remain supported (by Oracle, and likely by the rest of the ecosystem, including Scala) for longer than the versions in between. See <https://www.oracle.com/technetwork/java/eol-135779.html>.
 
-JDK 8, 11, 17, and 21 are LTS versions. (The next LTS version will be 25.)
+JDK 8, 11, 17, 21, and 25 are LTS versions. (The next LTS version will be 29.)
 
-Scala provides experimental support for running the Scala compiler on non-LTS versions of the JDK. The current LTS versions are normally tested in our CI matrix and by the Scala community build. We may also test non-LTS versions, but any issues found there are considered lower priority, and will not be considered release blockers. (The Scala team at Akka may be able to offer faster resolution of issues like this under commercial support.)
+Scala provides experimental support for running the Scala compiler on non-LTS versions of the JDK. The current LTS versions are normally tested in our CI matrix and by the Scala community build. We may also test non-LTS versions, but any issues found there are considered lower priority, and will not be considered release blockers. (The Scala teams at VirtusLab and Akka may be able to offer faster resolution of issues like this under commercial support.)
 
-As already mentioned, Scala code compiled on JDK 8 should run without problems in later JVMs. We will give higher priority to bugs that break this property. (For example, in 2.13.x we might eventually provide support for JPMS module access checks, to ensure your code won't incur `LinkageErrors` due to module access violations.)
+As already mentioned, Scala code compiled on JDK 8 should run without problems in later JVMs. We will give higher priority to bugs that break this property. (For example, we might eventually provide support for JPMS module access checks, to ensure your code won't incur `LinkageErrors` due to module access violations.)
 
 ## JDK vendors and distributions
 
@@ -74,7 +75,7 @@ JDK 8 users typically use the Oracle JDK or some flavor of OpenJDK.
 
 Most JDK 11+ users are using OpenJDK, or GraalVM which runs in the context of OpenJDK. GraalVM performs well on the Scala benchmarks, and it benefits from GraalVM runtime and runs faster too.
 
-OpenJDK comes in various flavors, offered by different providers.  We build and test Scala using [Temurin](https://adoptium.net) primarily, but the differences are unlikely to matter to most users.
+OpenJDK comes in various flavors, offered by different providers. We typically build and test Scala using [Temurin](https://adoptium.net) or [Zulu](https://www.azul.com/downloads/), but the differences are unlikely to matter to most users.
 
 ## JDK 11 compatibility notes
 
@@ -99,7 +100,7 @@ The Scala test suite and Scala community build are green on JDK 17.
 
 For sbt users, sbt 1.6.0-RC1 is the first version to support JDK 17, but in practice sbt 1.5.5 may also work. (It will print a warning on startup about `TrapExit` that you can ignore.)
 
-For possible Scala issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11) and [jdk17](https://github.com/scala/bug/labels/jdk17) labels in the Scala 2 bug tracker.
+For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11) and [jdk17](https://github.com/scala/bug/labels/jdk17) labels in the Scala 2 bug tracker.
 
 ## JDK 21 compatibility notes
 
@@ -111,34 +112,22 @@ The Scala test suite and Scala 2.13 community build are green on JDK 21.
 
 For sbt users, sbt 1.9.0 is the first version to support JDK 21.
 
-For possible Scala issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), and [jdk21](https://github.com/scala/bug/labels/jdk21) labels in the Scala 2 bug tracker.
-
-## JDK 22 compatibility notes
-
-JDK 22 is non-LTS.
-
-Scala 2.13.13+, 2.12.19+, 3.3.4+, and 3.6.2+ support JDK 22.
-
 For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), and [jdk21](https://github.com/scala/bug/labels/jdk21) labels in the Scala 2 bug tracker.
 
-## JDK 23 compatibility notes
+## JDK 25 compatibility notes
 
-JDK 23 is non-LTS.
+JDK 25 is an LTS release.
 
-Scala 2.13.15+, Scala 2.12.20+, and Scala 3.6.2+ support JDK 23.
+Scala 3.3.6+ and 3.7.1+ support JDK 25.
 
-We are working on adding JDK 23 support to Scala 3.3.x.
-(Support may be available in nightly builds and/or release candidates.)
+The Scala test suite and Scala 2.13 community build are green on JDK 25.
 
-For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), and [jdk21](https://github.com/scala/bug/labels/jdk21) labels in the Scala 2 bug tracker.
+The forthcoming Scala 2.13.17 and 2.12.21 releases will support JDK 25.
+Support is already available in [nightlies](https://docs.scala-lang.org/overviews/core/nightlies.html).
 
-## JDK 24 compatibility notes
+<!-- TODO For sbt users, sbt 1.9.0 is the first version to support JDK 21.-->
 
-JDK 24 will be non-LTS.
-
-Scala 2.13.16+ supports, and Scala 2.12.21 (forthcoming) will support, JDK 24. We are also working on adding JDK 24 support to Scala 3. (Support may be available in nightly builds and/or release candidates.)
-
-For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), and [jdk21](https://github.com/scala/bug/labels/jdk21) labels in the Scala 2 bug tracker.
+For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11), [jdk17](https://github.com/scala/bug/labels/jdk17), [jdk21](https://github.com/scala/bug/labels/jdk21), and [jdk25](https://github.com/scala/bug/labels/jdk25) labels in the Scala 2 bug tracker
 
 ## GraalVM Native Image compatibility notes
 
@@ -152,8 +141,7 @@ A few sbt plugins are offering support for GraalVM Native Image compilation:
 
 ## Scala 3
 
-At present, both Scala 3 LTS and Scala Next support JDK 8, as well as 11 and beyond.
+At present, both Scala 3.3 LTS and Scala Next support JDK 8, as well as 11 and beyond.
 
-As per [this blog post](https://www.scala-lang.org/news/next-scala-lts.html),
-a forthcoming Scala 3 LTS version will drop JDK 8 support and may drop
-11 as well.  Stay tuned.
+As per [this blog post](https://www.scala-lang.org/news/next-scala-lts-jdk.html),
+Scala 3.8 will have a new minimum JDK version of 17.

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -153,4 +153,4 @@ A few sbt plugins are offering support for GraalVM Native Image compilation:
 At present, both Scala 3.3 LTS and Scala Next support JDK 8, as well as 11 and beyond.
 
 As per [this blog post](https://www.scala-lang.org/news/next-scala-lts-jdk.html),
-Scala 3.8 will have a new minimum JDK version of 17.
+Scala 3.8 will have a new minimum JDK version of 17. This can already be tested in Scala 3.8 nightlies.

--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -100,7 +100,9 @@ The Scala test suite and Scala community build are green on JDK 17.
 
 For sbt users, sbt 1.6.0-RC1 is the first version to support JDK 17, but in practice sbt 1.5.5 may also work. (It will print a warning on startup about `TrapExit` that you can ignore.)
 
-For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11) and [jdk17](https://github.com/scala/bug/labels/jdk17) labels in the Scala 2 bug tracker.
+For possible Scala 3 issues, see the [area:jdk](https://github.com/scala/scala3/labels/area%3Ajdk) and [compat:java](https://github.com/scala/scala3/labels/compat%3Ajava) labels in [the Scala 3 issue tracker](https://github.com/scala/scala3/issues).
+
+For possible Scala 2 issues, see the [jdk11](https://github.com/scala/bug/labels/jdk11) and [jdk17](https://github.com/scala/bug/labels/jdk17) labels in [the Scala 2 bug tracker](https://github.com/scala/bug/issues).
 
 ## JDK 21 compatibility notes
 


### PR DESCRIPTION
but I left the "Tooling compatibility table" section alone for now since I don't have that information yet. I think we should merge this regardless.

Also I haven't added "JDK 26 (ea)" yet even though early-access builds do exist; that can come later.