### PR TITLE
Add Scala 3.7.4 to API docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ keywords:
 
 scala-version: 2.13.17
 scala-212-version: 2.12.20
-scala-3-version: 3.7.3
+scala-3-version: 3.7.4
 
 collections:
   style:

--- a/api/all.md
+++ b/api/all.md
@@ -64,6 +64,8 @@ https://scala-ci.typesafe.com/artifactory/scala-integration/org/scala-lang/
 
 ## Previous releases
 
+* Scala 3.7.3
+  * [Library API](https://www.scala-lang.org/api/3.7.3/)
 * Scala 3.7.2
   * [Library API](https://www.scala-lang.org/api/3.7.2/)
 * Scala 3.7.1


### PR DESCRIPTION
Part of Scala 3.7.4 release procedure https://github.com/scala/scala3/issues/24344, public announcement planned for 10th Novemeber