### PR TITLE
Fix typo in trait extension explanation in th lang 

### DIFF
--- a/_th/tour/basics.md
+++ b/_th/tour/basics.md
@@ -270,7 +270,7 @@ trait Greeter {
 }
 ```
 
-เราสามารถขยาย trait ได้ด้วย keyword `extents` และ overrid implementation ด้วย keyword `override`
+เราสามารถขยาย trait ได้ด้วย keyword `extends` และ overrid implementation ด้วย keyword `override`
 
 ```scala mdoc
 class DefaultGreeter extends Greeter


### PR DESCRIPTION
Found a typo in the Trait section where 'trait' was misspelled as 'traint'.