### PR TITLE
Fix incorrect reference to non-existent tailOption method

### DIFF
--- a/_overviews/scala3-book/collections-methods.md
+++ b/_overviews/scala3-book/collections-methods.md
@@ -385,7 +385,10 @@ Just like `head`, `tail` also works on strings:
 
 {% endtabs %}
 
-`tail` throws a _java.lang.UnsupportedOperationException_ if the list is empty, so just like `head` and `headOption`, there’s also a `tailOption` method, which is preferred in functional programming.
+`tail` throws a _java.lang.UnsupportedOperationException_ if the list is empty.
+Unlike `headOption`, Scala collections do not provide a `tailOption` method.
+To safely work with the tail of a collection, you can use pattern matching
+or methods such as `drop(1)`.
 
 A list can also be matched, so you can write expressions like this:
 


### PR DESCRIPTION
Fixes #2338

Removes incorrect reference to a non-existent `tailOption` method and
documents safe alternatives for working with collection tails.