### PR TITLE
Fix typo in types-adts-gadts.md

### DIFF
--- a/_overviews/scala3-book/types-adts-gadts.md
+++ b/_overviews/scala3-book/types-adts-gadts.md
@@ -142,7 +142,7 @@ enum Nat:
   case Zero
   case Succ(n: Nat)
 ```
-For example the value `Succ(Succ(Zero))` represents the number `2` in an unary encoding.
+For example the value `Succ(Succ(Zero))` represents the number `2` in a unary encoding.
 Lists can be defined in a very similar way:
 
 ```scala


### PR DESCRIPTION
There's no "n" after the a if the "u" is pronounced like "you"