### PR TITLE
Fix warning in example

### DIFF
--- a/_overviews/scala3-book/string-interpolation.md
+++ b/_overviews/scala3-book/string-interpolation.md
@@ -348,7 +348,7 @@ p"${x/5}, $x"   // Point(2.4, 12.0)
 extension (sc: StringContext)
   def p(args: Double*): Point = {
     // reuse the `s`-interpolator and then split on ','
-    val pts = sc.s(args: _*).split(",", 2).map { _.toDoubleOption.getOrElse(0.0) }
+    val pts = sc.s(args*).split(",", 2).map { _.toDoubleOption.getOrElse(0.0) }
     Point(pts(0), pts(1))
   }
 


### PR DESCRIPTION
Reported the following warning:
```
The syntax `x: _*` is no longer supported for vararg splices; use `x*` instead
This construct can be rewritten automatically under -rewrite -source 3.4-migration.
```