### PR TITLE
CI: update some outdated Actions version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,14 +4,14 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2.6
           bundler-cache: true
       - name: Set up coursier
-        uses: coursier/setup-action@v1.3.5
+        uses: coursier/setup-action@v3
         with:
           jvm: adopt:11
       - name: Run mdoc

--- a/.github/workflows/sync-sips.yml
+++ b/.github/workflows/sync-sips.yml
@@ -9,7 +9,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fetch SIPs from improvement-proposals
         run: |


### PR DESCRIPTION
antiquated versions were causing Node-related warnings to show up in the web UI
