### PR TITLE
Document Array in Scala 3 collections documentation

### DIFF
--- a/_overviews/scala3-book/collections-classes.md
+++ b/_overviews/scala3-book/collections-classes.md
@@ -507,7 +507,7 @@ val a = Array(1, 2, 3)
 
 ### Accessing and updating elements
 
-Access and update `Array` elements just like an `ArrayBuffer` or `Vector`:
+Access and update `Array` elements just like an `ArrayBuffer`:
 
 {% tabs array-update %}
 


### PR DESCRIPTION
This PR adds a short section documenting `Array` in the Scala 3
collections documentation and briefly clarifies when it should be used
instead of `ArrayBuffer`.

Fixes #3070