### PR TITLE
docs(scala3): clarify type inference behavior for multiple parameter …

### DIFF
--- a/_tour/multiple-parameter-lists.md
+++ b/_tour/multiple-parameter-lists.md
@@ -19,6 +19,7 @@ Here is an example, as defined on the `Iterable` trait in Scala's collections AP
 {% tabs foldLeft_definition class=tabs-scala-version %}
 
 {% tab 'Scala 2' for=foldLeft_definition %}
+
 ```scala
 trait Iterable[A] {
   ...
@@ -26,15 +27,18 @@ trait Iterable[A] {
   ...
 }
 ```
+
 {% endtab %}
 
 {% tab 'Scala 3' for=foldLeft_definition %}
+
 ```scala
 trait Iterable[A]:
   ...
   def foldLeft[B](z: B)(op: (B, A) => B): B
   ...
 ```
+
 {% endtab %}
 
 {% endtabs %}
@@ -46,11 +50,13 @@ Starting with an initial value of 0, `foldLeft` here applies the function `(m, n
 {% tabs foldLeft_use %}
 
 {% tab 'Scala 2 and 3' for=foldLeft_use %}
+
 ```scala mdoc
 val numbers = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 val res = numbers.foldLeft(0)((m, n) => m + n)
 println(res) // 55
 ```
+
 {% endtab %}
 
 {% endtabs %}
@@ -61,15 +67,24 @@ Suggested use cases for multiple parameter lists include:
 
 #### Drive type inference
 
-It so happens that in Scala, type inference proceeds one parameter list at a time.
+In Scala 2, type inference proceeds one parameter list at a time.
+
+> Scala 3 note :  
+> This explanation does not apply to Scala 3.  
+> In Scala 3, type variables are inferred as late as possible and are not
+> constrained by parameter list boundaries. As a result, later parameter
+> lists may contribute to type inference.
+
 Say you have the following method:
 
 {% tabs foldLeft1_definition %}
 
 {% tab 'Scala 2 and 3' for=foldLeft1_definition %}
+
 ```scala mdoc
 def foldLeft1[A, B](as: List[A], b0: B, op: (B, A) => B) = ???
 ```
+
 {% endtab %}
 
 {% endtabs %}
@@ -79,9 +94,11 @@ Then you'd like to call it in the following way, but will find that it doesn't c
 {% tabs foldLeft1_wrong_use %}
 
 {% tab 'Scala 2 and 3' for=foldLeft1_wrong_use %}
+
 ```scala mdoc:fail
 def notPossible = foldLeft1(numbers, 0, _ + _)
 ```
+
 {% endtab %}
 
 {% endtabs %}
@@ -91,10 +108,12 @@ you will have to call it like one of the below ways:
 {% tabs foldLeft1_good_use %}
 
 {% tab 'Scala 2 and 3' for=foldLeft1_good_use %}
+
 ```scala mdoc
 def firstWay = foldLeft1[Int, Int](numbers, 0, _ + _)
 def secondWay = foldLeft1(numbers, 0, (a: Int, b: Int) => a + b)
 ```
+
 {% endtab %}
 
 {% endtabs %}
@@ -104,16 +123,17 @@ That's because Scala won't be able to infer the type of the function `_ + _`, as
 {% tabs foldLeft2_definition_and_use %}
 
 {% tab 'Scala 2 and 3' for=foldLeft2_definition_and_use %}
+
 ```scala mdoc
 def foldLeft2[A, B](as: List[A], b0: B)(op: (B, A) => B) = ???
 def possible = foldLeft2(numbers, 0)(_ + _)
 ```
+
 {% endtab %}
 
 {% endtabs %}
 
 This definition doesn't need any type hints and can infer all of its type parameters.
-
 
 #### Implicit parameters
 
@@ -124,15 +144,19 @@ An example of this is:
 {% tabs execute_definition class=tabs-scala-version %}
 
 {% tab 'Scala 2' for=execute_definition %}
+
 ```scala mdoc
 def execute(arg: Int)(implicit ec: scala.concurrent.ExecutionContext) = ???
 ```
+
 {% endtab %}
 
 {% tab 'Scala 3' for=execute_definition %}
+
 ```scala
 def execute(arg: Int)(using ec: scala.concurrent.ExecutionContext) = ???
 ```
+
 {% endtab %}
 
 {% endtabs %}
@@ -146,6 +170,7 @@ For example,
 {% tabs foldLeft_partial class=tabs-scala-version %}
 
 {% tab 'Scala 2' for=foldLeft_partial %}
+
 ```scala mdoc:nest
 val numbers = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 val numberFunc = numbers.foldLeft(List[Int]()) _
@@ -156,9 +181,11 @@ println(squares) // List(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)
 val cubes = numberFunc((xs, x) => xs :+ x*x*x)
 println(cubes)  // List(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000)
 ```
+
 {% endtab %}
 
 {% tab 'Scala 3' for=foldLeft_partial %}
+
 ```scala
 val numbers = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 val numberFunc = numbers.foldLeft(List[Int]())
@@ -169,6 +196,7 @@ println(squares) // List(1, 4, 9, 16, 25, 36, 49, 64, 81, 100)
 val cubes = numberFunc((xs, x) => xs :+ x*x*x)
 println(cubes)  // List(1, 8, 27, 64, 125, 216, 343, 512, 729, 1000)
 ```
+
 {% endtab %}
 
 {% endtabs %}
@@ -185,13 +213,13 @@ As the [Wikipedia article on currying](https://en.wikipedia.org/wiki/Currying) s
 
 We discourage the use of the word "curry" in reference to Scala's multiple parameter lists, for two reasons:
 
-1) In Scala, multiple parameters and multiple parameter lists are
-specified and implemented directly, as part of the language, rather
-being derived from single-parameter functions.
+1. In Scala, multiple parameters and multiple parameter lists are
+   specified and implemented directly, as part of the language, rather
+   being derived from single-parameter functions.
 
-2) There is danger of confusion with the Scala standard library's
-[`curried`](https://www.scala-lang.org/api/current/scala/Function2.html#curried:T1=%3E(T2=%3ER))
-and [`uncurried`](https://www.scala-lang.org/api/current/scala/Function$.html#uncurried[T1,T2,R](f:T1=%3E(T2=%3ER)):(T1,T2)=%3ER) methods, which don't involve multiple parameter lists at all.
+2. There is danger of confusion with the Scala standard library's
+   [`curried`](<https://www.scala-lang.org/api/current/scala/Function2.html#curried:T1=%3E(T2=%3ER)>)
+   and [`uncurried`](<https://www.scala-lang.org/api/current/scala/Function$.html#uncurried[T1,T2,R](f:T1=%3E(T2=%3ER)):(T1,T2)=%3ER>) methods, which don't involve multiple parameter lists at all.
 
 Regardless, there are certainly similarities to be found between
 multiple parameter lists and currying. Though they are different at
@@ -201,6 +229,7 @@ as in this example:
 {% tabs about_currying %}
 
 {% tab 'Scala 2 and 3' for=about_currying %}
+
 ```scala mdoc
 // version with multiple parameter lists
 def addMultiple(n1: Int)(n2: Int) = n1 + n2
@@ -213,6 +242,7 @@ addMultiple(3)(4)  // 7
 addCurried1(3)(4)  // 7
 addCurried2(3)(4)  // 7
 ```
+
 {% endtab %}
 
 {% endtabs %}


### PR DESCRIPTION
Clarify differences in type inference between Scala 2 and Scala 3, and update `foldLeft` examples accordingly.