### PR TITLE
Scala book: add documentation for custom control structures

### DIFF
--- a/_overviews/scala3-book/control-structures.md
+++ b/_overviews/scala3-book/control-structures.md
@@ -1151,8 +1151,8 @@ To use it, you define a `boundary` block. Inside that block, you can call `break
 
 Here is an example of a method that searches for the first index of a target element in a list of integers:
 
-{% tabs custom-control-2 class=tabs-scala-version %}
-{% tab 'Scala 3' for=custom-control-2 %}
+{% tabs custom-control-2 %}
+{% tab 'Scala 3 Only' %}
 ```scala
 import scala.util.boundary, boundary.break
 


### PR DESCRIPTION
This PR adds a new **Custom Control Structures** section to the Scala 3 book.

It fulfills the teaser in `taste-control-structures.md` and documents how Scala
supports user-defined control structures using by-name parameters and
higher-order functions.

The section also introduces the `boundary` and `break` constructs added in
Scala 3.3, with an example demonstrating structured early exit from control
flow.

Changes are limited to:
`_overviews/scala3-book/control-structures.md`

Fixes #2947
