### PR TITLE
Recover recommendation for GraalVM

### DIFF
--- a/_overviews/jdk-compatibility/overview.md
+++ b/_overviews/jdk-compatibility/overview.md
@@ -103,6 +103,8 @@ JDK 8 users typically use the Oracle JDK or some flavor of OpenJDK.
 
 OpenJDK comes in various flavors, offered by different providers. We typically build and test Scala using [Temurin](https://adoptium.net) or [Zulu](https://www.azul.com/downloads/), but the differences are unlikely to matter to most users.
 
+GraalVM includes an advanced JIT compiler that performs well on Scala benchmarks. For example, the Scala 2.13 compiler runs about 10% faster (Java 25). GraalVM is available in two editions: GraalVM Community Edition (GPLv2 + Classpath Exception) and Oracle GraalVM (GraalVM Free Terms & Conditions, free to use also commercially).
+
 ## JDK 11 compatibility notes
 
 The Scala test suite and Scala community build are green on JDK 11.


### PR DESCRIPTION
It was removed due to my comment here: https://github.com/scala/docs.scala-lang/pull/3230#discussion_r2517452104

I think I completely misunderstood the corporate speak in that blog post.

IIUC, the blog says
  - you can no longer just opt in to the Graal JIT compiler with a flag on an Oracle hotspot release
  - so customers for Oracle hotspot with a contract need to move to the ordinary JIT compiler
  - To use the Graal JIT, download GraalVM
  - Graal will from now on align its releases (and versioning) with the JDK releases

Thomas Wuerthinger (lead of Graal) posted a comment here, agreeing that the wording is confusing: https://www.reddit.com/r/java/comments/1niamuc/detaching_graalvm_from_the_java_ecosystem_train/

Also relevant, since 2023 the enterprise edition can be used for free (blog post with more corporate speak: https://blogs.oracle.com/cloud-infrastructure/graalvm-free-license)

In the context of https://github.com/scala/scala3/pull/25165 I'm running some benchmarks. The Scala 2.13 compiler for exmaple is about 10% faster when running on GraalVM Enterprise 25 compared to OpenJDK Temurin 25.
