### PR TITLE
fix: copy button visibility issue

### DIFF
--- a/_sass/components/code.scss
+++ b/_sass/components/code.scss
@@ -51,11 +51,15 @@
         top: 5px;
 
         button {
-            border: none;
+            // border: none;
             background: #fff;
             font-size: $font-size-medium;
             color: $gray-darker;
             cursor: pointer;
+            border: 1px solid #E5EAEA;
+            border-radius: 3px;
+            margin: 4px;
+            padding: 3px 5px;
         }
     }
 

--- a/resources/js/functions.js
+++ b/resources/js/functions.js
@@ -705,3 +705,33 @@ $(document).ready(function() {
     }
   });
 });
+
+
+
+$(document).ready(function () {
+  $("pre > code").each(function () {
+    const $code = $(this);
+    // Skip if it's already wrapped in a .code-snippet-area
+    if ($code.closest(".code-snippet-area").length) return;
+
+    const $pre = $code.parent();
+    const $wrapper = $('<div class="code-snippet-area"></div>');
+    const $buttons = $(`
+      <div class="code-snippet-buttons">
+        <button class="copy-button">
+          <i class="far fa-clone"></i>
+        </button>
+      </div>
+    `);
+
+    $pre.wrap($wrapper);
+    $pre.before($buttons);
+  });
+
+  $(document).on("click", ".copy-button", function () {
+    const $button = $(this);
+    const $area = $button.closest(".code-snippet-area");
+    const codeText = $area.find("code").text().trim();
+    navigator.clipboard.writeText(codeText)
+  });
+});


### PR DESCRIPTION
Fixes issue: #3226 

The copy buttons were missing on code blocks within the Learn (Scala 2/3) pages, while they worked correctly on other sections such as Downloads.

Cause:
These pages render plain code blocks without the .code-snippet-area wrapper required by the existing copy-button script.

Fix
Added a small jQuery script that dynamically wraps unwrapped code blocks in a .code-snippet-area and injects a copy button, ensuring consistent behavior across all pages.

Result:
✅ Copy button now shows and works correctly across Learn, Scala Book, and Download pages.

https://github.com/user-attachments/assets/926932e3-51b4-469c-99c3-deca2162bdc2

