### PR TITLE
Add French Tour placeholder linking to English version

### DIFF
--- a/_fr/tour/index.md
+++ b/_fr/tour/index.md
@@ -4,9 +4,10 @@ title: Tour of Scala
 permalink: /fr/tour/
 ---
 
-::: warning
+## Tour de Scala
+
 La **Tour de Scala** n’est actuellement disponible qu’en **anglais**.
 
 Vous pouvez la consulter ici :
+
 https://docs.scala-lang.org/tour/tour-of-scala.html
-:::

--- a/_fr/tour/index.md
+++ b/_fr/tour/index.md
@@ -1,0 +1,12 @@
+---
+layout: tour
+title: Tour of Scala
+permalink: /fr/tour/
+---
+
+::: warning
+La **Tour de Scala** n’est actuellement disponible qu’en **anglais**.
+
+Vous pouvez la consulter ici :
+https://docs.scala-lang.org/tour/tour-of-scala.html
+:::


### PR DESCRIPTION
Adds a placeholder page for the French Tour.

Since the Tour of Scala is currently available only in English, this page displays a message and links users to the English Tour to avoid empty pages.

Fixes #3002 